### PR TITLE
PR: Add consistent AWS tags to all resources

### DIFF
--- a/.agents/implementation/2026-04-18/aws-tags-all-resources/implementation-notes.md
+++ b/.agents/implementation/2026-04-18/aws-tags-all-resources/implementation-notes.md
@@ -1,0 +1,56 @@
+# AWS Tags on All Resources
+
+## Problem
+AWS resources created during deployment (Secrets Manager secrets, ECR repositories, RDS instances, Lambda functions, S3 buckets, etc.) were missing the standard `simple-container.com/*` tags. Only a subset of resources in `ecs_fargate.go` had tags applied.
+
+## Root Cause
+The tagging utility (`BuildTagsFromStackParams().ToAWSTags()`) was only called in `createEcsFargateCluster()`, and the resulting tags were not passed to helper functions like `createSecret()`, `createEcrRegistry()`, or used in other resource provisioning files.
+
+## Changes
+
+### Core signature changes
+- **`createSecret()`** (`secrets.go`): Added `tags sdk.StringMap` parameter, applied to `secretsmanager.SecretArgs.Tags`
+- **`createSNSTopicForAlerts()`** (`alerts.go`): Added `tags sdk.StringMap` parameter, applied to `sns.TopicArgs.Tags`
+- **`provisionScheduleForLambda()`** (`aws_lambda.go`): Added `tags sdk.StringMap` parameter, applied to `cloudwatch.EventRuleArgs.Tags`
+- **`attachAutoScalingPolicy()`** (`ecs_fargate.go`): Added `tags sdk.StringMap` parameter, applied to `appautoscaling.TargetArgs.Tags`
+- **`alertCfg`** struct (`alerts.go`): Added `tags sdk.StringMap` field
+- **`ecsTaskConfig`** struct (`exec_ecs_task.go`): Added `tags sdk.StringMap` field
+- **`StaticSiteInput`** struct (`static_website.go`): Added `Tags sdk.StringMap` field
+- **`S3BucketInput`** struct (`bucket.go`): Added `Tags sdk.StringMap` field
+
+### Files modified with tags added to resources
+
+| File | Resources tagged |
+|------|-----------------|
+| `secrets.go` | `secretsmanager.NewSecret` |
+| `ecr_repository.go` | `ecr.NewRepository` |
+| `ecs_fargate.go` | `ecs.NewFargateService` (merged with existing deployTime tag), `appautoscaling.NewTarget`, `StaticEgressIPIn.StackParams` |
+| `aws_lambda.go` | `iam.NewRole`, `iam.NewPolicy`, `cloudwatch.NewLogGroup`, `lambda.FunctionArgs`, `apigatewayv2.NewApi`, `apigatewayv2.NewStage`, `cloudwatch.NewEventRule`, `StaticEgressIPIn.StackParams` |
+| `alerts.go` | `iam.NewRole`, `iam.NewPolicy`, `lambda.NewFunction`, `cloudwatch.MetricAlarmArgs`, `sns.NewTopic` |
+| `rds_postgres.go` | `ec2.NewSecurityGroup`, `rds.NewSubnetGroup`, `rds.NewInstance` |
+| `rds_mysql.go` | `ec2.NewSecurityGroup`, `rds.NewSubnetGroup`, `rds.NewInstance` |
+| `static_website.go` | `s3.NewBucket` (main + www redirect) |
+| `bucket.go` | `s3.NewBucket`, `iam.NewUser` |
+| `static_egress.go` | `ec2.NewVpc`, `ec2.NewSubnet` (x2), `ec2.NewInternetGateway`, `ec2.NewRouteTable` (x2), `ec2.NewEip`, `ec2.NewNatGateway`, `ec2.NewSecurityGroup` |
+| `exec_ecs_task.go` | `iam.NewRole`, `ecs.NewTaskDefinition`, `ecs.NewCluster`, `ec2.NewSecurityGroup`, `iam.NewPolicy` |
+| `compute_proc.go` | Passes tags via `ecsTaskConfig` for both postgres and mysql init tasks |
+
+### Resources NOT tagged (AWS API does not support tags on these)
+- `secretsmanager.NewSecretVersion`
+- `ecr.NewLifecyclePolicy`
+- `efs.NewBackupPolicy`, `efs.NewMountTarget`
+- `iam.NewRolePolicyAttachment`
+- `appautoscaling.NewPolicy`
+- `s3.NewBucketPublicAccessBlock`, `s3.NewBucketOwnershipControls`, `s3.NewBucketPolicy`, `s3.NewBucketCorsConfigurationV2`
+- `cloudwatch.NewDashboard`, `cloudwatch.NewEventTarget`
+- `lambda.NewPermission`, `lambda.NewFunctionUrl`
+- `apigatewayv2.NewIntegration`, `apigatewayv2.NewRoute`
+- `sns.NewTopicSubscription`
+- `ec2.NewRouteTableAssociation`
+
+## Tags applied
+All tagged resources receive:
+- `simple-container.com/stack` — stack name
+- `simple-container.com/env` — environment name
+- `simple-container.com/parent-stack` — (optional) parent stack
+- `simple-container.com/client-stack` — (optional) client stack

