### PR TITLE
fix: trivy cache isolation + 0.70.0 bump + multi-image report heading

### DIFF
--- a/pkg/clouds/pulumi/docker/security_report.go
+++ b/pkg/clouds/pulumi/docker/security_report.go
@@ -19,10 +19,14 @@ func buildSecurityReportScript(imageRef, imageName string, security *api.Securit
 
 	// Build the report script. Uses jq for JSON parsing if available, falls back to grep.
 	// The script is self-contained — no SC CLI dependency.
+	//
+	// The heading includes imageName so stacks with multiple images (e.g. web+worker)
+	// produce visibly-distinct report sections in $GITHUB_STEP_SUMMARY — otherwise
+	// identical-looking headers make them appear as duplicates.
 	var sb strings.Builder
 	sb.WriteString("set +e\n") // Don't exit on error — report is best-effort
 	sb.WriteString("REPORT=''\n")
-	sb.WriteString("REPORT=\"${REPORT}## Security Pipeline Summary\\n\\n\"\n")
+	sb.WriteString(fmt.Sprintf("REPORT=\"${REPORT}## Security Pipeline Summary — %s\\n\\n\"\n", shellEscape(imageName)))
 	sb.WriteString(fmt.Sprintf("REPORT=\"${REPORT}**Image:** \\`%s\\`\\n\\n\"\n", shellEscape(imageRef)))
 	sb.WriteString("REPORT=\"${REPORT}| Step | Status | Details |\\n\"\n")
 	sb.WriteString("REPORT=\"${REPORT}| --- | --- | --- |\\n\"\n")

--- a/pkg/security/scan/trivy.go
+++ b/pkg/security/scan/trivy.go
@@ -14,7 +14,7 @@ import (
 
 // DefaultTrivyVersion is the pinned install version. Bump here to upgrade cluster-wide,
 // or override per-scan via SC config (ScanToolConfig.Version) or SC_TRIVY_VERSION env var.
-const DefaultTrivyVersion = "0.69.3"
+const DefaultTrivyVersion = "0.70.0"
 
 // TrivyScanner implements Scanner interface using Trivy
 type TrivyScanner struct {
@@ -46,6 +46,7 @@ func (t *TrivyScanner) Scan(ctx context.Context, image string) (*ScanResult, err
 	if err != nil {
 		return nil, err
 	}
+	defer cleanupTrivyCacheDir(cacheDir)
 
 	// Scan from the local Docker daemon (docker-daemon: prefix).
 	// The image must already be present locally — callers are expected to scan
@@ -303,16 +304,39 @@ func parseTrivyVersion(output string) (string, error) {
 	return "", fmt.Errorf("failed to parse trivy version from: %s", output)
 }
 
+// ensureTrivyCacheDir returns a per-invocation Trivy cache directory under the
+// user cache root. Using a unique subdirectory per scan eliminates the cache
+// lock contention that Trivy exhibits when the same directory is shared across
+// concurrent processes or reused with stale locks from crashed runs. The cost
+// is re-downloading the vulnerability DB per scan (~100MB, a few seconds),
+// which is acceptable in CI and avoids the "cache may be in use by another
+// process: timeout" failure mode documented at
+// https://trivy.dev/docs/guide/references/troubleshooting#database-and-cache-lock-errors
+//
+// Caller is responsible for cleanup (see cleanupTrivyCacheDir).
 func ensureTrivyCacheDir() (string, error) {
 	cacheRoot, err := os.UserCacheDir()
 	if err != nil {
 		cacheRoot = os.TempDir()
 	}
-	cacheDir := filepath.Join(cacheRoot, "trivy")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		return "", fmt.Errorf("create trivy cache directory: %w", err)
+	parent := filepath.Join(cacheRoot, "trivy")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", fmt.Errorf("create trivy cache parent directory: %w", err)
+	}
+	cacheDir, err := os.MkdirTemp(parent, "scan-*")
+	if err != nil {
+		return "", fmt.Errorf("create trivy cache scratch directory: %w", err)
 	}
 	return cacheDir, nil
+}
+
+// cleanupTrivyCacheDir removes a per-invocation cache directory created by
+// ensureTrivyCacheDir. Best-effort: errors are ignored.
+func cleanupTrivyCacheDir(cacheDir string) {
+	if cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(cacheDir)
 }
 
 func trivyDBPresent(cacheDir string) bool {

--- a/pkg/security/scan/trivy_test.go
+++ b/pkg/security/scan/trivy_test.go
@@ -218,7 +218,24 @@ func TestEnsureTrivyCacheDir(t *testing.T) {
 
 	cacheDir, err := ensureTrivyCacheDir()
 	Expect(err).ToNot(HaveOccurred())
-	Expect(cacheDir).To(Equal(filepath.Join(cacheRoot, "trivy")))
+	defer cleanupTrivyCacheDir(cacheDir)
+
+	// Per-invocation cache dir lives under <cacheRoot>/trivy/scan-* so
+	// concurrent scans can't clobber each other's lock files.
+	parent := filepath.Join(cacheRoot, "trivy")
+	Expect(cacheDir).To(HavePrefix(parent+string(filepath.Separator)+"scan-"))
+	Expect(cacheDir).To(BeADirectory())
+
+	// Second call returns a different directory (thread-safety property).
+	cacheDir2, err := ensureTrivyCacheDir()
+	Expect(err).ToNot(HaveOccurred())
+	defer cleanupTrivyCacheDir(cacheDir2)
+	Expect(cacheDir2).ToNot(Equal(cacheDir))
+
+	// Cleanup removes the directory.
+	cleanupTrivyCacheDir(cacheDir)
+	_, statErr := os.Stat(cacheDir)
+	Expect(os.IsNotExist(statErr)).To(BeTrue())
 }
 
 func TestTrivyDBPresenceHelpers(t *testing.T) {


### PR DESCRIPTION
Three small fixes surfaced from the first PAY-SPACE prod rollout:

## 1. Trivy cache lock timeout

**Symptom** (pay_space_wallet, crypto-tools runs):
```
ERROR Failed to acquire cache or database lock, see https://trivy.dev/docs/...
FATAL image scan error: unable to initialize fs cache: cache may be in use by another process: timeout
```

**Cause**: Trivy uses file locks on its cache directory to synchronize DB access. When the cache persists across runs (Blacksmith persistent cache) or a prior trivy crashed, stale locks cause the next scan to time out waiting for them.

**Fix**: Use a per-scan ephemeral cache directory via `os.MkdirTemp("<userCache>/trivy", "scan-*")`, with `defer cleanup` in `Scan()`. Eliminates lock contention entirely. Cost: re-downloads the ~100MB vulnerability DB per scan (a few seconds), acceptable for CI. Codex flagged the earlier "just delete the lock files" approach as unsafe under real concurrency — this version sidesteps the race entirely.

Updated `TestEnsureTrivyCacheDir` to assert the per-invocation `scan-*` suffix and that two calls return different directories.

## 2. Trivy version bump 0.69.3 → 0.70.0

Scan logs from the 0.69.3 runs surface the upstream notice:
```
📣 Notices:
  - Version 0.70.0 of Trivy is now available, current version is 0.69.3
```

## 3. Multi-image report heading disambiguation

**Symptom** (PAY-SPACE/pay_space_wallet): the step summary showed what looked like the same Security Pipeline Summary report twice.

**Cause**: The `pay_space_wallet` stack builds two images (`web` + `worker`), so the pipeline creates one `security-report-<image>` local.Command per image. Each one writes `## Security Pipeline Summary` to `$GITHUB_STEP_SUMMARY`. Both reports have identical scan counts (same codebase, different entrypoints), so two distinct reports look like a duplicate.

**Fix**: Suffix the heading with the image name:
```
## Security Pipeline Summary — web
**Image:** `...--web@sha256:...`

## Security Pipeline Summary — worker
**Image:** `...--worker@sha256:...`
```

## Verification

- `go build ./...` clean
- `go test ./pkg/security/scan/...` green (incl. updated cache-dir tests)
- `go test ./pkg/clouds/pulumi/docker/...` green