### PR TITLE
Add externalTrafficPolicy to CaddyConfig for client IP preservation

### DIFF
--- a/pkg/clouds/k8s/types.go
+++ b/pkg/clouds/k8s/types.go
@@ -47,6 +47,9 @@ type CaddyConfig struct {
 	UseSSL           *bool      `json:"useSSL,omitempty" yaml:"useSSL,omitempty"`                     // whether to use ssl by default (default: true)
 	// Deployment name override for existing Caddy deployments (used when adopting clusters)
 	DeploymentName *string `json:"deploymentName,omitempty" yaml:"deploymentName,omitempty"` // override deployment name when adopting existing Caddy
+	// ExternalTrafficPolicy for LoadBalancer service. "Local" preserves client source IP
+	// (required for correct X-Forwarded-For when behind L4 LB). Default: "Cluster".
+	ExternalTrafficPolicy *string `json:"externalTrafficPolicy,omitempty" yaml:"externalTrafficPolicy,omitempty"`
 }
 
 type DisruptionBudget struct {

--- a/pkg/clouds/pulumi/kubernetes/caddy.go
+++ b/pkg/clouds/pulumi/kubernetes/caddy.go
@@ -239,18 +239,19 @@ func DeployCaddyService(ctx *sdk.Context, caddy CaddyDeployment, input api.Resou
 	}
 
 	sc, err := DeploySimpleContainer(ctx, Args{
-		ServiceType:         serviceType, // to provision external IP
-		ProvisionIngress:    caddy.ProvisionIngress,
-		UseSSL:              useSSL,
-		Namespace:           namespace,
-		DeploymentName:      deploymentName,
-		Input:               input,
-		ServiceAccountName:  lo.ToPtr(serviceAccount.Name),
-		Deployment:          deploymentConfig,
-		SecretVolumes:       caddy.SecretVolumes,       // Cloud credentials volumes (e.g., GCP service account)
-		SecretVolumeOutputs: caddy.SecretVolumeOutputs, // Pulumi outputs for secret volumes
-		SecretEnvs:          secretEnvs,                // Secret environment variables
-		VPA:                 caddy.VPA,                 // Vertical Pod Autoscaler configuration for Caddy
+		ServiceType:           serviceType, // to provision external IP
+		ProvisionIngress:      caddy.ProvisionIngress,
+		UseSSL:                useSSL,
+		Namespace:             namespace,
+		DeploymentName:        deploymentName,
+		Input:                 input,
+		ServiceAccountName:    lo.ToPtr(serviceAccount.Name),
+		Deployment:            deploymentConfig,
+		SecretVolumes:         caddy.SecretVolumes,       // Cloud credentials volumes (e.g., GCP service account)
+		SecretVolumeOutputs:   caddy.SecretVolumeOutputs, // Pulumi outputs for secret volumes
+		SecretEnvs:            secretEnvs,                // Secret environment variables
+		VPA:                   caddy.VPA,                 // Vertical Pod Autoscaler configuration for Caddy
+		ExternalTrafficPolicy: lo.FromPtr(caddy.CaddyConfig).ExternalTrafficPolicy,
 		Images: []*ContainerImage{
 			{
 				Container: caddyContainer,

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -45,6 +45,7 @@ type Args struct {
 	VPA                    *k8s.VPAConfig     // Vertical Pod Autoscaler configuration
 	ReadinessProbe         *k8s.CloudRunProbe // Global readiness probe configuration
 	LivenessProbe          *k8s.CloudRunProbe // Global liveness probe configuration
+	ExternalTrafficPolicy  *string            // "Local" preserves client IP on LoadBalancer services
 }
 
 func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOption) (*SimpleContainer, error) {
@@ -238,6 +239,7 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		Sidecars:               args.Sidecars,
 		VPA:                    args.VPA,              // Pass VPA configuration to SimpleContainer
 		Scale:                  args.Deployment.Scale, // Pass Scale configuration to SimpleContainer
+		ExternalTrafficPolicy:  args.ExternalTrafficPolicy,
 		PodDisruption: lo.If(args.Deployment.DisruptionBudget != nil, args.Deployment.DisruptionBudget).Else(&k8s.DisruptionBudget{
 			MinAvailable: lo.ToPtr(1),
 		}),

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -105,21 +105,22 @@ type SimpleContainerArgs struct {
 	KubeProvider           sdk.ProviderResource
 
 	// optional properties
-	PodDisruption     *k8s.DisruptionBudget        `json:"podDisruption" yaml:"podDisruption"`
-	LbConfig          *api.SimpleContainerLBConfig `json:"lbConfig" yaml:"lbConfig"`
-	SecretEnvs        map[string]string            `json:"secretEnvs" yaml:"secretEnvs"`
-	Annotations       map[string]string            `json:"annotations" yaml:"annotations"`
-	NodeSelector      map[string]string            `json:"nodeSelector" yaml:"nodeSelector"`
-	Affinity          *k8s.AffinityRules           `json:"affinity" yaml:"affinity"`
-	IngressContainer  *k8s.CloudRunContainer       `json:"ingressContainer" yaml:"ingressContainer"`
-	ServiceType       *string                      `json:"serviceType" yaml:"serviceType"`
-	ProvisionIngress  bool                         `json:"provisionIngress" yaml:"provisionIngress"`
-	Headers           *k8s.Headers                 `json:"headers" yaml:"headers"`
-	Volumes           []k8s.SimpleTextVolume       `json:"volumes" yaml:"volumes"`
-	SecretVolumes     []k8s.SimpleTextVolume       `json:"secretVolumes" yaml:"secretVolumes"`
-	PersistentVolumes []k8s.PersistentVolume       `json:"persistentVolumes" yaml:"persistentVolumes"`
-	VPA               *k8s.VPAConfig               `json:"vpa" yaml:"vpa"`
-	Scale             *k8s.Scale                   `json:"scale" yaml:"scale"`
+	PodDisruption         *k8s.DisruptionBudget        `json:"podDisruption" yaml:"podDisruption"`
+	LbConfig              *api.SimpleContainerLBConfig `json:"lbConfig" yaml:"lbConfig"`
+	SecretEnvs            map[string]string            `json:"secretEnvs" yaml:"secretEnvs"`
+	Annotations           map[string]string            `json:"annotations" yaml:"annotations"`
+	NodeSelector          map[string]string            `json:"nodeSelector" yaml:"nodeSelector"`
+	Affinity              *k8s.AffinityRules           `json:"affinity" yaml:"affinity"`
+	IngressContainer      *k8s.CloudRunContainer       `json:"ingressContainer" yaml:"ingressContainer"`
+	ServiceType           *string                      `json:"serviceType" yaml:"serviceType"`
+	ExternalTrafficPolicy *string                      `json:"externalTrafficPolicy" yaml:"externalTrafficPolicy"`
+	ProvisionIngress      bool                         `json:"provisionIngress" yaml:"provisionIngress"`
+	Headers               *k8s.Headers                 `json:"headers" yaml:"headers"`
+	Volumes               []k8s.SimpleTextVolume       `json:"volumes" yaml:"volumes"`
+	SecretVolumes         []k8s.SimpleTextVolume       `json:"secretVolumes" yaml:"secretVolumes"`
+	PersistentVolumes     []k8s.PersistentVolume       `json:"persistentVolumes" yaml:"persistentVolumes"`
+	VPA                   *k8s.VPAConfig               `json:"vpa" yaml:"vpa"`
+	Scale                 *k8s.Scale                   `json:"scale" yaml:"scale"`
 
 	Log logger.Logger
 	// ...
@@ -510,10 +511,11 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	}
 
 	// Expose service
-	serviceType := sdk.String("ClusterIP")
+	serviceTypeStr := "ClusterIP"
 	if args.ServiceType != nil {
-		serviceType = sdk.String(lo.FromPtr(args.ServiceType))
+		serviceTypeStr = lo.FromPtr(args.ServiceType)
 	}
+	serviceType := sdk.String(serviceTypeStr)
 
 	serviceAnnotations := lo.Assign(appAnnotations)
 
@@ -589,11 +591,7 @@ ${proto}://${domain} {
 				Labels:      sdk.ToStringMap(appLabels),
 				Annotations: sdk.ToStringMap(serviceAnnotations),
 			},
-			Spec: &corev1.ServiceSpecArgs{
-				Selector: sdk.ToStringMap(appLabels),
-				Ports:    servicePorts,
-				Type:     serviceType,
-			},
+			Spec: serviceSpec(appLabels, servicePorts, serviceType, serviceTypeStr, args.ExternalTrafficPolicy),
 		}, opts...)
 		if err != nil {
 			return nil, err
@@ -848,6 +846,23 @@ func createVPA(ctx *sdk.Context, args *SimpleContainerArgs, deploymentName, name
 
 	args.Log.Info(ctx.Context(), "Created VPA %s for deployment %s", vpaName, deploymentName)
 	return nil
+}
+
+// serviceSpec builds a ServiceSpecArgs, optionally setting ExternalTrafficPolicy
+// when the service type is LoadBalancer. "Local" preserves the client source IP
+// by skipping SNAT — required for correct X-Forwarded-For behind an L4 LB.
+func serviceSpec(appLabels map[string]string, ports corev1.ServicePortArray, serviceType sdk.StringInput, serviceTypeStr string, externalTrafficPolicy *string) *corev1.ServiceSpecArgs {
+	spec := &corev1.ServiceSpecArgs{
+		Selector: sdk.ToStringMap(appLabels),
+		Ports:    ports,
+		Type:     serviceType,
+	}
+	// ExternalTrafficPolicy only applies to LoadBalancer and NodePort services.
+	// Setting it on ClusterIP produces an invalid k8s Service spec.
+	if externalTrafficPolicy != nil && serviceTypeStr != "ClusterIP" {
+		spec.ExternalTrafficPolicy = sdk.StringPtr(*externalTrafficPolicy)
+	}
+	return spec
 }
 
 func ToImagePullSecretName(deploymentName string) string {

--- a/pkg/clouds/pulumi/kubernetes/simple_container_advanced_test.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container_advanced_test.go
@@ -660,3 +660,94 @@ func TestSimpleContainer_ServiceTypeVariations(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceSpec_ExternalTrafficPolicy(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("nil policy uses default", func(t *testing.T) {
+		spec := serviceSpec(
+			map[string]string{"app": "test"},
+			corev1.ServicePortArray{},
+			sdk.String("LoadBalancer"),
+			"LoadBalancer",
+			nil,
+		)
+		Expect(spec).ToNot(BeNil())
+		Expect(spec.ExternalTrafficPolicy).To(BeNil())
+	})
+
+	t.Run("Local policy is set", func(t *testing.T) {
+		policy := "Local"
+		spec := serviceSpec(
+			map[string]string{"app": "test"},
+			corev1.ServicePortArray{},
+			sdk.String("LoadBalancer"),
+			"LoadBalancer",
+			&policy,
+		)
+		Expect(spec).ToNot(BeNil())
+		Expect(spec.ExternalTrafficPolicy).ToNot(BeNil())
+	})
+
+	t.Run("ClusterIP ignores policy", func(t *testing.T) {
+		policy := "Cluster"
+		spec := serviceSpec(
+			map[string]string{"app": "test"},
+			corev1.ServicePortArray{},
+			sdk.String("ClusterIP"),
+			"ClusterIP",
+			&policy,
+		)
+		Expect(spec).ToNot(BeNil())
+		Expect(spec.ExternalTrafficPolicy).To(BeNil())
+	})
+}
+
+func TestSimpleContainer_ExternalTrafficPolicy(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("LoadBalancer with Local traffic policy", func(t *testing.T) {
+		mocks := NewSimpleContainerMocks()
+
+		err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+			policy := "Local"
+			args := &SimpleContainerArgs{
+				Namespace:  "traffic-test",
+				Service:    "traffic-test",
+				ScEnv:      "test",
+				Deployment: "traffic-deployment",
+				Replicas:   1,
+				Log:        logger.New(),
+
+				IngressContainer: &k8s.CloudRunContainer{
+					Name:     "traffic-container",
+					Ports:    []int{8080},
+					MainPort: lo.ToPtr(8080),
+				},
+				ServiceType:           lo.ToPtr("LoadBalancer"),
+				ExternalTrafficPolicy: &policy,
+
+				Containers: []corev1.ContainerArgs{
+					{
+						Name:  sdk.String("traffic-container"),
+						Image: sdk.String("nginx:latest"),
+						Ports: corev1.ContainerPortArray{
+							&corev1.ContainerPortArgs{
+								ContainerPort: sdk.Int(8080),
+							},
+						},
+					},
+				},
+			}
+
+			sc, err := NewSimpleContainer(ctx, args)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sc).ToNot(BeNil())
+			Expect(sc.Service).ToNot(BeNil())
+
+			return nil
+		}, pulumi.WithMocks("project", "stack", mocks))
+
+		Expect(err).ToNot(HaveOccurred())
+	})
+}


### PR DESCRIPTION
## Problem

GKE Autopilot L4 LoadBalancer with default `externalTrafficPolicy: Cluster` performs SNAT on incoming traffic. The real client IP is lost — Caddy sees only internal GKE node IPs in `REMOTE_ADDR`, and `X-Forwarded-For` contains `10.x.x.x` instead of the actual user IP.

The recently added `trustedProxies` tells Caddy to trust XFF from known proxies, but it doesn't help when the L4 LB strips the real IP before it reaches Caddy.

## Fix

Adds `externalTrafficPolicy` field to `CaddyConfig`. When set to `"Local"`, the L4 LoadBalancer routes traffic directly to the node running the Caddy pod, preserving the original source IP.

### Changes

- `pkg/clouds/k8s/types.go` — `ExternalTrafficPolicy *string` field on `CaddyConfig`
- `pkg/clouds/pulumi/kubernetes/deployment.go` — pass through `Args` → `SimpleContainerArgs`
- `pkg/clouds/pulumi/kubernetes/caddy.go` — read from `CaddyConfig` and pass to `Args`
- `pkg/clouds/pulumi/kubernetes/simple_container.go` — `serviceSpec()` helper that sets `ExternalTrafficPolicy` on the k8s Service when provided

### Usage

```yaml
# server.yaml
caddy:
  enable: true
  externalTrafficPolicy: "Local"
  trustedProxies:
    - "10.0.0.0/8"
    - "173.245.48.0/20"
```

Both `trustedProxies` and `externalTrafficPolicy: Local` are needed together:
- `externalTrafficPolicy: Local` — preserves real IP at L4 LB level
- `trustedProxies` — tells Caddy to trust XFF headers from those IPs

### Notes
- Only applies when service type is `LoadBalancer` (default for Caddy)
- With `Local` policy, traffic only routes to nodes with Caddy pods. GKE Autopilot handles this correctly with health checks.
- Manually tested on PAY-SPACE production — client IPs now correctly appear in application logs