### PR TITLE
Fix GCS S3-Compatible API Access with AWS CLI

### DIFF
--- a/pkg/clouds/pulumi/gcp/bucket.go
+++ b/pkg/clouds/pulumi/gcp/bucket.go
@@ -219,15 +219,22 @@ func BucketComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Resourc
 			input.Descriptor.Type, input.Descriptor.Name, parentStackName)
 
 		// Add AWS CLI specific configuration for GCS compatibility
-		// Convert GCS location to lowercase for AWS CLI compatibility
-		awsRegion := strings.ToLower(resBucketLocation)
-		collector.AddEnvVariableIfNotExist(util.ToEnvVariableName("AWS_DEFAULT_REGION"), awsRegion,
+		// Use "auto" region for GCS S3-compatible API signature calculation
+		collector.AddEnvVariableIfNotExist(util.ToEnvVariableName("AWS_DEFAULT_REGION"), "auto",
 			input.Descriptor.Type, input.Descriptor.Name, parentStackName)
 		// Force AWS CLI to use signature version 4 for GCS compatibility
 		collector.AddEnvVariableIfNotExist(util.ToEnvVariableName("AWS_S3_SIGNATURE_VERSION"), "s3v4",
 			input.Descriptor.Type, input.Descriptor.Name, parentStackName)
 		// Force path-style URLs for GCS compatibility (required for some bucket names)
 		collector.AddEnvVariableIfNotExist(util.ToEnvVariableName("AWS_S3_ADDRESSING_STYLE"), "path",
+			input.Descriptor.Type, input.Descriptor.Name, parentStackName)
+		// Disable payload signing for GCS compatibility (GCS uses x-goog-content-sha256 instead of x-amz-content-sha256)
+		collector.AddEnvVariableIfNotExist(util.ToEnvVariableName("AWS_S3_PAYLOAD_SIGNING_ENABLED"), "false",
+			input.Descriptor.Type, input.Descriptor.Name, parentStackName)
+		// Fix AWS CLI checksum behavior for GCS compatibility (AWS changed defaults in 2024/2025)
+		collector.AddEnvVariableIfNotExist(util.ToEnvVariableName("AWS_REQUEST_CHECKSUM_CALCULATION"), "when_required",
+			input.Descriptor.Type, input.Descriptor.Name, parentStackName)
+		collector.AddEnvVariableIfNotExist(util.ToEnvVariableName("AWS_RESPONSE_CHECKSUM_VALIDATION"), "when_required",
 			input.Descriptor.Type, input.Descriptor.Name, parentStackName)
 
 		// Add resource template extension for programmatic access


### PR DESCRIPTION
### Problem
AWS CLI commands (like `aws s3 cp`) were failing with `SignatureDoesNotMatch` errors when accessing GCS buckets through the S3-compatible API, despite correct HMAC credentials and bucket permissions.

### Root Cause
Two main issues were identified:
1. **Missing IAM permissions**: Service accounts only had `storage.objectAdmin` role, which is insufficient for S3-compatible bucket operations like `GetBucketAcl`
2. **AWS CLI compatibility breaking changes**: AWS changed their default checksum behavior in 2024/2025, breaking compatibility with third-party S3-compatible services including GCS

### Solution

#### 1. Enhanced IAM Permissions
- Added `roles/storage.legacyBucketWriter` role to service accounts
- This role provides the necessary S3-compatible bucket operations permissions
- Maintains existing `roles/storage.objectAdmin` for comprehensive object access

#### 2. Complete AWS CLI Configuration for GCS Compatibility
Added all required environment variables to ensure AWS CLI works seamlessly with GCS:

```bash
AWS_DEFAULT_REGION=auto                           # GCS S3 API expects "auto" region
AWS_S3_SIGNATURE_VERSION=s3v4                    # Force signature version 4
AWS_S3_ADDRESSING_STYLE=path                     # Required for GCS path-style URLs
AWS_S3_PAYLOAD_SIGNING_ENABLED=false             # GCS uses different payload signing
AWS_REQUEST_CHECKSUM_CALCULATION=when_required    # Fix for AWS 2024/2025 changes
AWS_RESPONSE_CHECKSUM_VALIDATION=when_required    # Fix for AWS 2024/2025 changes