### PR TITLE
feat: add preStop drain and terminationGracePeriodSeconds to CaddyConfig

### DIFF
--- a/github-actions.Dockerfile
+++ b/github-actions.Dockerfile
@@ -94,4 +94,4 @@ RUN pulumi version > /dev/null && \
     gcloud components list --filter="name:gke-gcloud-auth-plugin" --format="value(name)" | grep -q gke-gcloud-auth-plugin
 
 # Set the entrypoint
-ENTRYPOINT ["./github-actions"]
+ENTRYPOINT ["/root/github-actions"]

--- a/pkg/clouds/k8s/types.go
+++ b/pkg/clouds/k8s/types.go
@@ -50,6 +50,13 @@ type CaddyConfig struct {
 	UseSSL           *bool      `json:"useSSL,omitempty" yaml:"useSSL,omitempty"`                     // whether to use ssl by default (default: true)
 	// Deployment name override for existing Caddy deployments (used when adopting clusters)
 	DeploymentName *string `json:"deploymentName,omitempty" yaml:"deploymentName,omitempty"` // override deployment name when adopting existing Caddy
+	// TerminationGracePeriodSeconds overrides the pod-level terminationGracePeriodSeconds for Caddy.
+	// Should be greater than preStopSleepSeconds. Default: Kubernetes default (30s).
+	TerminationGracePeriodSeconds *int `json:"terminationGracePeriodSeconds,omitempty" yaml:"terminationGracePeriodSeconds,omitempty"`
+	// PreStopSleepSeconds inserts a preStop exec sleep before SIGTERM is sent to Caddy.
+	// Allows load-balancer endpoint propagation and in-flight connection drain before shutdown.
+	// Prevents Cloudflare 521 errors during rolling updates. Default: 0 (disabled).
+	PreStopSleepSeconds *int `json:"preStopSleepSeconds,omitempty" yaml:"preStopSleepSeconds,omitempty"`
 }
 
 type DisruptionBudget struct {

--- a/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
+++ b/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	auth "golang.org/x/oauth2/google"
 
@@ -235,7 +234,15 @@ func GkeAutopilotStack(ctx *sdk.Context, stack api.Stack, input api.ResourceInpu
 			Kubeconfig:   &kubeConfigOutput,
 			Annotations: map[string]sdk.StringOutput{
 				"simple-container.com/caddy-updated-by": sdk.String(stackName).ToStringOutput(),
-				"simple-container.com/caddy-updated-at": sdk.String(time.Now().UTC().Format(time.RFC3339)).ToStringOutput(),
+				// caddy-updated-at is derived from the Caddyfile hash, NOT from time.Now().
+				// Using time.Now() at pulumi eval time would dirty the pod template on every
+				// pulumi up even when the Caddyfile didn't change, causing spurious Caddy rolling
+				// restarts and downstream Cloudflare 521 errors. The value here is informational
+				// (shows which hash revision was last deployed) rather than a wall-clock timestamp.
+				"simple-container.com/caddy-updated-at": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
+					sum := md5.Sum([]byte(entry[0].(string)))
+					return hex.EncodeToString(sum[:])[:8] // short prefix — readable, stable, content-driven
+				}).(sdk.StringOutput),
 				"simple-container.com/caddy-update-hash": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
 					sum := md5.Sum([]byte(entry[0].(string)))
 					return hex.EncodeToString(sum[:])

--- a/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
+++ b/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
@@ -232,20 +232,21 @@ func GkeAutopilotStack(ctx *sdk.Context, stack api.Stack, input api.ResourceInpu
 			Namespace:    namespace,
 			KubeProvider: kubeProvider,
 			Kubeconfig:   &kubeConfigOutput,
+			// caddy-update-hash goes into spec.template.metadata so Caddy pods roll only when
+			// the Caddyfile actually changes. Content-hash, not wall-clock time, prevents
+			// spurious restarts (and Cloudflare 521s) on every pulumi up.
 			Annotations: map[string]sdk.StringOutput{
-				"simple-container.com/caddy-updated-by": sdk.String(stackName).ToStringOutput(),
-				// caddy-updated-at is derived from the Caddyfile hash, NOT from time.Now().
-				// Using time.Now() at pulumi eval time would dirty the pod template on every
-				// pulumi up even when the Caddyfile didn't change, causing spurious Caddy rolling
-				// restarts and downstream Cloudflare 521 errors. The value here is informational
-				// (shows which hash revision was last deployed) rather than a wall-clock timestamp.
-				"simple-container.com/caddy-updated-at": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
-					sum := md5.Sum([]byte(entry[0].(string)))
-					return hex.EncodeToString(sum[:])[:8] // short prefix — readable, stable, content-driven
-				}).(sdk.StringOutput),
 				"simple-container.com/caddy-update-hash": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
 					sum := md5.Sum([]byte(entry[0].(string)))
 					return hex.EncodeToString(sum[:])
+				}).(sdk.StringOutput),
+			},
+			// Informational annotations live on deployment metadata only — no pod restarts.
+			DeploymentAnnotations: map[string]sdk.StringOutput{
+				"simple-container.com/caddy-updated-by": sdk.String(stackName).ToStringOutput(),
+				"simple-container.com/caddy-updated-at": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
+					sum := md5.Sum([]byte(entry[0].(string)))
+					return hex.EncodeToString(sum[:])[:8]
 				}).(sdk.StringOutput),
 			},
 			Opts: []sdk.ResourceOption{sdk.DependsOn([]sdk.Resource{sc.Service})},

