### PR TITLE
Fix AWS Lambda Function URL Permission Error

### DIFF
--- a/pkg/clouds/pulumi/aws/aws_lambda.go
+++ b/pkg/clouds/pulumi/aws/aws_lambda.go
@@ -376,11 +376,13 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 
 		// Add permission to allow anonymous invocation via function URL
 		// This is required for AuthorizationType: "NONE" to work properly
+		// AWS now requires FunctionUrlAuthType to be specified for public access
 		urlPermissionName := fmt.Sprintf("%s-url-permission", lambdaName)
 		_, err = lambda.NewPermission(ctx, urlPermissionName, &lambda.PermissionArgs{
-			Action:    sdk.String("lambda:InvokeFunctionUrl"),
-			Function:  lambdaFunc.Name,
-			Principal: sdk.String("*"),
+			Action:              sdk.String("lambda:InvokeFunctionUrl"),
+			Function:            lambdaFunc.Name,
+			Principal:           sdk.String("*"),
+			FunctionUrlAuthType: sdk.String("NONE"),
 		}, opts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create lambda function url permission")


### PR DESCRIPTION
## 🔒 Fix AWS Lambda Function URL Permission Error

**Problem**: AWS Lambda function URL deployments failing with:
```
InvalidParameterValueException: This policy could enable public access to your lambda function as it allows all Principals (*) to perform lambda:InvokeFunctionUrl action. You must specify lambda:FunctionUrlAuthType condition
```

**Root Cause**: AWS now requires explicit specification of the authentication type when granting public access (`Principal: "*"`) to Lambda function URLs.

**Solution**: Added the required `FunctionUrlAuthType` field to Lambda permission configuration.

**Technical Fix**:
```go
// Before (failing)
_, err = lambda.NewPermission(ctx, urlPermissionName, &lambda.PermissionArgs{
    Action:    sdk.String("lambda:InvokeFunctionUrl"),
    Function:  lambdaFunc.Name,
    Principal: sdk.String("*"),
})

// After (working)
_, err = lambda.NewPermission(ctx, urlPermissionName, &lambda.PermissionArgs{
    Action:              sdk.String("lambda:InvokeFunctionUrl"),
    Function:            lambdaFunc.Name,
    Principal:           sdk.String("*"),
    FunctionUrlAuthType: sdk.String("NONE"), // ✅ Required by AWS
})
```

**Files Modified**:
- [pkg/clouds/pulumi/aws/aws_lambda.go](cci:7://file:///home/iasadykov/projects/github/simple-container/api/pkg/clouds/pulumi/aws/aws_lambda.go:0:0-0:0) - Added `FunctionUrlAuthType: "NONE"` to function URL permissions

**Impact**: 
- ✅ Fixes Lambda function URL deployments with public access
- ✅ Compliant with AWS security requirements
- ✅ Matches the `AuthorizationType: "NONE"` configuration on the function URL