### PR TITLE
fix(docker): add sc symlink to main's github-actions-staging Dockerfile (root cause of repeated :staging regressions)

### DIFF
--- a/github-actions-staging.Dockerfile
+++ b/github-actions-staging.Dockerfile
@@ -90,6 +90,9 @@ COPY ./bin/github-actions ./github-actions
 RUN chmod +x ./github-actions && \
     # Strip debug symbols if not already done (reduces binary size)
     strip ./github-actions 2>/dev/null || true && \
+    # Make 'sc' available in PATH for Pulumi local.Command subprocesses
+    # (security pipeline runs: sc image sign, sc image scan, sc sbom generate, etc.)
+    ln -s /root/github-actions /usr/local/bin/sc && \
     # Remove build tools no longer needed
     apk del upx binutils && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
@@ -97,7 +100,8 @@ RUN chmod +x ./github-actions && \
 # Verify installations work (but remove verification output to reduce layer size)
 RUN pulumi version > /dev/null && \
     gcloud version > /dev/null && \
-    gcloud components list --filter="name:gke-gcloud-auth-plugin" --format="value(name)" | grep -q gke-gcloud-auth-plugin
+    gcloud components list --filter="name:gke-gcloud-auth-plugin" --format="value(name)" | grep -q gke-gcloud-auth-plugin && \
+    test -L /usr/local/bin/sc && test -x /usr/local/bin/sc
 
 # Set the entrypoint to use the github-actions binary with absolute path
 # GitHub Actions runner overrides WORKDIR with --workdir /github/workspace


### PR DESCRIPTION
## Symptom

After #221 merged main→staging and #222 added the sc symlink to staging's Dockerfile, PAY-SPACE deploys briefly worked. Then #223 merged to main and immediately after, PAY-SPACE/crypto-tools started failing again with:

```
/bin/sh: sc: not found
error: exit status 127: running "... 'sc' 'sbom' 'generate' ..."
```

## Root cause

**Two separate workflows build and push `simplecontainer/github-actions:staging`:**

| Workflow | Trigger | Dockerfile (from which branch) |
|---|---|---|
| `build-staging.yml` | push to `staging` | `github-actions-staging.Dockerfile` on `staging` branch |
| `push.yaml` | push to `main` | `github-actions-staging.Dockerfile` on `main` branch |

PR #222 only fixed the Dockerfile on **staging**. The main branch copy never got the `ln -s /root/github-actions /usr/local/bin/sc` line. So every time anything merges to main, `push.yaml` runs, builds without the symlink, and **overwrites** the good `:staging` image that was pushed by `build-staging.yml`.

Verified by `docker pull simplecontainer/github-actions:staging && docker run --rm --entrypoint sh .../github-actions:staging -c 'ls -la /usr/local/bin/sc'`:
```
ls: /usr/local/bin/sc: No such file or directory
```

Image created timestamp matches `push.yaml` run at 19:47 (after PR #223 merged at 19:47), not `build-staging.yml` run at 17:53 (after #222).

## Fix

Apply the identical symlink + verify lines to main's copy of `github-actions-staging.Dockerfile`. Both workflows now produce an image with `sc` in PATH. This keeps the two Dockerfiles in sync going forward.

## Long-term

Two workflows publishing the same tag from two branches is fragile — whichever runs last wins. Consider consolidating: either `build-staging.yml` is the sole publisher of `:staging`, or `push.yaml` drops the staging tag. Out of scope for this PR.

## Test plan

- [ ] Merge triggers `push.yaml` → new `:staging` image pushed
- [ ] `docker pull simplecontainer/github-actions:staging && docker run --rm --entrypoint sh ... -c 'sc --help | head -1'` succeeds
- [ ] Re-run PAY-SPACE/crypto-tools deploy — passes end-to-end