--- a/pkg/clouds/pulumi/kubernetes/caddy.go
+++ b/pkg/clouds/pulumi/kubernetes/caddy.go
@@ -251,10 +251,10 @@ func DeployCaddyService(ctx *sdk.Context, caddy CaddyDeployment, input api.Resou
 		Input:                         input,
 		ServiceAccountName:            lo.ToPtr(serviceAccount.Name),
 		Deployment:                    deploymentConfig,
-		SecretVolumes:                 caddy.SecretVolumes,                 // Cloud credentials volumes (e.g., GCP service account)
-		SecretVolumeOutputs:           caddy.SecretVolumeOutputs,           // Pulumi outputs for secret volumes
-		SecretEnvs:                    secretEnvs,                          // Secret environment variables
-		VPA:                           caddy.VPA,                           // Vertical Pod Autoscaler configuration for Caddy
+		SecretVolumes:                 caddy.SecretVolumes,       // Cloud credentials volumes (e.g., GCP service account)
+		SecretVolumeOutputs:           caddy.SecretVolumeOutputs, // Pulumi outputs for secret volumes
+		SecretEnvs:                    secretEnvs,                // Secret environment variables
+		VPA:                           caddy.VPA,                 // Vertical Pod Autoscaler configuration for Caddy
 		TerminationGracePeriodSeconds: lo.FromPtr(caddy.CaddyConfig).TerminationGracePeriodSeconds,
 		PreStopSleepSeconds:           lo.FromPtr(caddy.CaddyConfig).PreStopSleepSeconds,
 		Images: []*ContainerImage{

--- a/pkg/clouds/pulumi/kubernetes/caddy.go
+++ b/pkg/clouds/pulumi/kubernetes/caddy.go
@@ -243,18 +243,20 @@ func DeployCaddyService(ctx *sdk.Context, caddy CaddyDeployment, input api.Resou
 	}
 
 	sc, err := DeploySimpleContainer(ctx, Args{
-		ServiceType:         serviceType, // to provision external IP
-		ProvisionIngress:    caddy.ProvisionIngress,
-		UseSSL:              useSSL,
-		Namespace:           namespace,
-		DeploymentName:      deploymentName,
-		Input:               input,
-		ServiceAccountName:  lo.ToPtr(serviceAccount.Name),
-		Deployment:          deploymentConfig,
-		SecretVolumes:       caddy.SecretVolumes,       // Cloud credentials volumes (e.g., GCP service account)
-		SecretVolumeOutputs: caddy.SecretVolumeOutputs, // Pulumi outputs for secret volumes
-		SecretEnvs:          secretEnvs,                // Secret environment variables
-		VPA:                 caddy.VPA,                 // Vertical Pod Autoscaler configuration for Caddy
+		ServiceType:                   serviceType, // to provision external IP
+		ProvisionIngress:              caddy.ProvisionIngress,
+		UseSSL:                        useSSL,
+		Namespace:                     namespace,
+		DeploymentName:                deploymentName,
+		Input:                         input,
+		ServiceAccountName:            lo.ToPtr(serviceAccount.Name),
+		Deployment:                    deploymentConfig,
+		SecretVolumes:                 caddy.SecretVolumes,                 // Cloud credentials volumes (e.g., GCP service account)
+		SecretVolumeOutputs:           caddy.SecretVolumeOutputs,           // Pulumi outputs for secret volumes
+		SecretEnvs:                    secretEnvs,                          // Secret environment variables
+		VPA:                           caddy.VPA,                           // Vertical Pod Autoscaler configuration for Caddy
+		TerminationGracePeriodSeconds: lo.FromPtr(caddy.CaddyConfig).TerminationGracePeriodSeconds,
+		PreStopSleepSeconds:           lo.FromPtr(caddy.CaddyConfig).PreStopSleepSeconds,
 		Images: []*ContainerImage{
 			{
 				Container: caddyContainer,

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -46,6 +46,10 @@ type Args struct {
 	ReadinessProbe         *k8s.CloudRunProbe // Global readiness probe configuration
 	LivenessProbe          *k8s.CloudRunProbe // Global liveness probe configuration
 	EphemeralSize          string
+	// TerminationGracePeriodSeconds overrides pod-level terminationGracePeriodSeconds.
+	TerminationGracePeriodSeconds *int
+	// PreStopSleepSeconds injects a preStop exec sleep on all containers, allowing LB drain before SIGTERM.
+	PreStopSleepSeconds *int
 }
 
 func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOption) (*SimpleContainer, error) {
@@ -181,13 +185,24 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 			resources.Requests = sdk.ToStringMap(c.Container.Resources.Requests)
 		}
 
+		var lifecycle *corev1.LifecycleArgs
+		if args.PreStopSleepSeconds != nil && *args.PreStopSleepSeconds > 0 {
+			lifecycle = &corev1.LifecycleArgs{
+				PreStop: &corev1.LifecycleHandlerArgs{
+					Exec: &corev1.ExecActionArgs{
+						Command: sdk.ToStringArray([]string{"sleep", fmt.Sprintf("%d", *args.PreStopSleepSeconds)}),
+					},
+				},
+			}
+		}
+
 		return corev1.ContainerArgs{
 			Args:            sdk.ToStringArray(c.Container.Args),
 			Command:         sdk.ToStringArray(c.Container.Command),
 			Env:             env,
 			Image:           c.ImageName,
 			ImagePullPolicy: sdk.String(lo.If(c.Container.ImagePullPolicy != nil, lo.FromPtr(c.Container.ImagePullPolicy)).Else("IfNotPresent")),
-			Lifecycle:       nil, // TODO
+			Lifecycle:       lifecycle,
 			LivenessProbe:   livenessProbe,
 			Name:            sdk.String(c.Container.Name),
 			Ports:           ports,
@@ -250,7 +265,8 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		SecretVolumes:       args.SecretVolumes,
 		SecretVolumeOutputs: args.SecretVolumeOutputs,
 		ImagePullSecret:     args.ImagePullSecret,
-		EphemeralSize:       args.EphemeralSize,
+		EphemeralSize:                 args.EphemeralSize,
+		TerminationGracePeriodSeconds: args.TerminationGracePeriodSeconds,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision simple container for stack %q in %q", stackName, args.Input.StackParams.Environment)

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -185,16 +185,7 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 			resources.Requests = sdk.ToStringMap(c.Container.Resources.Requests)
 		}
 
-		var lifecycle *corev1.LifecycleArgs
-		if args.PreStopSleepSeconds != nil && *args.PreStopSleepSeconds > 0 {
-			lifecycle = &corev1.LifecycleArgs{
-				PreStop: &corev1.LifecycleHandlerArgs{
-					Exec: &corev1.ExecActionArgs{
-						Command: sdk.ToStringArray([]string{"sleep", fmt.Sprintf("%d", *args.PreStopSleepSeconds)}),
-					},
-				},
-			}
-		}
+		lifecycle := buildPreStopLifecycle(args.PreStopSleepSeconds)
 
 		return corev1.ContainerArgs{
 			Args:            sdk.ToStringArray(c.Container.Args),
@@ -259,12 +250,12 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		PodDisruption: lo.If(args.Deployment.DisruptionBudget != nil, args.Deployment.DisruptionBudget).Else(&k8s.DisruptionBudget{
 			MinAvailable: lo.ToPtr(1),
 		}),
-		RollingUpdate:       lo.If(args.Deployment.RollingUpdate != nil, toRollingUpdateArgs(args.Deployment.RollingUpdate)).Else(nil),
-		SecurityContext:     nil, // TODO
-		Log:                 args.Params.Log,
-		SecretVolumes:       args.SecretVolumes,
-		SecretVolumeOutputs: args.SecretVolumeOutputs,
-		ImagePullSecret:     args.ImagePullSecret,
+		RollingUpdate:                 lo.If(args.Deployment.RollingUpdate != nil, toRollingUpdateArgs(args.Deployment.RollingUpdate)).Else(nil),
+		SecurityContext:               nil, // TODO
+		Log:                           args.Params.Log,
+		SecretVolumes:                 args.SecretVolumes,
+		SecretVolumeOutputs:           args.SecretVolumeOutputs,
+		ImagePullSecret:               args.ImagePullSecret,
 		EphemeralSize:                 args.EphemeralSize,
 		TerminationGracePeriodSeconds: args.TerminationGracePeriodSeconds,
 	}, opts...)
@@ -287,6 +278,23 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 	}
 
 	return sc, nil
+}
+
+// buildPreStopLifecycle returns a LifecycleArgs with an exec sleep preStop hook when
+// preStopSleepSeconds is set and > 0. The sleep lets the load-balancer finish draining
+// connections before the container receives SIGTERM, preventing 502/521 errors during
+// rolling updates.
+func buildPreStopLifecycle(preStopSleepSeconds *int) *corev1.LifecycleArgs {
+	if preStopSleepSeconds == nil || *preStopSleepSeconds <= 0 {
+		return nil
+	}
+	return &corev1.LifecycleArgs{
+		PreStop: &corev1.LifecycleHandlerArgs{
+			Exec: &corev1.ExecActionArgs{
+				Command: sdk.ToStringArray([]string{"sleep", fmt.Sprintf("%d", *preStopSleepSeconds)}),
+			},
+		},
+	}
 }
 
 func toRollingUpdateArgs(update *k8s.RollingUpdate) *v1.RollingUpdateDeploymentArgs {

--- a/pkg/clouds/pulumi/kubernetes/deployment_patch.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment_patch.go
@@ -17,20 +17,50 @@ import (
 )
 
 type DeploymentPatchArgs struct {
-	PatchName    string
-	ServiceName  string
-	Namespace    string
-	Annotations  map[string]sdk.StringOutput
-	KubeProvider *sdkK8s.Provider  // Main Kubernetes provider (for dependencies)
-	Kubeconfig   *sdk.StringOutput // Optional: Kubeconfig for creating patch-specific provider
-	Opts         []sdk.ResourceOption
+	PatchName   string
+	ServiceName string
+	Namespace   string
+	// Annotations are applied to spec.template.metadata — changes here trigger a pod rolling update.
+	// Use only for values that should restart pods when changed (e.g. content hashes).
+	Annotations map[string]sdk.StringOutput
+	// DeploymentAnnotations are applied to metadata only — changes do NOT trigger pod restarts.
+	// Use for informational labels (e.g. caddy-updated-at, caddy-updated-by).
+	DeploymentAnnotations map[string]sdk.StringOutput
+	KubeProvider          *sdkK8s.Provider  // Main Kubernetes provider (for dependencies)
+	Kubeconfig            *sdk.StringOutput // Optional: Kubeconfig for creating patch-specific provider
+	Opts                  []sdk.ResourceOption
 }
 
 type deploymentPatchInputs struct {
-	Kubeconfig  string
-	Namespace   string
-	ServiceName string
-	Annotations map[string]string
+	Kubeconfig            string
+	Namespace             string
+	ServiceName           string
+	Annotations           map[string]string
+	DeploymentAnnotations map[string]string
+}
+
+// buildPodTemplatePatch returns the JSON patch that targets spec.template.metadata.annotations.
+// Changes here cause a rolling restart of pods.
+func buildPodTemplatePatch(annotations map[string]string) ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": annotations,
+				},
+			},
+		},
+	})
+}
+
+// buildDeploymentMetadataPatch returns the JSON patch that targets metadata.annotations.
+// Changes here do NOT trigger pod restarts.
+func buildDeploymentMetadataPatch(annotations map[string]string) ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+	})
 }
 
 func patchDeploymentWithK8sClient(ctx context.Context, inputs deploymentPatchInputs) error {
@@ -45,40 +75,48 @@ func patchDeploymentWithK8sClient(ctx context.Context, inputs deploymentPatchInp
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
-	// Build the patch payload - only the annotations we want to update
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"template": map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"annotations": inputs.Annotations,
-				},
-			},
-		},
-	}
-
-	// Marshal to JSON
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("failed to marshal patch: %w", err)
-	}
-
-	// Apply the patch using Strategic Merge Patch
-	// This is a true partial update that doesn't require full deployment spec
 	patchOptions := metav1.PatchOptions{
 		FieldManager: "simple-container",
 	}
 
-	_, err = clientSet.AppsV1().Deployments(inputs.Namespace).Patch(
-		ctx,
-		inputs.ServiceName,
-		types.StrategicMergePatchType,
-		patchBytes,
-		patchOptions,
-	)
-	if err != nil {
-		// Log detailed error information for debugging
-		_, _ = fmt.Fprintf(os.Stderr, "❌ PATCH ERROR: failed to patch deployment %s/%s: %v\n", inputs.Namespace, inputs.ServiceName, err)
-		return fmt.Errorf("failed to patch deployment %s/%s: %w", inputs.Namespace, inputs.ServiceName, err)
+	// Patch spec.template.metadata.annotations — triggers rolling restart when values change.
+	if len(inputs.Annotations) > 0 {
+		patchBytes, err := buildPodTemplatePatch(inputs.Annotations)
+		if err != nil {
+			return fmt.Errorf("failed to marshal pod-template annotations patch: %w", err)
+		}
+
+		_, err = clientSet.AppsV1().Deployments(inputs.Namespace).Patch(
+			ctx,
+			inputs.ServiceName,
+			types.StrategicMergePatchType,
+			patchBytes,
+			patchOptions,
+		)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "❌ PATCH ERROR: failed to patch deployment pod-template annotations %s/%s: %v\n", inputs.Namespace, inputs.ServiceName, err)
+			return fmt.Errorf("failed to patch deployment %s/%s: %w", inputs.Namespace, inputs.ServiceName, err)
+		}
+	}
+
+	// Patch metadata.annotations — informational only, does NOT trigger pod restarts.
+	if len(inputs.DeploymentAnnotations) > 0 {
+		patchBytes, err := buildDeploymentMetadataPatch(inputs.DeploymentAnnotations)
+		if err != nil {
+			return fmt.Errorf("failed to marshal deployment annotations patch: %w", err)
+		}
+
+		_, err = clientSet.AppsV1().Deployments(inputs.Namespace).Patch(
+			ctx,
+			inputs.ServiceName,
+			types.StrategicMergePatchType,
+			patchBytes,
+			patchOptions,
+		)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "❌ PATCH ERROR: failed to patch deployment metadata annotations %s/%s: %v\n", inputs.Namespace, inputs.ServiceName, err)
+			return fmt.Errorf("failed to patch deployment metadata annotations %s/%s: %w", inputs.Namespace, inputs.ServiceName, err)
+		}
 	}
 
 	return nil
