### PR TITLE
fix(docker): add sc symlink to github-actions-staging image

### DIFF
--- a/github-actions-staging.Dockerfile
+++ b/github-actions-staging.Dockerfile
@@ -90,6 +90,9 @@ COPY ./bin/github-actions ./github-actions
 RUN chmod +x ./github-actions && \
     # Strip debug symbols if not already done (reduces binary size)
     strip ./github-actions 2>/dev/null || true && \
+    # Make 'sc' available in PATH for Pulumi local.Command subprocesses
+    # (security pipeline runs: sc image sign, sc image scan, sc sbom generate, etc.)
+    ln -s /root/github-actions /usr/local/bin/sc && \
     # Remove build tools no longer needed
     apk del upx binutils && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
@@ -97,7 +100,8 @@ RUN chmod +x ./github-actions && \
 # Verify installations work (but remove verification output to reduce layer size)
 RUN pulumi version > /dev/null && \
     gcloud version > /dev/null && \
-    gcloud components list --filter="name:gke-gcloud-auth-plugin" --format="value(name)" | grep -q gke-gcloud-auth-plugin
+    gcloud components list --filter="name:gke-gcloud-auth-plugin" --format="value(name)" | grep -q gke-gcloud-auth-plugin && \
+    test -L /usr/local/bin/sc && test -x /usr/local/bin/sc
 
 # Set the entrypoint to use the github-actions binary with absolute path
 # GitHub Actions runner overrides WORKDIR with --workdir /github/workspace


### PR DESCRIPTION
## Problem

After #221 merged main into staging, `build-staging.yml` rebuilt the `simplecontainer/github-actions:staging` Docker image, but PAY-SPACE deploys are **still** failing with the same error:

```
/bin/sh: sc: not found
error: exit status 127: running "... 'sc' 'image' 'scan' ..."
error: exit status 127: running "... 'sc' 'sbom' 'generate' ..."
error: exit status 127: running "... 'sc' 'image' 'sign' ..."
```

## Root cause

The **production** Dockerfile `github-actions.Dockerfile` has this line:

```dockerfile
ln -s /root/github-actions /usr/local/bin/sc
```

…and verifies it with `test -L /usr/local/bin/sc && test -x /usr/local/bin/sc`.

The **staging** Dockerfile `github-actions-staging.Dockerfile` (which `build-staging.yml` builds from) **does not** — so `:staging` images ship the `github-actions` binary at `/root/github-actions` but no `sc` in PATH. When the security pipeline shells out to `sc image sign/scan`, `sc sbom generate`, `sc provenance attach` from Pulumi's `local.Command`, the shell can't find `sc`.

The two Dockerfiles drifted at some point — the production one was updated when the security pipeline landed, the staging one wasn't.

## Fix

Add the `sc` symlink and the build-time verification to `github-actions-staging.Dockerfile`, mirroring the production file exactly. This keeps the two in sync going forward.

## Test plan

- [ ] Merge triggers `build-staging.yml` → new `:staging` image pushed
- [ ] Re-run a failing PAY-SPACE deploy (e.g. https://github.com/PAY-SPACE/neural-api/actions) — security pipeline all green
- [ ] Verify in image: `docker run --rm --entrypoint sh simplecontainer/github-actions:staging -c 'which sc && sc --help | head -3'`