--- a/.agents/implementation/2026-04-18/aws-tags-all-resources/pr-description.md
+++ b/.agents/implementation/2026-04-18/aws-tags-all-resources/pr-description.md
@@ -1,0 +1,58 @@
+# PR: Add consistent AWS tags to all resources
+
+## Title
+
+fix: add `simple-container.com/*` tags to all AWS resources
+
+## Body
+
+## Summary
+
+- Add standard `simple-container.com/stack` and `simple-container.com/env` tags to **every** AWS resource that supports tagging — previously only a subset of ECS Fargate resources were tagged
+- Thread `StackParams`-derived tags through all resource provisioning functions (secrets, ECR, Lambda, RDS, S3, static egress, ECS tasks, alerts)
+- Skip resources where the AWS API does not support tags (e.g. `RolePolicyAttachment`, `SecretVersion`, `BucketPolicy`, `LifecyclePolicy`)
+
+## Motivation
+
+Tags were missing on Secrets Manager secrets, ECR repositories, and many other AWS resources (RDS instances, Lambda functions, S3 buckets, VPC networking, etc.). This made it difficult to:
+- Track costs per stack/environment in AWS Cost Explorer
+- Filter resources in the AWS console
+- Implement automated governance and cleanup policies
+
+## Changes by file
+
+| File | What changed |
+|------|-------------|
+| `secrets.go` | Added `tags` param to `createSecret()`, applied to `SecretArgs.Tags` |
+| `ecr_repository.go` | Build tags from `deployParams`, applied to `RepositoryArgs.Tags` |
+| `ecs_fargate.go` | Merged stack tags into `FargateService.Tags` (alongside `deployTime`), pass tags to `attachAutoScalingPolicy` and `createEcsAlerts`, pass `StackParams` to static egress |
+| `aws_lambda.go` | Build tags from `deployParams`, applied to IAM role, IAM policy, LogGroup, Lambda function, API Gateway, Stage, EventRule; pass tags to `createSecret` and `provisionScheduleForLambda`; pass `StackParams` to static egress |
+| `alerts.go` | Added `tags` field to `alertCfg`, applied to IAM role, IAM policy, Lambda, MetricAlarm; added `tags` param to `createSNSTopicForAlerts`, applied to SNS Topic |
+| `rds_postgres.go` | Build tags, applied to SecurityGroup, SubnetGroup, RDS Instance |
+| `rds_mysql.go` | Build tags, applied to SecurityGroup, SubnetGroup, RDS Instance |
+| `static_website.go` | Added `Tags` to `StaticSiteInput`, applied to both S3 buckets |
+| `bucket.go` | Added `Tags` to `S3BucketInput`, applied to S3 bucket and IAM user |
+| `static_egress.go` | Build tags in single-zone `provisionVpcWithStaticEgress`, applied to VPC, subnets, IGW, route tables, EIP, NAT gateway, security group |
+| `exec_ecs_task.go` | Added `tags` to `ecsTaskConfig`, applied to IAM role, task definition, ECS cluster, security group, IAM policy |
+| `compute_proc.go` | Pass tags via `ecsTaskConfig` for postgres and mysql init tasks |
+
+## Resources intentionally NOT tagged (AWS does not support tags)
+
+`SecretVersion`, `LifecyclePolicy`, `BackupPolicy`, `MountTarget`, `RolePolicyAttachment`, `BucketPublicAccessBlock`, `BucketOwnershipControls`, `BucketPolicy`, `BucketCorsConfigurationV2`, `Dashboard`, `EventTarget`, `Permission`, `FunctionUrl`, `Integration`, `Route`, `TopicSubscription`, `RouteTableAssociation`, `autoscaling.Policy`
+
+## Test plan
+
+- [x] `go build ./...` passes
+- [x] `welder run fmt` passes (gofumpt + golangci-lint clean)
+- [ ] Deploy a stack to AWS and verify tags appear on:
+  - Secrets Manager secrets
+  - ECR repositories
+  - ECS Fargate service and cluster
+  - RDS instances
+  - Lambda functions
+  - S3 buckets
+  - VPC/subnet/IGW/NAT resources
+  - CloudWatch alarms and log groups
+  - SNS topics
+  - API Gateway
+- [ ] Verify existing deployments are not disrupted (tags are additive, no resource replacement expected)