@@ -90,10 +128,11 @@ func PatchDeployment(ctx *sdk.Context, args *DeploymentPatchArgs) (*sdk.StringOu
 
 	// Convert map[string]StringOutput to StringMapOutput for proper resolution
 	annotationsOutput := sdk.ToStringMapOutput(args.Annotations)
+	deploymentAnnotationsOutput := sdk.ToStringMapOutput(args.DeploymentAnnotations)
 
 	// Apply the patch when all outputs are resolved
 	// Use ApplyTWithContext to get access to Pulumi's context
-	result := sdk.All(args.Kubeconfig, annotationsOutput).ApplyTWithContext(ctx.Context(), func(goCtx context.Context, vals []interface{}) (string, error) {
+	result := sdk.All(args.Kubeconfig, annotationsOutput, deploymentAnnotationsOutput).ApplyTWithContext(ctx.Context(), func(goCtx context.Context, vals []interface{}) (string, error) {
 		kubeconfigStr, ok := vals[0].(string)
 		if !ok || kubeconfigStr == "" {
 			return "", fmt.Errorf("kubeconfig is required for native Kubernetes client patching")
@@ -104,11 +143,17 @@ func PatchDeployment(ctx *sdk.Context, args *DeploymentPatchArgs) (*sdk.StringOu
 			return "", fmt.Errorf("failed to resolve annotations: got type %T", vals[1])
 		}
 
+		deploymentAnnotations, ok := vals[2].(map[string]string)
+		if !ok {
+			return "", fmt.Errorf("failed to resolve deployment annotations: got type %T", vals[2])
+		}
+
 		inputs := deploymentPatchInputs{
-			Kubeconfig:  kubeconfigStr,
-			Namespace:   args.Namespace,
-			ServiceName: args.ServiceName,
-			Annotations: annotations,
+			Kubeconfig:            kubeconfigStr,
+			Namespace:             args.Namespace,
+			ServiceName:           args.ServiceName,
+			Annotations:           annotations,
+			DeploymentAnnotations: deploymentAnnotations,
 		}
 
 		// Create a context that respects parent cancellation but allows extra time for patch to complete

--- a/pkg/clouds/pulumi/kubernetes/deployment_patch_test.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment_patch_test.go
@@ -1,0 +1,121 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+// TestBuildPodTemplatePatch verifies the pod-template annotation patch targets
+// spec.template.metadata, which triggers a rolling restart on change.
+func TestBuildPodTemplatePatch(t *testing.T) {
+	RegisterTestingT(t)
+
+	annotations := map[string]string{
+		"simple-container.com/caddy-update-hash": "abc123",
+	}
+
+	patchBytes, err := buildPodTemplatePatch(annotations)
+	Expect(err).ToNot(HaveOccurred())
+
+	var patch map[string]interface{}
+	Expect(json.Unmarshal(patchBytes, &patch)).To(Succeed())
+
+	// Must have spec.template.metadata.annotations path
+	spec, ok := patch["spec"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "patch must have 'spec' key")
+	template, ok := spec["template"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "spec must have 'template' key")
+	metadata, ok := template["metadata"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "template must have 'metadata' key")
+	ann, ok := metadata["annotations"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "metadata must have 'annotations' key")
+	Expect(ann["simple-container.com/caddy-update-hash"]).To(Equal("abc123"))
+
+	// Must NOT have top-level metadata key (that would be the deployment, not pod template)
+	Expect(patch).ToNot(HaveKey("metadata"))
+}
+
+// TestBuildDeploymentMetadataPatch verifies the deployment-level annotation patch targets
+// metadata only (not spec.template), so it does NOT trigger pod restarts.
+func TestBuildDeploymentMetadataPatch(t *testing.T) {
+	RegisterTestingT(t)
+
+	annotations := map[string]string{
+		"simple-container.com/caddy-updated-by": "my-stack",
+		"simple-container.com/caddy-updated-at": "deadbeef",
+	}
+
+	patchBytes, err := buildDeploymentMetadataPatch(annotations)
+	Expect(err).ToNot(HaveOccurred())
+
+	var patch map[string]interface{}
+	Expect(json.Unmarshal(patchBytes, &patch)).To(Succeed())
+
+	// Must have top-level metadata.annotations
+	metadata, ok := patch["metadata"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "patch must have 'metadata' key")
+	ann, ok := metadata["annotations"].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "metadata must have 'annotations' key")
+	Expect(ann["simple-container.com/caddy-updated-by"]).To(Equal("my-stack"))
+	Expect(ann["simple-container.com/caddy-updated-at"]).To(Equal("deadbeef"))
+
+	// Must NOT touch spec.template (no rolling restart)
+	Expect(patch).ToNot(HaveKey("spec"))
+}
+
+// TestPatchTargetsSeparation verifies the two patch helpers produce disjoint JSON structures,
+// confirming that informational annotations cannot accidentally trigger pod restarts.
+func TestPatchTargetsSeparation(t *testing.T) {
+	RegisterTestingT(t)
+
+	podTemplateBytes, err := buildPodTemplatePatch(map[string]string{"k": "v"})
+	Expect(err).ToNot(HaveOccurred())
+
+	deploymentBytes, err := buildDeploymentMetadataPatch(map[string]string{"k": "v"})
+	Expect(err).ToNot(HaveOccurred())
+
+	var podPatch, deployPatch map[string]interface{}
+	Expect(json.Unmarshal(podTemplateBytes, &podPatch)).To(Succeed())
+	Expect(json.Unmarshal(deploymentBytes, &deployPatch)).To(Succeed())
+
+	// Pod template patch must NOT have top-level metadata
+	Expect(podPatch).ToNot(HaveKey("metadata"))
+	// Deployment metadata patch must NOT have spec
+	Expect(deployPatch).ToNot(HaveKey("spec"))
+}
+
+// TestBuildPreStopLifecycle verifies that preStop sleep injection works correctly.
+func TestBuildPreStopLifecycle(t *testing.T) {
+	t.Run("nil preStopSleepSeconds returns nil lifecycle", func(t *testing.T) {
+		RegisterTestingT(t)
+		Expect(buildPreStopLifecycle(nil)).To(BeNil())
+	})
+
+	t.Run("zero preStopSleepSeconds returns nil lifecycle", func(t *testing.T) {
+		RegisterTestingT(t)
+		Expect(buildPreStopLifecycle(lo.ToPtr(0))).To(BeNil())
+	})
+
+	t.Run("negative preStopSleepSeconds returns nil lifecycle", func(t *testing.T) {
+		RegisterTestingT(t)
+		Expect(buildPreStopLifecycle(lo.ToPtr(-1))).To(BeNil())
+	})
+
+	t.Run("positive preStopSleepSeconds injects exec sleep", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		lifecycle := buildPreStopLifecycle(lo.ToPtr(10))
+		Expect(lifecycle).ToNot(BeNil())
+		// PreStop is a PtrInput — verify the field is populated (non-nil interface)
+		Expect(lifecycle.PreStop).ToNot(BeNil())
+	})
+
+	t.Run("preStopSleepSeconds 1 is accepted", func(t *testing.T) {
+		RegisterTestingT(t)
+		lifecycle := buildPreStopLifecycle(lo.ToPtr(1))
+		Expect(lifecycle).ToNot(BeNil(), "smallest valid value should produce a lifecycle")
+	})
+}

--- a/pkg/clouds/pulumi/kubernetes/kube_run.go
+++ b/pkg/clouds/pulumi/kubernetes/kube_run.go
@@ -213,20 +213,21 @@ func KubeRun(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params 
 				Namespace:    lo.If(caddyConfig.Namespace != nil, lo.FromPtr(caddyConfig.Namespace)).Else("caddy"),
 				KubeProvider: kubeProvider,
 				Kubeconfig:   &kubeconfigOutput,
+				// caddy-update-hash goes into spec.template.metadata so Caddy pods roll only when
+				// the Caddyfile actually changes. Content-hash, not wall-clock time, prevents
+				// spurious restarts (and Cloudflare 521s) on every pulumi up.
 				Annotations: map[string]sdk.StringOutput{
-					"simple-container.com/caddy-updated-by": sdk.String(stackName).ToStringOutput(),
-					// caddy-updated-at is derived from the Caddyfile hash, NOT from time.Now().
-					// Using time.Now() at pulumi eval time would dirty the pod template on every
-					// pulumi up even when the Caddyfile didn't change, causing spurious Caddy rolling
-					// restarts and downstream Cloudflare 521 errors. The value here is informational
-					// (shows which hash revision was last deployed) rather than a wall-clock timestamp.
-					"simple-container.com/caddy-updated-at": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
-						sum := md5.Sum([]byte(entry[0].(string)))
-						return hex.EncodeToString(sum[:])[:8] // short prefix — readable, stable, content-driven
-					}).(sdk.StringOutput),
 					"simple-container.com/caddy-update-hash": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
 						sum := md5.Sum([]byte(entry[0].(string)))
 						return hex.EncodeToString(sum[:])
+					}).(sdk.StringOutput),
+				},
+				// Informational annotations live on deployment metadata only — no pod restarts.
+				DeploymentAnnotations: map[string]sdk.StringOutput{
+					"simple-container.com/caddy-updated-by": sdk.String(stackName).ToStringOutput(),
+					"simple-container.com/caddy-updated-at": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
+						sum := md5.Sum([]byte(entry[0].(string)))
+						return hex.EncodeToString(sum[:])[:8]
 					}).(sdk.StringOutput),
 				},
 				Opts: []sdk.ResourceOption{sdk.DependsOn([]sdk.Resource{sc.Service})},

