### PR TITLE
Generic Ephemeral Volumes Support

### DIFF
--- a/docs/schemas/kubernetes/kubernetescloudextras.json
+++ b/docs/schemas/kubernetes/kubernetescloudextras.json
@@ -9,6 +9,36 @@
   "schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+      "ephemeralVolumes": {
+        "description": "Generic ephemeral volumes for large temporary storage (>10GB). These volumes bypass GKE Autopilot's 10GB ephemeral storage limit by using PersistentVolumeClaims that are automatically created and deleted with pods.",
+        "items": {
+          "properties": {
+            "mountPath": {
+              "description": "Path where the volume should be mounted inside the container",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the ephemeral volume (will be sanitized for Kubernetes RFC 1123 compliance)",
+              "type": "string"
+            },
+            "size": {
+              "description": "Size of the volume (e.g., '10Gi', '100Gi', '1Ti'). Can be much larger than the 10GB regular ephemeral storage limit.",
+              "type": "string"
+            },
+            "storageClassName": {
+              "description": "Storage class to use for the PersistentVolumeClaim (e.g., 'standard-rwo', 'pd-balanced'). Defaults to cluster default if not specified.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "mountPath",
+            "size"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
       "affinity": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -757,6 +787,7 @@
       }
     },
     "required": [
+      "ephemeralVolumes",
       "affinity",
       "disruptionBudget",
       "livenessProbe",

--- a/pkg/clouds/k8s/kube_run.go
+++ b/pkg/clouds/k8s/kube_run.go
@@ -17,14 +17,15 @@ func (i *KubeRunInput) OverriddenBaseZone() string {
 }
 
 type CloudExtras struct {
-	NodeSelector     map[string]string `json:"nodeSelector" yaml:"nodeSelector"`
-	DisruptionBudget *DisruptionBudget `json:"disruptionBudget" yaml:"disruptionBudget"`
-	RollingUpdate    *RollingUpdate    `json:"rollingUpdate" yaml:"rollingUpdate"`
-	Affinity         *AffinityRules    `json:"affinity" yaml:"affinity"`
-	Tolerations      []Toleration      `json:"tolerations" yaml:"tolerations"`
-	VPA              *VPAConfig        `json:"vpa" yaml:"vpa"`
-	ReadinessProbe   *CloudRunProbe    `json:"readinessProbe" yaml:"readinessProbe"`
-	LivenessProbe    *CloudRunProbe    `json:"livenessProbe" yaml:"livenessProbe"`
+	NodeSelector     map[string]string        `json:"nodeSelector" yaml:"nodeSelector"`
+	DisruptionBudget *DisruptionBudget        `json:"disruptionBudget" yaml:"disruptionBudget"`
+	RollingUpdate    *RollingUpdate           `json:"rollingUpdate" yaml:"rollingUpdate"`
+	Affinity         *AffinityRules           `json:"affinity" yaml:"affinity"`
+	Tolerations      []Toleration             `json:"tolerations" yaml:"tolerations"`
+	VPA              *VPAConfig               `json:"vpa" yaml:"vpa"`
+	ReadinessProbe   *CloudRunProbe           `json:"readinessProbe" yaml:"readinessProbe"`
+	LivenessProbe    *CloudRunProbe           `json:"livenessProbe" yaml:"livenessProbe"`
+	EphemeralVolumes []GenericEphemeralVolume `json:"ephemeralVolumes" yaml:"ephemeralVolumes"` // Generic ephemeral volumes for large temp storage
 }
 
 // AffinityRules defines pod affinity and anti-affinity rules for node pool isolation
@@ -159,9 +160,10 @@ func ToKubernetesRunConfig(tpl any, composeCfg compose.Config, stackCfg *api.Sta
 		deployCfg.RollingUpdate = k8sCloudExtras.RollingUpdate
 		deployCfg.DisruptionBudget = k8sCloudExtras.DisruptionBudget
 		deployCfg.NodeSelector = k8sCloudExtras.NodeSelector
-		deployCfg.VPA = k8sCloudExtras.VPA                       // Extract VPA configuration from CloudExtras
-		deployCfg.ReadinessProbe = k8sCloudExtras.ReadinessProbe // Extract global readiness probe configuration
-		deployCfg.LivenessProbe = k8sCloudExtras.LivenessProbe   // Extract global liveness probe configuration
+		deployCfg.VPA = k8sCloudExtras.VPA                           // Extract VPA configuration from CloudExtras
+		deployCfg.ReadinessProbe = k8sCloudExtras.ReadinessProbe     // Extract global readiness probe configuration
+		deployCfg.LivenessProbe = k8sCloudExtras.LivenessProbe       // Extract global liveness probe configuration
+		deployCfg.EphemeralVolumes = k8sCloudExtras.EphemeralVolumes // Extract generic ephemeral volumes configuration
 
 		// Process affinity rules and merge with existing NodeSelector if needed
 		if k8sCloudExtras.Affinity != nil {

--- a/pkg/clouds/k8s/types.go
+++ b/pkg/clouds/k8s/types.go
@@ -16,20 +16,21 @@ import (
 )
 
 type DeploymentConfig struct {
-	StackConfig      *api.StackConfigCompose `json:"stackConfig" yaml:"stackConfig"`
-	Containers       []CloudRunContainer     `json:"containers" yaml:"containers"`
-	IngressContainer *CloudRunContainer      `json:"ingressContainer" yaml:"ingressContainer"`
-	Scale            *Scale                  `json:"scale" yaml:"scale"`
-	Headers          *Headers                `json:"headers" yaml:"headers"`
-	TextVolumes      []SimpleTextVolume      `json:"textVolumes" yaml:"textVolumes"`
-	DisruptionBudget *DisruptionBudget       `json:"disruptionBudget" yaml:"disruptionBudget"`
-	RollingUpdate    *RollingUpdate          `json:"rollingUpdate" yaml:"rollingUpdate"`
-	NodeSelector     map[string]string       `json:"nodeSelector" yaml:"nodeSelector"`
-	Affinity         *AffinityRules          `json:"affinity" yaml:"affinity"`
-	Tolerations      []Toleration            `json:"tolerations" yaml:"tolerations"`
-	VPA              *VPAConfig              `json:"vpa" yaml:"vpa"`                       // Vertical Pod Autoscaler configuration
-	ReadinessProbe   *CloudRunProbe          `json:"readinessProbe" yaml:"readinessProbe"` // Global readiness probe configuration
-	LivenessProbe    *CloudRunProbe          `json:"livenessProbe" yaml:"livenessProbe"`   // Global liveness probe configuration
+	StackConfig      *api.StackConfigCompose  `json:"stackConfig" yaml:"stackConfig"`
+	Containers       []CloudRunContainer      `json:"containers" yaml:"containers"`
+	IngressContainer *CloudRunContainer       `json:"ingressContainer" yaml:"ingressContainer"`
+	Scale            *Scale                   `json:"scale" yaml:"scale"`
+	Headers          *Headers                 `json:"headers" yaml:"headers"`
+	TextVolumes      []SimpleTextVolume       `json:"textVolumes" yaml:"textVolumes"`
+	DisruptionBudget *DisruptionBudget        `json:"disruptionBudget" yaml:"disruptionBudget"`
+	RollingUpdate    *RollingUpdate           `json:"rollingUpdate" yaml:"rollingUpdate"`
+	NodeSelector     map[string]string        `json:"nodeSelector" yaml:"nodeSelector"`
+	Affinity         *AffinityRules           `json:"affinity" yaml:"affinity"`
+	Tolerations      []Toleration             `json:"tolerations" yaml:"tolerations"`
+	VPA              *VPAConfig               `json:"vpa" yaml:"vpa"`                           // Vertical Pod Autoscaler configuration
+	ReadinessProbe   *CloudRunProbe           `json:"readinessProbe" yaml:"readinessProbe"`     // Global readiness probe configuration
+	LivenessProbe    *CloudRunProbe           `json:"livenessProbe" yaml:"livenessProbe"`       // Global liveness probe configuration
+	EphemeralVolumes []GenericEphemeralVolume `json:"ephemeralVolumes" yaml:"ephemeralVolumes"` // Generic ephemeral volumes for large temp storage
 }
 
 type CaddyConfig struct {
@@ -85,6 +86,18 @@ type PersistentVolume struct {
 	Storage          string   `json:"storage" yaml:"storage"`
 	AccessModes      []string `json:"accessModes" yaml:"accessModes"`
 	StorageClassName *string  `json:"storageClassName" yaml:"storageClassName"`
+}
+
+// GenericEphemeralVolume defines a generic ephemeral volume configuration
+// These volumes use Kubernetes generic ephemeral volumes feature, which creates
+// a PersistentVolumeClaim for each pod and deletes it when the pod is deleted.
+// This is useful for applications requiring large temporary storage (>10GB) on
+// GKE Autopilot, which has a 10GB limit on regular ephemeral storage.
+type GenericEphemeralVolume struct {
+	Name             string  `json:"name" yaml:"name"`
+	MountPath        string  `json:"mountPath" yaml:"mountPath"`
+	Size             string  `json:"size" yaml:"size"`
+	StorageClassName *string `json:"storageClassName" yaml:"storageClassName"` // Optional, defaults to cluster default
 }
 
 type Scale struct {

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -229,6 +229,7 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		LbConfig:               args.Deployment.StackConfig.LBConfig,
 		Volumes:                args.Deployment.TextVolumes,
 		PersistentVolumes:      pvs,
+		EphemeralVolumes:       args.Deployment.EphemeralVolumes, // Pass generic ephemeral volumes configuration
 		Containers:             containers,
 		ServiceAccountName:     args.ServiceAccountName,
 		InitContainers:         args.InitContainers,

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -118,6 +118,7 @@ type SimpleContainerArgs struct {
 	Volumes           []k8s.SimpleTextVolume       `json:"volumes" yaml:"volumes"`
 	SecretVolumes     []k8s.SimpleTextVolume       `json:"secretVolumes" yaml:"secretVolumes"`
 	PersistentVolumes []k8s.PersistentVolume       `json:"persistentVolumes" yaml:"persistentVolumes"`
+	EphemeralVolumes  []k8s.GenericEphemeralVolume `json:"ephemeralVolumes" yaml:"ephemeralVolumes"` // Generic ephemeral volumes for large temp storage
 	VPA               *k8s.VPAConfig               `json:"vpa" yaml:"vpa"`
 	Scale             *k8s.Scale                   `json:"scale" yaml:"scale"`
 
@@ -410,6 +411,62 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 			Name:      sdk.String(sanitizedName),
 			MountPath: sdk.String(pv.MountPath),
 		})
+	}
+
+	// Generic ephemeral volumes
+	// These use the generic ephemeral volume feature which creates a PVC for each pod
+	// and deletes it when the pod is deleted. This allows for larger temporary storage
+	// than the 10GB limit on GKE Autopilot regular ephemeral storage.
+	for _, ev := range args.EphemeralVolumes {
+		// Sanitize volume name for Kubernetes RFC 1123 compliance (no underscores allowed)
+		sanitizedName := sanitizeK8sResourceName(ev.Name)
+		if sanitizedName != ev.Name {
+			args.Log.Info(ctx.Context(), "📝 Sanitized ephemeral volume name %q -> %q for Kubernetes RFC 1123 compliance", ev.Name, sanitizedName)
+		}
+
+		// Set default storage class if not specified
+		storageClass := ev.StorageClassName
+		if storageClass == nil {
+			// Use the default standard-rwo storage class for GKE
+			defaultSC := "standard-rwo"
+			storageClass = &defaultSC
+			args.Log.Info(ctx.Context(), "📦 Using default storage class %q for ephemeral volume %q", defaultSC, sanitizedName)
+		}
+
+		// Create the generic ephemeral volume with volumeClaimTemplate
+		// This creates a PVC for each pod and deletes it when the pod is deleted
+		volumes = append(volumes, corev1.VolumeArgs{
+			Name: sdk.String(sanitizedName),
+			Ephemeral: &corev1.EphemeralVolumeSourceArgs{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplateArgs{
+					Metadata: &metav1.ObjectMetaArgs{
+						Name:        sdk.String(sanitizedName),
+						Labels:      sdk.ToStringMap(appLabels),
+						Annotations: sdk.ToStringMap(appAnnotations),
+					},
+					Spec: &corev1.PersistentVolumeClaimSpecArgs{
+						AccessModes: sdk.StringArray{
+							sdk.String("ReadWriteOnce"),
+						},
+						StorageClassName: sdk.StringPtrFromPtr(storageClass),
+						Resources: &corev1.VolumeResourceRequirementsArgs{
+							Requests: sdk.StringMap{
+								"storage": sdk.String(ev.Size),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		// Add the volume mount
+		volumeMounts = append(volumeMounts, corev1.VolumeMountArgs{
+			Name:      sdk.String(sanitizedName),
+			MountPath: sdk.String(ev.MountPath),
+		})
+
+		args.Log.Info(ctx.Context(), "✨ Added generic ephemeral volume %q at %q with size %q (storage class: %q)",
+			sanitizedName, ev.MountPath, ev.Size, lo.FromPtr(storageClass))
 	}
 
 	var strategy v1.DeploymentStrategyArgs


### PR DESCRIPTION
### Summary
This PR adds support for **Generic Ephemeral Volumes** to bypass GKE Autopilot's 10GB ephemeral storage limit while maintaining truly ephemeral behavior.

### Problem Statement
GKE Autopilot hard-limits regular ephemeral storage to **10GB maximum**, which cannot be increased through configuration, VPA, or any other means. This creates a bottleneck for applications that need larger temporary storage (like N8N binary data processing, container builds, data processing workflows, and ML model training).

### Solution
Implemented support for Kubernetes **Generic Ephemeral Volumes**, which:
- Creates a PersistentVolumeClaim for each pod automatically
- Deletes the PVC when the pod is deleted (truly ephemeral)
- Supports storage sizes up to 64TB with `pd-balanced` storage class
- Is fully compatible with GKE Autopilot constraints

### Changes Made

#### 1. New Type Definition (`pkg/clouds/k8s/types.go`)
```go
type GenericEphemeralVolume struct {
    Name             string  `json:"name" yaml:"name"`
    MountPath        string  `json:"mountPath" yaml:"mountPath"`
    Size             string  `json:"size" yaml:"size"`
    StorageClassName *string `json:"storageClassName" yaml:"storageClassName"`
}
```

#### 2. Configuration Structure Updates
- Added `EphemeralVolumes []GenericEphemeralVolume` to `CloudExtras` and `DeploymentConfig` structs
- Updated JSON schema with proper validation

#### 3. Kubernetes Manifest Generation
Implemented volume processing that creates generic ephemeral volumes using the `volumeClaimTemplate` approach:
- Names are sanitized for Kubernetes RFC 1123 compliance
- Defaults to `standard-rwo` storage class for GKE
- Creates volumes and mounts automatically

### Usage Example

```yaml
cloudExtras:
  ephemeralVolumes:
    - name: binary-data
      mountPath: "/data"
      size: "100Gi"
      storageClass: "standard-rwo"  # optional
    - name: build-cache
      mountPath: "/build"
      size: "50Gi"
```

### Benefits
- **Large capacity**: Up to 64TB with `pd-balanced` storage class
- **Truly ephemeral**: Automatically cleaned up when pod terminates
- **GKE Autopilot compatible**: Works within all Autopilot constraints
- **RFC 1123 compliant**: Volume names are automatically sanitized
- **Follows existing patterns**: Integrates seamlessly with current volume handling

### Testing
- All existing tests pass
- Build successful with no errors

### References
- [GKE Generic Ephemeral Volumes Documentation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/generic-ephemeral-volumes)
- [GKE Autopilot Resource Limits](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests)