### PR TITLE
Fix: Enable baseDnsZone support for single-image stacks (AWS Lambda)

### DIFF
--- a/pkg/clouds/aws/aws_lambda.go
+++ b/pkg/clouds/aws/aws_lambda.go
@@ -25,6 +25,10 @@ func (l *LambdaInput) Uses() []string {
 	return l.StackConfig.Uses
 }
 
+func (l *LambdaInput) OverriddenBaseZone() string {
+	return l.StackConfig.BaseDnsZone
+}
+
 func ToAwsLambdaConfig(tpl any, stackCfg *api.StackConfigSingleImage) (any, error) {
 	templateCfg, ok := tpl.(*TemplateConfig)
 	if !ok {


### PR DESCRIPTION
### Problem
The `baseDnsZone` configuration was working correctly for `cloud-compose` stacks (ECS Fargate) but not for `single-image` stacks (AWS Lambda). While the field was defined in [StackConfigSingleImage](cci:2://file:///home/iasadykov/projects/github/simple-container/api/pkg/api/client.go:122:0-138:1), the AWS Lambda implementation wasn't properly exposing it through the required [OverriddenBaseZone()](cci:1://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:27:0-29:1) interface method.

### Root Cause
- [EcsFargateInput](cci:2://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/ecs_fargate.go:100:0-117:1) had a `BaseDnsZone` field and implemented [OverriddenBaseZone()](cci:1://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:27:0-29:1) method ✅
- [LambdaInput](cci:2://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:12:0-15:1) was missing the [OverriddenBaseZone()](cci:1://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:27:0-29:1) method ❌
- This prevented DNS zone override functionality from working with AWS Lambda deployments

### Solution
Added the missing [OverriddenBaseZone()](cci:1://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:27:0-29:1) method to [LambdaInput](cci:2://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:12:0-15:1) that returns `l.StackConfig.BaseDnsZone` directly, eliminating the need for field duplication.

### Changes
- **Added**: [OverriddenBaseZone()](cci:1://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:27:0-29:1) method to [LambdaInput](cci:2://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:12:0-15:1) struct in [pkg/clouds/aws/aws_lambda.go](cci:7://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/aws/aws_lambda.go:0:0-0:0)
- **Implementation**: Returns `l.StackConfig.BaseDnsZone` directly (clean, no field duplication)

### Impact
- ✅ `baseDnsZone` configuration now works for single-image stacks (AWS Lambda)
- ✅ Feature parity between cloud-compose and single-image deployment types
- ✅ Clean implementation without unnecessary field duplication

### Usage Example
```yaml
# client.yaml - Now works for single-image stacks!
stacks:
  my-lambda:
    type: single-image
    config:
      baseDnsZone: "my-custom-zone.com"
      domain: "api.my-custom-zone.com"
      # ... other config
```

### Testing
- [x] Code compiles successfully
- [x] Follows existing patterns from ECS Fargate implementation
- [x] No breaking changes to existing functionality