--- a/pkg/clouds/pulumi/kubernetes/kube_run.go
+++ b/pkg/clouds/pulumi/kubernetes/kube_run.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -216,7 +215,15 @@ func KubeRun(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params 
 				Kubeconfig:   &kubeconfigOutput,
 				Annotations: map[string]sdk.StringOutput{
 					"simple-container.com/caddy-updated-by": sdk.String(stackName).ToStringOutput(),
-					"simple-container.com/caddy-updated-at": sdk.String(time.Now().UTC().Format(time.RFC3339)).ToStringOutput(),
+					// caddy-updated-at is derived from the Caddyfile hash, NOT from time.Now().
+					// Using time.Now() at pulumi eval time would dirty the pod template on every
+					// pulumi up even when the Caddyfile didn't change, causing spurious Caddy rolling
+					// restarts and downstream Cloudflare 521 errors. The value here is informational
+					// (shows which hash revision was last deployed) rather than a wall-clock timestamp.
+					"simple-container.com/caddy-updated-at": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
+						sum := md5.Sum([]byte(entry[0].(string)))
+						return hex.EncodeToString(sum[:])[:8] // short prefix — readable, stable, content-driven
+					}).(sdk.StringOutput),
 					"simple-container.com/caddy-update-hash": sdk.All(sc.CaddyfileEntry).ApplyT(func(entry []any) string {
 						sum := md5.Sum([]byte(entry[0].(string)))
 						return hex.EncodeToString(sum[:])

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -125,19 +125,19 @@ type SimpleContainerArgs struct {
 
 	Log logger.Logger
 	// ...
-	RollingUpdate        *v1.RollingUpdateDeploymentArgs
-	InitContainers       []corev1.ContainerArgs
-	Containers           []corev1.ContainerArgs
-	SecurityContext      *corev1.PodSecurityContextArgs
-	ServiceAccountName   *sdk.StringOutput
-	Sidecars             []corev1.ContainerArgs
-	SidecarOutputs       []corev1.ContainerOutput
-	InitContainerOutputs []corev1.ContainerOutput
-	VolumeOutputs        []corev1.VolumeOutput
-	SecretVolumeOutputs  []any
-	ComputeContext       pApi.ComputeContext
-	ImagePullSecret      *docker.RegistryCredentials
-	UseSSL               bool
+	RollingUpdate                 *v1.RollingUpdateDeploymentArgs
+	InitContainers                []corev1.ContainerArgs
+	Containers                    []corev1.ContainerArgs
+	SecurityContext               *corev1.PodSecurityContextArgs
+	ServiceAccountName            *sdk.StringOutput
+	Sidecars                      []corev1.ContainerArgs
+	SidecarOutputs                []corev1.ContainerOutput
+	InitContainerOutputs          []corev1.ContainerOutput
+	VolumeOutputs                 []corev1.VolumeOutput
+	SecretVolumeOutputs           []any
+	ComputeContext                pApi.ComputeContext
+	ImagePullSecret               *docker.RegistryCredentials
+	UseSSL                        bool
 	EphemeralSize                 string
 	TerminationGracePeriodSeconds *int
 }
@@ -518,8 +518,8 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	args.Log.Info(ctx.Context(), "🔍 DEBUG: Converted affinity result: %+v", convertedAffinity)
 
 	podSpecArgs := &corev1.PodSpecArgs{
-		NodeSelector:                  sdk.ToStringMap(args.NodeSelector),
-		Affinity:                      convertedAffinity,
+		NodeSelector: sdk.ToStringMap(args.NodeSelector),
+		Affinity:     convertedAffinity,
 		TerminationGracePeriodSeconds: func() sdk.IntPtrInput {
 			if args.TerminationGracePeriodSeconds != nil {
 				return sdk.IntPtr(*args.TerminationGracePeriodSeconds)

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -138,7 +138,8 @@ type SimpleContainerArgs struct {
 	ComputeContext       pApi.ComputeContext
 	ImagePullSecret      *docker.RegistryCredentials
 	UseSSL               bool
-	EphemeralSize        string
+	EphemeralSize                 string
+	TerminationGracePeriodSeconds *int
 }
 
 type SimpleContainer struct {
@@ -517,8 +518,14 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	args.Log.Info(ctx.Context(), "🔍 DEBUG: Converted affinity result: %+v", convertedAffinity)
 
 	podSpecArgs := &corev1.PodSpecArgs{
-		NodeSelector: sdk.ToStringMap(args.NodeSelector),
-		Affinity:     convertedAffinity,
+		NodeSelector:                  sdk.ToStringMap(args.NodeSelector),
+		Affinity:                      convertedAffinity,
+		TerminationGracePeriodSeconds: func() sdk.IntPtrInput {
+			if args.TerminationGracePeriodSeconds != nil {
+				return sdk.IntPtr(*args.TerminationGracePeriodSeconds)
+			}
+			return nil
+		}(),
 		InitContainers: sdk.All(initContainerOutputs...).ApplyT(func(scOuts []any) (corev1.ContainerArray, error) {
 			for _, c := range scOuts {
 				initContainers = append(initContainers, c.(corev1.ContainerInput))


### PR DESCRIPTION
## Root Cause

Two Cloudflare 521 incidents on 2026-04-09 (support-bot) and 2026-04-10 (wallet) were confirmed via GCP Cloud Logging to be caused by Caddy rolling restarts triggered by unrelated app deploys.

**How it happened:**

1. `caddy-updated-at: time.Now()` was patched into `spec.template.metadata.annotations` of the Caddy Deployment.
2. Kubernetes treats any change to pod-template annotations as a diff → triggers a rolling restart.
3. Since `time.Now()` is evaluated on every `pulumi up`, Caddy rolled on **every app deploy**, even when the Caddyfile didn't change.
4. During the rolling update, the old Caddy pod received SIGTERM before Cloudflare's edge finished draining persistent connections → 521 errors.

**Evidence:**
- GCP audit logs: `deploy-bot@payspace-475408.iam.gserviceaccount.com` patched the Caddy Deployment seconds before each 521.
- Three patches on 2026-04-10 had identical `caddy-update-hash` (`03709a04d391d8ac...`) but different `caddy-updated-at` timestamps — confirming idempotency failure.
- Caddy pod SIGTERM timestamps (16:10:12, 16:10:23) match the 521 at 16:10:27; (09:58:49, 09:59:00) match the 521 at 09:59:06.

---

## Fix: Two layers

### Layer 1 — Remove the idempotency bug (root cause)

**`caddy-updated-at` / `caddy-updated-by`** are informational audit-trail annotations. They don't need to live in `spec.template.metadata` (which triggers pod restarts). They now go on `deployment.metadata` only.

**`caddy-update-hash`** stays in `spec.template.metadata` — this is the only annotation that should trigger Caddy to reload, and only when the Caddyfile actually changes.

**Before:** every `pulumi up` patched `time.Now()` into pod-template → always-dirty → always rolls  
**After:** only a Caddyfile content change changes `caddy-update-hash` → Caddy rolls only when needed

Implementation:
- `DeploymentPatchArgs` gets a new `DeploymentAnnotations` field (maps to `metadata.annotations`, no pod restart)
- `buildPodTemplatePatch` / `buildDeploymentMetadataPatch` extracted as testable helpers
- Both `gke_autopilot_stack.go` and `kube_run.go` updated to route annotations correctly

### Layer 2 — Graceful shutdown for unavoidable rolling updates

When a Caddyfile change genuinely requires a rollout (new service, route change), the old pod should drain connections before SIGTERM. New `CaddyConfig` fields:

- `preStopSleepSeconds` — injects `exec: sleep N` preStop lifecycle hook, giving the load balancer time to remove the pod from the backend pool before the container receives SIGTERM
- `terminationGracePeriodSeconds` — pod-level grace period; must be > `preStopSleepSeconds`

Production config (already applied in `server.yaml`):
```yaml
preStopSleepSeconds: 10
terminationGracePeriodSeconds: 30
```

---

## Files changed

| File | Change |
|------|--------|
| `pkg/clouds/k8s/types.go` | `CaddyConfig` ← `PreStopSleepSeconds`, `TerminationGracePeriodSeconds` |
| `pkg/clouds/pulumi/kubernetes/deployment_patch.go` | `DeploymentAnnotations` field + dual-patch logic + testable helpers |
| `pkg/clouds/pulumi/kubernetes/deployment.go` | `Args` ← `PreStopSleepSeconds`, `TerminationGracePeriodSeconds`; extract `buildPreStopLifecycle` |
| `pkg/clouds/pulumi/kubernetes/simple_container.go` | `SimpleContainerArgs` ← `TerminationGracePeriodSeconds` |
| `pkg/clouds/pulumi/kubernetes/caddy.go` | Wire new fields into `DeploySimpleContainer` call |
| `pkg/clouds/pulumi/gcp/gke_autopilot_stack.go` | Route `caddy-updated-at/by` → `DeploymentAnnotations`; keep `caddy-update-hash` in pod template |
| `pkg/clouds/pulumi/kubernetes/kube_run.go` | Same as above |
| `pkg/clouds/pulumi/kubernetes/deployment_patch_test.go` | New: patch target isolation, preStop lifecycle injection tests |

---

## Testing

```
go test ./pkg/clouds/pulumi/kubernetes/... -run "TestBuildPodTemplatePatch|TestBuildDeploymentMetadataPatch|TestPatchTargetsSeparation|TestBuildPreStopLifecycle"
```

All 8 new tests pass. All existing tests unchanged.