### PR TITLE
Pass through ephemeral-storage size for k8s deployments

### DIFF
--- a/.github/workflows/simple-forge.yml
+++ b/.github/workflows/simple-forge.yml
@@ -32,6 +32,10 @@ on:
         description: 'JWT token for both AI gateway and forge service API access'
         required: false
         type: string
+      anthropic_base_url:
+        description: 'Anthropic API base URL (overrides secrets if provided)'
+        required: false
+        type: string
 
 jobs:
   generate-code:
@@ -62,7 +66,7 @@ jobs:
           model_name: ${{ inputs.model_name }}
           branch: ${{ inputs.branch }}
           anthropic_api_key: ${{ inputs.api_token || secrets.ANTHROPIC_API_KEY }}
-          anthropic_base_url: ${{ secrets.ANTHROPIC_BASE_URL || format('{0}/ai', inputs.service_url || 'https://forge.simple-container.com') || 'https://api.anthropic.com' }}
+          anthropic_base_url: ${{ inputs.anthropic_base_url || secrets.ANTHROPIC_BASE_URL || format('{0}/ai', inputs.service_url || 'https://forge.simple-container.com') || 'https://api.anthropic.com' }}
           simple_forge_api_key: ${{ inputs.api_token || secrets.SIMPLE_FORGE_API_KEY }}
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           script_version: ${{ inputs.script_version }}

--- a/pkg/clouds/k8s/types.go
+++ b/pkg/clouds/k8s/types.go
@@ -174,6 +174,10 @@ func ToResources(cfg *api.StackConfigCompose, svc types.ServiceConfig) (*Resourc
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert memory limits")
 	}
+	ephemeralLimitInBytesInt, err := toEphemeralLimit(cfg, svc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to convert ephemeral storage limits")
+	}
 
 	// Get requests (with fallback to limits if not specified)
 	cpuRequestInt, err := toCpuRequest(cfg, svc, cpuLimitInt)
@@ -184,16 +188,31 @@ func ToResources(cfg *api.StackConfigCompose, svc types.ServiceConfig) (*Resourc
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert memory requests")
 	}
+	ephemeralRequestInBytesInt, err := toEphemeralRequest(cfg, svc, ephemeralLimitInBytesInt)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to convert ephemeral storage requests")
+	}
+
+	limits := map[string]string{
+		"memory": bytesSizeToHuman(memLimitInBytesInt), // must be in MB
+		"cpu":    fmt.Sprintf("%dm", cpuLimitInt),
+	}
+	requests := map[string]string{
+		"memory": bytesSizeToHuman(memRequestInBytesInt), // must be in MB
+		"cpu":    fmt.Sprintf("%dm", cpuRequestInt),
+	}
+
+	// Add ephemeral storage if configured
+	if ephemeralLimitInBytesInt > 0 {
+		limits["ephemeral-storage"] = bytesSizeToHuman(ephemeralLimitInBytesInt)
+	}
+	if ephemeralRequestInBytesInt > 0 {
+		requests["ephemeral-storage"] = bytesSizeToHuman(ephemeralRequestInBytesInt)
+	}
 
 	return &Resources{
-		Limits: map[string]string{
-			"memory": bytesSizeToHuman(memLimitInBytesInt), // must be in MB
-			"cpu":    fmt.Sprintf("%dm", cpuLimitInt),
-		},
-		Requests: map[string]string{
-			"memory": bytesSizeToHuman(memRequestInBytesInt), // must be in MB
-			"cpu":    fmt.Sprintf("%dm", cpuRequestInt),
-		},
+		Limits:   limits,
+		Requests: requests,
 	}, nil
 }
 
@@ -301,6 +320,50 @@ func toMemoryRequest(cfg *api.StackConfigCompose, svc types.ServiceConfig, memor
 
 	// Fallback: Use 50% of limit as request (Kubernetes best practice)
 	return memoryLimit / 2, nil
+}
+
+// toEphemeralLimit extracts ephemeral storage limits from configuration
+func toEphemeralLimit(cfg *api.StackConfigCompose, svc types.ServiceConfig) (int64, error) {
+	// Priority 1: Explicit limits in size configuration
+	if len(cfg.Runs) == 1 && cfg.Size != nil && cfg.Size.Limits != nil && cfg.Size.Limits.Ephemeral != "" {
+		if v, err := strconv.Atoi(cfg.Size.Limits.Ephemeral); err != nil {
+			return 0, errors.Wrapf(err, "failed to parse ephemeral storage limit specified for stack: %q", cfg.Size.Limits.Ephemeral)
+		} else {
+			return int64(v) * 1024 * 1024, nil // Convert MB to bytes
+		}
+	}
+
+	// Priority 2: Size configuration ephemeral field
+	if len(cfg.Runs) == 1 && cfg.Size != nil && cfg.Size.Ephemeral != "" {
+		if v, err := strconv.Atoi(cfg.Size.Ephemeral); err != nil {
+			return 0, errors.Wrapf(err, "failed to parse ephemeral storage specified for stack: %q", cfg.Size.Ephemeral)
+		} else {
+			return int64(v) * 1024 * 1024, nil // Convert MB to bytes
+		}
+	}
+
+	// No ephemeral storage configured - return 0 (will be omitted from resources)
+	return 0, nil
+}
+
+// toEphemeralRequest extracts ephemeral storage requests from configuration, with fallback to limits
+func toEphemeralRequest(cfg *api.StackConfigCompose, svc types.ServiceConfig, ephemeralLimit int64) (int64, error) {
+	// Priority 1: Explicit requests in size configuration
+	if len(cfg.Runs) == 1 && cfg.Size != nil && cfg.Size.Requests != nil && cfg.Size.Requests.Ephemeral != "" {
+		if v, err := strconv.Atoi(cfg.Size.Requests.Ephemeral); err != nil {
+			return 0, errors.Wrapf(err, "failed to parse ephemeral storage request specified for stack: %q", cfg.Size.Requests.Ephemeral)
+		} else {
+			return int64(v) * 1024 * 1024, nil // Convert MB to bytes
+		}
+	}
+
+	// If no limit is set, don't set a request either
+	if ephemeralLimit == 0 {
+		return 0, nil
+	}
+
+	// Fallback: Use 50% of limit as request (Kubernetes best practice)
+	return ephemeralLimit / 2, nil
 }
 
 func ToHeaders(headers *api.Headers) Headers {


### PR DESCRIPTION
Add necessary k8s layer conversion for ephemeral-storage pass through to k8s