--- a/pkg/clouds/pulumi/aws/alerts.go
+++ b/pkg/clouds/pulumi/aws/alerts.go
@@ -31,6 +31,7 @@ type alertCfg struct {
 	telegramConfig  *api.TelegramCfg
 	secretSuffix    string
 	opts            []sdk.ResourceOption
+	tags            sdk.StringMap
 	metricAlarmArgs cloudwatch.MetricAlarmArgs
 	helpersImage    *docker.Image
 	snsTopic        *sns.Topic
@@ -105,6 +106,7 @@ func pushHelpersImageToECR(ctx *sdk.Context, cfg helperCfg) (*docker.Image, erro
 func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 	// Create IAM Role for Lambda Function
 	lambdaExecutionRole, err := iam.NewRole(ctx, fmt.Sprintf("%s-execution-role", cfg.name), &iam.RoleArgs{
+		Tags: cfg.tags,
 		AssumeRolePolicy: pulumi.String(`{
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -134,6 +136,7 @@ func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 	extraPolicy, err := iam.NewPolicy(ctx, extraPolicyName, &iam.PolicyArgs{
 		Description: sdk.String("Allows reading secrets for alerts cloud helper"),
 		Name:        sdk.String(extraPolicyName),
+		Tags:        cfg.tags,
 		Policy: sdk.All().ApplyT(func(args []interface{}) (sdk.StringOutput, error) {
 			policy := map[string]interface{}{
 				"Version": "2012-10-17",
@@ -184,7 +187,7 @@ func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 	if cfg.discordConfig != nil {
 		if s, err := createSecret(ctx,
 			toSecretName(cfg.deployParams, "alert", cfg.name, api.ComputeEnv.DiscordWebhookUrl, cfg.secretSuffix),
-			api.ComputeEnv.DiscordWebhookUrl, cfg.discordConfig.WebhookUrl, cfg.opts...,
+			api.ComputeEnv.DiscordWebhookUrl, cfg.discordConfig.WebhookUrl, cfg.tags, cfg.opts...,
 		); err != nil {
 			return errors.Wrapf(err, "failed to create secret %q", api.ComputeEnv.DiscordWebhookUrl)
 		} else {
@@ -195,7 +198,7 @@ func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 	if cfg.slackConfig != nil {
 		if s, err := createSecret(ctx,
 			toSecretName(cfg.deployParams, "alert", cfg.name, api.ComputeEnv.SlackWebhookUrl, cfg.secretSuffix),
-			api.ComputeEnv.SlackWebhookUrl, cfg.slackConfig.WebhookUrl, cfg.opts...,
+			api.ComputeEnv.SlackWebhookUrl, cfg.slackConfig.WebhookUrl, cfg.tags, cfg.opts...,
 		); err != nil {
 			return errors.Wrapf(err, "failed to create secret %q", api.ComputeEnv.SlackWebhookUrl)
 		} else {
@@ -206,7 +209,7 @@ func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 	if cfg.telegramConfig != nil {
 		if s, err := createSecret(ctx,
 			toSecretName(cfg.deployParams, "alert", cfg.name, api.ComputeEnv.TelegramToken, cfg.secretSuffix),
-			api.ComputeEnv.TelegramToken, cfg.telegramConfig.Token, cfg.opts...,
+			api.ComputeEnv.TelegramToken, cfg.telegramConfig.Token, cfg.tags, cfg.opts...,
 		); err != nil {
 			return errors.Wrapf(err, "failed to create secret %q", api.ComputeEnv.TelegramToken)
 		} else {
@@ -220,6 +223,7 @@ func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 		Role:        lambdaExecutionRole.Arn,
 		ImageUri:    cfg.helpersImage.ImageName,
 		Timeout:     sdk.IntPtr(10),
+		Tags:        cfg.tags,
 		Environment: lambda.FunctionEnvironmentArgs{
 			Variables: envVariables,
 		},
@@ -239,6 +243,7 @@ func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 
 	cfg.metricAlarmArgs.AlarmActions = alarmActions
 	cfg.metricAlarmArgs.OkActions = okActions
+	cfg.metricAlarmArgs.Tags = cfg.tags
 	alarm, err := cloudwatch.NewMetricAlarm(ctx, fmt.Sprintf("%s-metric-alarm", cfg.name), &cfg.metricAlarmArgs, cfg.opts...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create metric alarm")
@@ -260,10 +265,11 @@ func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 	return nil
 }
 
-func createSNSTopicForAlerts(ctx *sdk.Context, topicName string, opts ...sdk.ResourceOption) (*sns.Topic, error) {
+func createSNSTopicForAlerts(ctx *sdk.Context, topicName string, tags sdk.StringMap, opts ...sdk.ResourceOption) (*sns.Topic, error) {
 	topic, err := sns.NewTopic(ctx, fmt.Sprintf("%s-sns-topic", topicName), &sns.TopicArgs{
 		Name:        sdk.String(topicName),
 		DisplayName: sdk.String(fmt.Sprintf("ALB Alerts Topic - %s", topicName)),
+		Tags:        tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create SNS topic")

--- a/pkg/clouds/pulumi/aws/aws_lambda.go
+++ b/pkg/clouds/pulumi/aws/aws_lambda.go
@@ -68,6 +68,8 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 		sdk.DependsOn(params.ComputeContext.Dependencies()),
 	}
 
+	tags := pApi.BuildTagsFromStackParams(deployParams).ToAWSTags()
+
 	image, err := buildAndPushDockerImageV2(ctx, stack, params, deployParams, dockerImage{
 		name:       stack.Name,
 		dockerfile: stackConfig.Image.Dockerfile,
@@ -91,6 +93,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 	lambdaExecutionRoleName := fmt.Sprintf("%s-execution-role", stack.Name)
 	params.Log.Info(ctx.Context(), "configure lambda execution role %q for %q in %q...", lambdaExecutionRoleName, stack.Name, deployParams.Environment)
 	lambdaExecutionRole, err := iam.NewRole(ctx, lambdaExecutionRoleName, &iam.RoleArgs{
+		Tags: tags,
 		AssumeRolePolicy: sdk.String(`{
 			"Version": "2012-10-17",
 			"Statement": [{
@@ -138,6 +141,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 	extraPolicy, err := iam.NewPolicy(ctx, extraPolicyName, &iam.PolicyArgs{
 		Description: sdk.String(fmt.Sprintf("Allows reading secrets in lambda for stack %s", stack.Name)),
 		Name:        sdk.String(extraPolicyName),
+		Tags:        tags,
 		Policy: sdk.All().ApplyT(func(args []interface{}) (sdk.StringOutput, error) {
 			policy := map[string]interface{}{
 				"Version": "2012-10-17",
@@ -173,14 +177,14 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 	// SECRETS
 	var secrets []*CreatedSecret
 	ctxSecrets, err := util.MapErr(secretEnvVariables, func(v pApi.ComputeEnvVariable, _ int) (*CreatedSecret, error) {
-		return createSecret(ctx, toSecretName(deployParams, v.ResourceType, v.ResourceName, v.Name, stackConfig.Version), v.Name, v.Value, opts...)
+		return createSecret(ctx, toSecretName(deployParams, v.ResourceType, v.ResourceName, v.Name, stackConfig.Version), v.Name, v.Value, tags, opts...)
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create context secrets for stack %q in %q", stack.Name, deployParams.Environment)
 	}
 	secrets = append(secrets, ctxSecrets...)
 	for name, value := range stackConfig.Secrets {
-		s, err := createSecret(ctx, toSecretName(deployParams, "values", "", name, stackConfig.Version), name, value, opts...)
+		s, err := createSecret(ctx, toSecretName(deployParams, "values", "", name, stackConfig.Version), name, value, tags, opts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create secret")
 		}
@@ -232,6 +236,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 	params.Log.Info(ctx.Context(), "configure cloudwatch access log group for %q in %q...", stack.Name, deployParams.Environment)
 	logGroup, err := cloudwatch.NewLogGroup(ctx, accessLogGroupName, &cloudwatch.LogGroupArgs{
 		Name: sdk.String(accessLogGroupName),
+		Tags: tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create access logs group for api gateway")
@@ -242,6 +247,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 		PackageType: sdk.String("Image"),
 		Role:        lambdaExecutionRole.Arn,
 		ImageUri:    image.image.ImageName,
+		Tags:        tags,
 		MemorySize:  sdk.IntPtr(lambdaSizeMb),
 		Timeout:     sdk.IntPtr(lo.If(stackConfig.Timeout != nil, lo.FromPtr(stackConfig.Timeout)).Else(10)),
 		EphemeralStorage: lambda.FunctionEphemeralStorageArgs{
@@ -263,6 +269,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 			Provider:      params.Provider,
 			AccountConfig: crInput.AccountConfig,
 			SecurityGroup: cloudExtras.SecurityGroup,
+			StackParams:   deployParams,
 		}, opts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to provision static egress IP for lambda")
@@ -291,6 +298,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 			Name: sdk.String(apiGwName),
 			// RouteKey:     sdk.String("$default"), // TODO: figure out whether this will work
 			ProtocolType: sdk.String("HTTP"),
+			Tags:         tags,
 		}, opts...)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create API gateway for lambda")
@@ -342,6 +350,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 		_, err = apigatewayv2.NewStage(ctx, fmt.Sprintf("%s-http-stage", stack.Name), &apigatewayv2.StageArgs{
 			ApiId: apiGw.ID(),
 			Name:  sdk.String(lo.If(stackConfig.BasePath == "", "api").Else(stackConfig.BasePath)),
+			Tags:  tags,
 			Description: route.ID().ApplyT(func(routeId string) string {
 				return fmt.Sprintf("stage for route %s", routeId)
 			}).(sdk.StringOutput),
@@ -426,7 +435,7 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 		return nil, errors.Errorf("schedules must have unique names")
 	}
 	for _, schedule := range schedules {
-		if err := provisionScheduleForLambda(ctx, stack, params, lambdaName, lambdaFunc, schedule, opts); err != nil {
+		if err := provisionScheduleForLambda(ctx, stack, params, lambdaName, lambdaFunc, schedule, tags, opts); err != nil {
 			return nil, errors.Wrapf(err, "failed to provision schedule %q for lambda", schedule.Name)
 		}
 	}
@@ -467,7 +476,7 @@ func provisionDNSForLambda(ctx *sdk.Context, stack api.Stack, params pApi.Provis
 }
 
 func provisionScheduleForLambda(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionParams,
-	lambdaName string, lambdaFunc *lambda.Function, schedule aws.LambdaSchedule, opts []sdk.ResourceOption,
+	lambdaName string, lambdaFunc *lambda.Function, schedule aws.LambdaSchedule, tags sdk.StringMap, opts []sdk.ResourceOption,
 ) error {
 	if schedule.Expression == "" {
 		return errors.Errorf("cron expression must be specified for schedule %q", schedule.Name)
@@ -481,6 +490,7 @@ func provisionScheduleForLambda(ctx *sdk.Context, stack api.Stack, params pApi.P
 	scheduleName := fmt.Sprintf("%s%s-schedule", lambdaName, lo.If(schedule.Name != "", fmt.Sprintf("-%s", schedule.Name)).Else(""))
 	scheduleRule, err := cloudwatch.NewEventRule(ctx, scheduleName, &cloudwatch.EventRuleArgs{
 		ScheduleExpression: sdk.String(expression),
+		Tags:               tags,
 	}, opts...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create aws lambda schedule")

--- a/pkg/clouds/pulumi/aws/bucket.go
+++ b/pkg/clouds/pulumi/aws/bucket.go
@@ -25,6 +25,7 @@ type S3BucketInput struct {
 	StaticSite     *api.StaticSiteConfig
 	Stack          api.Stack
 	AllowOnlyHttps bool
+	Tags           sdk.StringMap
 }
 
 type PrivateBucketOutput struct {
@@ -51,6 +52,10 @@ func S3Bucket(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 	params.Log.Info(ctx.Context(), "configure private s3 bucket %q for %q in %q",
 		bucketName, input.StackParams.StackName, input.StackParams.Environment)
 
+	var tags sdk.StringMap
+	if input.StackParams != nil {
+		tags = pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags()
+	}
 	res, err := createS3Bucket(ctx, S3BucketInput{
 		Name:           bucketName,
 		Provider:       params.Provider,
@@ -59,6 +64,7 @@ func S3Bucket(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 		Log:            params.Log,
 		StaticSite:     bucketCfg.StaticSiteConfig,
 		AllowOnlyHttps: bucketCfg.AllowOnlyHttps,
+		Tags:           tags,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision private bucket")
@@ -87,6 +93,7 @@ func createS3Bucket(ctx *sdk.Context, input S3BucketInput) (*PrivateBucketOutput
 		}
 	}
 
+	bucketArgs.Tags = input.Tags
 	bucket, err := s3.NewBucket(ctx, input.Name, bucketArgs, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision bucket %q", input.Name)
@@ -154,6 +161,7 @@ func createS3Bucket(ctx *sdk.Context, input S3BucketInput) (*PrivateBucketOutput
 	input.Log.Info(ctx.Context(), "configure user having write access to s3 bucket...")
 	user, err := iam.NewUser(ctx, fmt.Sprintf("%s-user", input.Name), &iam.UserArgs{
 		ForceDestroy: sdk.BoolPtr(true),
+		Tags:         input.Tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision user for bucket %q", input.Name)

--- a/pkg/clouds/pulumi/aws/compute_proc.go
+++ b/pkg/clouds/pulumi/aws/compute_proc.go
@@ -148,6 +148,7 @@ func RdsPostgresComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Re
 				name:    fmt.Sprintf("%s-pg-init", stack.Name),
 				account: postgresCfg.AccountConfig,
 				params:  params,
+				tags:    pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags(),
 				image:   "alpine:latest",
 				command: command,
 				env: map[string]string{
@@ -298,6 +299,7 @@ func RdsMysqlComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Resou
 				name:    fmt.Sprintf("%s-mysql-init", stack.Name),
 				account: dbCfg.AccountConfig,
 				params:  params,
+				tags:    pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags(),
 				image:   "alpine:latest",
 				command: command,
 				env: map[string]string{

--- a/pkg/clouds/pulumi/aws/ecr_repository.go
+++ b/pkg/clouds/pulumi/aws/ecr_repository.go
@@ -40,9 +40,11 @@ func createEcrRegistry(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionP
 	res := EcsFargateRepository{}
 	ecrRepoName := fmt.Sprintf("%s-%s", stack.Name, repoName)
 	params.Log.Info(ctx.Context(), "configure ECR repository %q for stack %q in %q...", ecrRepoName, stack.Name, deployParams.Environment)
+	tags := pApi.BuildTagsFromStackParams(deployParams).ToAWSTags()
 	ecrRepo, err := ecr.NewRepository(ctx, ecrRepoName, &ecr.RepositoryArgs{
 		ForceDelete: sdk.BoolPtr(true),
 		Name:        sdk.String(awsResName(ecrRepoName, "ecr")),
+		Tags:        tags,
 	}, sdk.Provider(params.Provider), sdk.DependsOn(params.ComputeContext.Dependencies()))
 	if err != nil {
 		return res, errors.Wrapf(err, "failed to provision ECR repository %q for stack %q in %q", ecrRepoName, stack.Name, deployParams.Environment)

--- a/pkg/clouds/pulumi/aws/ecs_fargate.go
+++ b/pkg/clouds/pulumi/aws/ecs_fargate.go
@@ -147,14 +147,14 @@ func createEcsFargateCluster(ctx *sdk.Context, stack api.Stack, params pApi.Prov
 
 	var secrets []*CreatedSecret
 	ctxSecrets, err := util.MapErr(contextSecretEnvVariables, func(v pApi.ComputeEnvVariable, _ int) (*CreatedSecret, error) {
-		return createSecret(ctx, toSecretName(deployParams, v.ResourceType, v.ResourceName, v.Name, crInput.Config.Version), v.Name, v.Value, opts...)
+		return createSecret(ctx, toSecretName(deployParams, v.ResourceType, v.ResourceName, v.Name, crInput.Config.Version), v.Name, v.Value, tags, opts...)
 	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to create context secrets for stack %q in %q", stack.Name, deployParams.Environment)
 	}
 	secrets = append(secrets, ctxSecrets...)
 	for name, value := range crInput.Secrets {
-		s, err := createSecret(ctx, toSecretName(deployParams, "values", "", name, crInput.Config.Version), name, value, opts...)
+		s, err := createSecret(ctx, toSecretName(deployParams, "values", "", name, crInput.Config.Version), name, value, tags, opts...)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create secret")
 		}
@@ -175,6 +175,7 @@ func createEcsFargateCluster(ctx *sdk.Context, stack api.Stack, params pApi.Prov
 			Params:        params,
 			Provider:      params.Provider,
 			AccountConfig: crInput.AccountConfig,
+			StackParams:   deployParams,
 		}, opts...)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create static egress IP for ECS cluster %q", ecsSimpleClusterName)
@@ -650,9 +651,15 @@ func createEcsFargateCluster(ctx *sdk.Context, stack api.Stack, params pApi.Prov
 		},
 		ForceNewDeployment:   sdk.BoolPtr(true),
 		EnableExecuteCommand: sdk.BoolPtr(true),
-		Tags: sdk.StringMap{
-			"deployTime": sdk.String(time.Now().Format(time.RFC3339)),
-		},
+		Tags: func() sdk.StringMap {
+			serviceTags := sdk.StringMap{
+				"deployTime": sdk.String(time.Now().Format(time.RFC3339)),
+			}
+			for k, v := range tags {
+				serviceTags[k] = v
+			}
+			return serviceTags
+		}(),
 		NetworkConfiguration: ecsV6.ServiceNetworkConfigurationArgs{
 			AssignPublicIp: sdk.BoolPtr(true),
 			SecurityGroups: sdk.StringArray{
@@ -708,7 +715,7 @@ func createEcsFargateCluster(ctx *sdk.Context, stack api.Stack, params pApi.Prov
 	}
 
 	if crInput.Scale.Policies != nil {
-		err = attachAutoScalingPolicy(ctx, stack, params, crInput, cluster, service)
+		err = attachAutoScalingPolicy(ctx, stack, params, crInput, cluster, service, tags)
 		if err != nil {
 			return errors.Wrapf(err, "failed to attach auto scaling policy to service %q/%q", ecsSimpleClusterName, fmt.Sprintf("%s-service", ecsSimpleClusterName))
 		}
@@ -724,6 +731,7 @@ func createEcsFargateCluster(ctx *sdk.Context, stack api.Stack, params pApi.Prov
 
 func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack api.Stack, crInput *aws.EcsFargateInput, deployParams api.StackParams, params pApi.ProvisionParams, loadBalancer *lb.ApplicationLoadBalancer, opts ...sdk.ResourceOption) error {
 	alerts := crInput.Alerts
+	tags := taggingUtil.BuildTagsFromStackParams(deployParams).ToAWSTags()
 
 	helpersImage, err := pushHelpersImageToECR(ctx, helperCfg{
 		imageName:       "sc-cloud-helpers",
@@ -749,6 +757,7 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 			helpersImage:   helpersImage,
 			secretSuffix:   crInput.Config.Version,
 			opts:           opts,
+			tags:           tags,
 			metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 				ComparisonOperator: sdk.String("GreaterThanThreshold"),
 				EvaluationPeriods:  sdk.Int(1),
@@ -779,6 +788,7 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 			secretSuffix:   crInput.Config.Version,
 			helpersImage:   helpersImage,
 			opts:           opts,
+			tags:           tags,
 			metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 				ComparisonOperator: sdk.String("GreaterThanThreshold"),
 				EvaluationPeriods:  sdk.Int(1),
@@ -831,7 +841,7 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 		var snsTopic *sns.Topic
 		if alerts.Email != nil && len(alerts.Email.Addresses) > 0 {
 			snsTopicName := fmt.Sprintf("%s-%s-alb-alerts", stack.Name, deployParams.Environment)
-			topic, err := createSNSTopicForAlerts(ctx, snsTopicName, opts...)
+			topic, err := createSNSTopicForAlerts(ctx, snsTopicName, tags, opts...)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create SNS topic for ALB alerts")
 			}
@@ -855,6 +865,7 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 				helpersImage:   helpersImage,
 				snsTopic:       snsTopic,
 				opts:           opts,
+				tags:           tags,
 				metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 					ComparisonOperator: sdk.String("GreaterThanThreshold"),
 					EvaluationPeriods:  sdk.Int(2),
@@ -887,6 +898,7 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 				helpersImage:   helpersImage,
 				snsTopic:       snsTopic,
 				opts:           opts,
+				tags:           tags,
 				metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 					ComparisonOperator: sdk.String("GreaterThanOrEqualToThreshold"),
 					EvaluationPeriods:  sdk.Int(2),
@@ -920,6 +932,7 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 				helpersImage:   helpersImage,
 				snsTopic:       snsTopic,
 				opts:           opts,
+				tags:           tags,
 				metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 					ComparisonOperator: sdk.String("GreaterThanThreshold"),
 					EvaluationPeriods:  sdk.Int(3),
@@ -986,13 +999,14 @@ func buildAndPushECSFargateImages(ctx *sdk.Context, stack api.Stack, params pApi
 	return nil
 }
 
-func attachAutoScalingPolicy(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionParams, crInput *aws.EcsFargateInput, cluster *ecsV6.Cluster, service *ecs.FargateService) error {
+func attachAutoScalingPolicy(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionParams, crInput *aws.EcsFargateInput, cluster *ecsV6.Cluster, service *ecs.FargateService, tags sdk.StringMap) error {
 	scalePolicyName := fmt.Sprintf("%s-ecs-scale", stack.Name)
 
 	// Register the ECS service as a scalable target
 	scalableTarget, err := appautoscaling.NewTarget(ctx, scalePolicyName, &appautoscaling.TargetArgs{
 		MaxCapacity: sdk.Int(crInput.Scale.Max),
 		MinCapacity: sdk.Int(crInput.Scale.Min),
+		Tags:        tags,
 		ResourceId: sdk.All(cluster.Name, service.Service.Name()).ApplyT(func(args []any) (string, error) {
 			clusterName := args[0].(string)
 			svcName := args[1].(string)

--- a/pkg/clouds/pulumi/aws/exec_ecs_task.go
+++ b/pkg/clouds/pulumi/aws/exec_ecs_task.go
@@ -22,6 +22,7 @@ type ecsTaskConfig struct {
 	name    string
 	account aws.AccountConfig
 	params  pApi.ProvisionParams
+	tags    sdk.StringMap
 	image   string
 	command []string
 	env     map[string]string
@@ -46,6 +47,7 @@ func execEcsTask(ctx *sdk.Context, config ecsTaskConfig) error {
 	execRoleName := fmt.Sprintf("%s-exec-role", name)
 	taskExecRole, err := iam.NewRole(ctx, execRoleName, &iam.RoleArgs{
 		Name: sdk.String(execRoleName),
+		Tags: config.tags,
 		AssumeRolePolicy: sdk.String(`{
                 "Version": "2012-10-17",
                 "Statement": [{
@@ -93,6 +95,7 @@ func execEcsTask(ctx *sdk.Context, config ecsTaskConfig) error {
 	taskDef, err := ecs.NewTaskDefinition(ctx, taskDefName, &ecs.TaskDefinitionArgs{
 		Family:      sdk.String(name),
 		NetworkMode: sdk.String("awsvpc"),
+		Tags:        config.tags,
 		RequiresCompatibilities: sdk.StringArray{
 			sdk.String("FARGATE"),
 		},
@@ -125,7 +128,9 @@ func execEcsTask(ctx *sdk.Context, config ecsTaskConfig) error {
 
 	ecsClusterName := fmt.Sprintf("%s-cluster", name)
 	params.Log.Info(ctx.Context(), "configure ECS cluster for %q", name)
-	cluster, err := ecs.NewCluster(ctx, ecsClusterName, &ecs.ClusterArgs{}, opts...)
+	cluster, err := ecs.NewCluster(ctx, ecsClusterName, &ecs.ClusterArgs{
+		Tags: config.tags,
+	}, opts...)
 	if err != nil {
 		return err
 	}
@@ -149,6 +154,7 @@ func execEcsTask(ctx *sdk.Context, config ecsTaskConfig) error {
 	params.Log.Info(ctx.Context(), "configure security group for %q", name)
 	securityGroup, err := ec2.NewSecurityGroup(ctx, securityGroupName, &ec2.SecurityGroupArgs{
 		VpcId: vpc.ID(),
+		Tags:  config.tags,
 		Egress: ec2.SecurityGroupEgressArray{
 			&ec2.SecurityGroupEgressArgs{
 				Description:    sdk.String("Allow ALL outbound TCP traffic"),
@@ -180,6 +186,7 @@ func execEcsTask(ctx *sdk.Context, config ecsTaskConfig) error {
 	ccPolicy, err := iam.NewPolicy(ctx, ccPolicyName, &iam.PolicyArgs{
 		Description: sdk.String("Allows CreateControlChannel operation and reading secrets"),
 		Name:        sdk.String(ccPolicyName),
+		Tags:        config.tags,
 		Policy: sdk.All().ApplyT(func(args []interface{}) (sdk.StringOutput, error) {
 			policy := map[string]interface{}{
 				"Version": "2012-10-17",

--- a/pkg/clouds/pulumi/aws/rds_mysql.go
+++ b/pkg/clouds/pulumi/aws/rds_mysql.go
@@ -38,6 +38,8 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 		sdk.Provider(params.Provider),
 	}
 
+	tags := pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags()
+
 	subnets, err := createDefaultSubnetsInRegionV5(ctx, mysqlCfg.AccountConfig, input.StackParams.Environment, params)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get or create default subnets in region")
@@ -76,6 +78,7 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 	rdsSg, err := ec2.NewSecurityGroup(ctx, securityGroupName, &ec2.SecurityGroupArgs{
 		Name:  sdk.String(securityGroupName),
 		VpcId: vpc.ID(),
+		Tags:  tags,
 		Ingress: &ec2.SecurityGroupIngressArray{
 			&sgIngressArgs,
 		},
@@ -90,6 +93,7 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 	subnetGroup, err := rds.NewSubnetGroup(ctx, subnetGroupName, &rds.SubnetGroupArgs{
 		Name:      sdk.String(subnetGroupName),
 		SubnetIds: subnets.Ids(),
+		Tags:      tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create subnet group for rds postgres cluster")
@@ -114,6 +118,7 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 		Username:          sdk.String(lo.If(dbConfig.Username != "", dbConfig.Username).Else("root")),
 		Password:          sdk.String(lo.If(dbConfig.Password != "", dbConfig.Password).Else("root")),
 		SkipFinalSnapshot: sdk.Bool(true),
+		Tags:              tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create rds mysql instance")

--- a/pkg/clouds/pulumi/aws/rds_postgres.go
+++ b/pkg/clouds/pulumi/aws/rds_postgres.go
@@ -38,6 +38,8 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 		sdk.Provider(params.Provider),
 	}
 
+	tags := pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags()
+
 	subnets, err := createDefaultSubnetsInRegionV5(ctx, postgresCfg.AccountConfig, input.StackParams.Environment, params)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get or create default subnets in region")
@@ -63,6 +65,7 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 	rdsSg, err := ec2.NewSecurityGroup(ctx, securityGroupName, &ec2.SecurityGroupArgs{
 		Name:  sdk.String(securityGroupName),
 		VpcId: vpc.ID(),
+		Tags:  tags,
 		Ingress: &ec2.SecurityGroupIngressArray{
 			&ec2.SecurityGroupIngressArgs{
 				Protocol:       sdk.String("tcp"),
@@ -83,6 +86,7 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 	subnetGroup, err := rds.NewSubnetGroup(ctx, subnetGroupName, &rds.SubnetGroupArgs{
 		Name:      sdk.String(subnetGroupName),
 		SubnetIds: subnets.Ids(),
+		Tags:      tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create subnet group for rds postgres cluster")
@@ -107,6 +111,7 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 		Username:          sdk.String(lo.If(postgresCfg.Username != "", postgresCfg.Username).Else("postgres")),
 		Password:          sdk.String(lo.If(postgresCfg.Password != "", postgresCfg.Password).Else("postgres")),
 		SkipFinalSnapshot: sdk.Bool(true),
+		Tags:              tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create rds postgres instance")

--- a/pkg/clouds/pulumi/aws/secrets.go
+++ b/pkg/clouds/pulumi/aws/secrets.go
@@ -18,10 +18,11 @@ func toSecretName(params api.StackParams, resType, resName, varName, suffix stri
 	return fmt.Sprintf("%s--%s--%s--%s--%s%s", params.StackName, params.Environment, resType, resName, varName, suffix)
 }
 
-func createSecret(ctx *sdk.Context, secretName, envVar, value string, opts ...sdk.ResourceOption) (*CreatedSecret, error) {
+func createSecret(ctx *sdk.Context, secretName, envVar, value string, tags sdk.StringMap, opts ...sdk.ResourceOption) (*CreatedSecret, error) {
 	secret, err := secretsmanager.NewSecret(ctx, secretName, &secretsmanager.SecretArgs{
 		Name:                 sdk.String(secretName),
 		RecoveryWindowInDays: sdk.IntPtr(0),
+		Tags:                 tags,
 	}, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/clouds/pulumi/aws/static_egress.go
+++ b/pkg/clouds/pulumi/aws/static_egress.go
@@ -288,10 +288,14 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 
 	params := input.Params
 
+	// Build unified tags using the tagging utility
+	tags := taggingUtil.BuildTagsFromStackParams(input.StackParams).ToAWSTags()
+
 	// Create a VPC
 	params.Log.Info(ctx.Context(), "configure VPC for %s...", resName)
 	vpc, err := ec2.NewVpc(ctx, vpcName, &ec2.VpcArgs{
 		CidrBlock: sdk.String(vpcCidrBlock),
+		Tags:      tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create vpc for %q", resName)
@@ -304,6 +308,7 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 		VpcId:            vpc.ID(),
 		CidrBlock:        sdk.String(publicSubnetCidrBlock),
 		AvailabilityZone: sdk.String(zoneName),
+		Tags:             tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision public subnet for %q", resName)
@@ -315,6 +320,7 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 		VpcId:            vpc.ID(),
 		CidrBlock:        sdk.String(privateSubnetCidrBlock),
 		AvailabilityZone: sdk.String(zoneName),
+		Tags:             tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision private subnet for %q", resName)
@@ -324,6 +330,7 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 	igwName := fmt.Sprintf("%s-igw", resName)
 	igw, err := ec2.NewInternetGateway(ctx, igwName, &ec2.InternetGatewayArgs{
 		VpcId: vpc.ID(),
+		Tags:  tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision internet gateway for %q", resName)
@@ -334,6 +341,7 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 	routeTableName := fmt.Sprintf("%s-route-table", resName)
 	routeTable, err := ec2.NewRouteTable(ctx, routeTableName, &ec2.RouteTableArgs{
 		VpcId: vpc.ID(),
+		Tags:  tags,
 		Routes: ec2.RouteTableRouteArray{
 			&ec2.RouteTableRouteArgs{
 				CidrBlock: sdk.String("0.0.0.0/0"),
@@ -359,7 +367,9 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 	// Create an Elastic IP for the NAT Gateway
 	params.Log.Info(ctx.Context(), "configure elastic IP address for %s...", resName)
 	eipName := fmt.Sprintf("%s-eip", resName)
-	eip, err := ec2.NewEip(ctx, eipName, nil, opts...)
+	eip, err := ec2.NewEip(ctx, eipName, &ec2.EipArgs{
+		Tags: tags,
+	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision elastic IP for %q", resName)
 	}
@@ -370,6 +380,7 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 	natGateway, err := ec2.NewNatGateway(ctx, natGwName, &ec2.NatGatewayArgs{
 		SubnetId:     publicSubnet.ID(),
 		AllocationId: eip.ID(),
+		Tags:         tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision elastic IP for %q", resName)
@@ -380,6 +391,7 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 	privateRouteTableName := fmt.Sprintf("%s-private-route-table", resName)
 	privateRouteTable, err := ec2.NewRouteTable(ctx, privateRouteTableName, &ec2.RouteTableArgs{
 		VpcId: vpc.ID(),
+		Tags:  tags,
 		Routes: ec2.RouteTableRouteArray{
 			&ec2.RouteTableRouteArgs{
 				CidrBlock:    sdk.String("0.0.0.0/0"),
@@ -431,6 +443,7 @@ func provisionVpcWithStaticEgress(ctx *sdk.Context, resName string, input *Stati
 
 	securityGroup, err := ec2.NewSecurityGroup(ctx, securityGroupName, &ec2.SecurityGroupArgs{
 		VpcId: vpc.ID(),
+		Tags:  tags,
 		Ingress: ec2.SecurityGroupIngressArray{
 			&ingressRule,
 		},

--- a/pkg/clouds/pulumi/aws/static_website.go
+++ b/pkg/clouds/pulumi/aws/static_website.go
@@ -36,6 +36,10 @@ func StaticWebsite(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, p
 	if !path.IsAbs(bundleDir) {
 		bundleDir = path.Join(cfg.StackDir, cfg.BundleDir)
 	}
+	var tags sdk.StringMap
+	if input.StackParams != nil {
+		tags = pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags()
+	}
 	ref, err := provisionStaticSite(&StaticSiteInput{
 		ServiceName:        stack.Name,
 		Provider:           params.Provider,
@@ -48,6 +52,7 @@ func StaticWebsite(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, p
 		ProvisionWwwDomain: cfg.Site.ProvisionWwwDomain,
 		Account:            cfg.AccountConfig,
 		Log:                params.Log,
+		Tags:               tags,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to provision static website for stack %q", stack.Name)
@@ -68,6 +73,7 @@ type StaticSiteInput struct {
 	ProvisionWwwDomain bool
 	Account            aws.AccountConfig
 	Log                logger.Logger
+	Tags               sdk.StringMap
 }
 
 type StaticSiteOutput struct {
@@ -90,6 +96,7 @@ func provisionStaticSite(input *StaticSiteInput) (*StaticSiteOutput, error) {
 	mainBucket, err := s3.NewBucket(ctx, bucketName, &s3.BucketArgs{
 		Bucket:       sdk.String(bucketName),
 		ForceDestroy: sdk.Bool(true),
+		Tags:         input.Tags,
 		Website: &s3.BucketWebsiteArgs{
 			IndexDocument: sdk.String(input.IndexDocument),
 			ErrorDocument: sdk.String(input.ErrorDocument),
@@ -197,6 +204,7 @@ func provisionStaticSite(input *StaticSiteInput) (*StaticSiteOutput, error) {
 		wwwBucket, err = s3.NewBucket(ctx, fmt.Sprintf("%s-www-redirect", input.ServiceName), &s3.BucketArgs{
 			Bucket:       sdk.String(wwwDomain),
 			ForceDestroy: sdk.Bool(true),
+			Tags:         input.Tags,
 			Website: s3.BucketWebsiteArgs{
 				RedirectAllRequestsTo: sdk.StringPtr(input.Domain),
 			},

--- a/pkg/clouds/pulumi/docker/build_and_push_test.go
+++ b/pkg/clouds/pulumi/docker/build_and_push_test.go
@@ -325,15 +325,15 @@ func TestEngagementRouting(t *testing.T) {
 		{"pr2209", "", "PR-2209"},
 		{"pr1", "", "PR-1"},
 		{"pr99999", "", "PR-99999"},
-		{"staging", "", "Source-Scan"},      // default for non-PR
-		{"test", "", "Source-Scan"},         // default for non-PR
-		{"prod", "", "Source-Scan"},         // must NOT match "pr" -- "prod" starts with "pr"
-		{"production", "", "Source-Scan"},   // must NOT match
-		{"preview", "", "Source-Scan"},      // must NOT match
-		{"pre-release", "", "Source-Scan"},  // must NOT match
-		{"", "", "Source-Scan"},             // empty env = non-PR
+		{"staging", "", "Source-Scan"},          // default for non-PR
+		{"test", "", "Source-Scan"},             // default for non-PR
+		{"prod", "", "Source-Scan"},             // must NOT match "pr" -- "prod" starts with "pr"
+		{"production", "", "Source-Scan"},       // must NOT match
+		{"preview", "", "Source-Scan"},          // must NOT match
+		{"pre-release", "", "Source-Scan"},      // must NOT match
+		{"", "", "Source-Scan"},                 // empty env = non-PR
 		{"staging", "Custom-Eng", "Custom-Eng"}, // configured name preserved for non-PR
-		{"pr123", "Custom-Eng", "PR-123"},        // PR override takes precedence
+		{"pr123", "Custom-Eng", "PR-123"},       // PR override takes precedence
 	}
 	for _, tt := range tests {
 		t.Run(tt.env+"_"+tt.configuredName, func(t *testing.T) {

--- a/pkg/clouds/pulumi/kubernetes/caddy.go
+++ b/pkg/clouds/pulumi/kubernetes/caddy.go
@@ -243,8 +243,8 @@ func DeployCaddyService(ctx *sdk.Context, caddy CaddyDeployment, input api.Resou
 	}
 
 	sc, err := DeploySimpleContainer(ctx, Args{
-		ServiceType:           serviceType, // to provision external IP
-		ExternalTrafficPolicy: lo.FromPtr(caddy.CaddyConfig).ExternalTrafficPolicy,
+		ServiceType:                   serviceType, // to provision external IP
+		ExternalTrafficPolicy:         lo.FromPtr(caddy.CaddyConfig).ExternalTrafficPolicy,
 		ProvisionIngress:              caddy.ProvisionIngress,
 		UseSSL:                        useSSL,
 		Namespace:                     namespace,

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -105,24 +105,24 @@ type SimpleContainerArgs struct {
 	KubeProvider           sdk.ProviderResource
 
 	// optional properties
-	PodDisruption     *k8s.DisruptionBudget        `json:"podDisruption" yaml:"podDisruption"`
-	LbConfig          *api.SimpleContainerLBConfig `json:"lbConfig" yaml:"lbConfig"`
-	SecretEnvs        map[string]string            `json:"secretEnvs" yaml:"secretEnvs"`
-	Annotations       map[string]string            `json:"annotations" yaml:"annotations"`
-	NodeSelector      map[string]string            `json:"nodeSelector" yaml:"nodeSelector"`
-	Affinity          *k8s.AffinityRules           `json:"affinity" yaml:"affinity"`
-	PriorityClassName *string                      `json:"priorityClassName" yaml:"priorityClassName"` // Kubernetes PriorityClass for pod scheduling and preemption
-	IngressContainer  *k8s.CloudRunContainer       `json:"ingressContainer" yaml:"ingressContainer"`
+	PodDisruption         *k8s.DisruptionBudget        `json:"podDisruption" yaml:"podDisruption"`
+	LbConfig              *api.SimpleContainerLBConfig `json:"lbConfig" yaml:"lbConfig"`
+	SecretEnvs            map[string]string            `json:"secretEnvs" yaml:"secretEnvs"`
+	Annotations           map[string]string            `json:"annotations" yaml:"annotations"`
+	NodeSelector          map[string]string            `json:"nodeSelector" yaml:"nodeSelector"`
+	Affinity              *k8s.AffinityRules           `json:"affinity" yaml:"affinity"`
+	PriorityClassName     *string                      `json:"priorityClassName" yaml:"priorityClassName"` // Kubernetes PriorityClass for pod scheduling and preemption
+	IngressContainer      *k8s.CloudRunContainer       `json:"ingressContainer" yaml:"ingressContainer"`
 	ServiceType           *string                      `json:"serviceType" yaml:"serviceType"`
 	ExternalTrafficPolicy *string                      `json:"externalTrafficPolicy" yaml:"externalTrafficPolicy"`
-	ProvisionIngress  bool                         `json:"provisionIngress" yaml:"provisionIngress"`
-	Headers           *k8s.Headers                 `json:"headers" yaml:"headers"`
-	Volumes           []k8s.SimpleTextVolume       `json:"volumes" yaml:"volumes"`
-	SecretVolumes     []k8s.SimpleTextVolume       `json:"secretVolumes" yaml:"secretVolumes"`
-	PersistentVolumes []k8s.PersistentVolume       `json:"persistentVolumes" yaml:"persistentVolumes"`
-	EphemeralVolumes  []k8s.GenericEphemeralVolume `json:"ephemeralVolumes" yaml:"ephemeralVolumes"` // Generic ephemeral volumes for large temp storage
-	VPA               *k8s.VPAConfig               `json:"vpa" yaml:"vpa"`
-	Scale             *k8s.Scale                   `json:"scale" yaml:"scale"`
+	ProvisionIngress      bool                         `json:"provisionIngress" yaml:"provisionIngress"`
+	Headers               *k8s.Headers                 `json:"headers" yaml:"headers"`
+	Volumes               []k8s.SimpleTextVolume       `json:"volumes" yaml:"volumes"`
+	SecretVolumes         []k8s.SimpleTextVolume       `json:"secretVolumes" yaml:"secretVolumes"`
+	PersistentVolumes     []k8s.PersistentVolume       `json:"persistentVolumes" yaml:"persistentVolumes"`
+	EphemeralVolumes      []k8s.GenericEphemeralVolume `json:"ephemeralVolumes" yaml:"ephemeralVolumes"` // Generic ephemeral volumes for large temp storage
+	VPA                   *k8s.VPAConfig               `json:"vpa" yaml:"vpa"`
+	Scale                 *k8s.Scale                   `json:"scale" yaml:"scale"`
 
 	Log logger.Logger
 	// ...

--- a/pkg/security/executor_test.go
+++ b/pkg/security/executor_test.go
@@ -333,11 +333,11 @@ func TestValidateImageRef(t *testing.T) {
 		"europe-north1-docker.pkg.dev/project/repo:tag",
 	}
 	invalid := []string{
-		"",                          // empty
+		"",                             // empty
 		"--image-that-looks-like-flag", // starts with -
-		"image;rm -rf /",            // shell metacharacter
-		"image$(whoami)",            // command substitution
-		"image`id`",                 // backtick injection
+		"image;rm -rf /",               // shell metacharacter
+		"image$(whoami)",               // command substitution
+		"image`id`",                    // backtick injection
 	}
 
 	for _, ref := range valid {

--- a/pkg/security/signing/keybased.go
+++ b/pkg/security/signing/keybased.go
@@ -74,7 +74,6 @@ func (s *KeyBasedSigner) Sign(ctx context.Context, imageRef string) (*SignResult
 	// Execute cosign sign command
 	args := []string{"sign", "--key", keyPath, imageRef}
 	stdout, stderr, err := tools.ExecCommand(ctx, "cosign", args, env, s.Timeout)
-
 	if err != nil {
 		return nil, fmt.Errorf("cosign sign failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}


### PR DESCRIPTION
## Title

fix: add `simple-container.com/*` tags to all AWS resources

## Body

## Summary

- Add standard `simple-container.com/stack` and `simple-container.com/env` tags to **every** AWS resource that supports tagging ? previously only a subset of ECS Fargate resources were tagged
- Thread `StackParams`-derived tags through all resource provisioning functions (secrets, ECR, Lambda, RDS, S3, static egress, ECS tasks, alerts)
- Skip resources where the AWS API does not support tags (e.g. `RolePolicyAttachment`, `SecretVersion`, `BucketPolicy`, `LifecyclePolicy`)

## Motivation

Tags were missing on Secrets Manager secrets, ECR repositories, and many other AWS resources (RDS instances, Lambda functions, S3 buckets, VPC networking, etc.). This made it difficult to:
- Track costs per stack/environment in AWS Cost Explorer
- Filter resources in the AWS console
- Implement automated governance and cleanup policies

## Changes by file

| File                | What changed                                                                                                                                                                                                                 |
|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `secrets.go`        | Added `tags` param to `createSecret()`, applied to `SecretArgs.Tags`                                                                                                                                                         |
| `ecr_repository.go` | Build tags from `deployParams`, applied to `RepositoryArgs.Tags`                                                                                                                                                             |
| `ecs_fargate.go`    | Merged stack tags into `FargateService.Tags` (alongside `deployTime`), pass tags to `attachAutoScalingPolicy` and `createEcsAlerts`, pass `StackParams` to static egress                                                     |
| `aws_lambda.go`     | Build tags from `deployParams`, applied to IAM role, IAM policy, LogGroup, Lambda function, API Gateway, Stage, EventRule; pass tags to `createSecret` and `provisionScheduleForLambda`; pass `StackParams` to static egress |
| `alerts.go`         | Added `tags` field to `alertCfg`, applied to IAM role, IAM policy, Lambda, MetricAlarm; added `tags` param to `createSNSTopicForAlerts`, applied to SNS Topic                                                                |
| `rds_postgres.go`   | Build tags, applied to SecurityGroup, SubnetGroup, RDS Instance                                                                                                                                                              |
| `rds_mysql.go`      | Build tags, applied to SecurityGroup, SubnetGroup, RDS Instance                                                                                                                                                              |
| `static_website.go` | Added `Tags` to `StaticSiteInput`, applied to both S3 buckets                                                                                                                                                                |
| `bucket.go`         | Added `Tags` to `S3BucketInput`, applied to S3 bucket and IAM user                                                                                                                                                           |
| `static_egress.go`  | Build tags in single-zone `provisionVpcWithStaticEgress`, applied to VPC, subnets, IGW, route tables, EIP, NAT gateway, security group                                                                                       |
| `exec_ecs_task.go`  | Added `tags` to `ecsTaskConfig`, applied to IAM role, task definition, ECS cluster, security group, IAM policy                                                                                                               |
| `compute_proc.go`   | Pass tags via `ecsTaskConfig` for postgres and mysql init tasks                                                                                                                                                              |

## Resources intentionally NOT tagged (AWS does not support tags)

`SecretVersion`, `LifecyclePolicy`, `BackupPolicy`, `MountTarget`, `RolePolicyAttachment`, `BucketPublicAccessBlock`, `BucketOwnershipControls`, `BucketPolicy`, `BucketCorsConfigurationV2`, `Dashboard`, `EventTarget`, `Permission`, `FunctionUrl`, `Integration`, `Route`, `TopicSubscription`, `RouteTableAssociation`, `autoscaling.Policy`

## Test plan

- [x] `go build ./...` passes
- [x] `welder run fmt` passes (gofumpt + golangci-lint clean)
- [ ] Deploy a stack to AWS and verify tags appear on:
  - Secrets Manager secrets
  - ECR repositories
  - ECS Fargate service and cluster
  - RDS instances
  - Lambda functions
  - S3 buckets
  - VPC/subnet/IGW/NAT resources
  - CloudWatch alarms and log groups
  - SNS topics
  - API Gateway
- [ ] Verify existing deployments are not disrupted (tags are additive, no resource replacement expected)
