### PR TITLE
fix(ci): publish unversioned sc tarball to dist.simple-container.com

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -152,7 +152,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sc-${{ matrix.os }}-${{ matrix.arch }}
-          path: .sc/stacks/dist/bundle/sc-${{ matrix.os }}-${{ matrix.arch }}-*.tar.gz
+          # Match both versioned (sc-os-arch-vX.Y.Z.tar.gz) AND unversioned (sc-os-arch.tar.gz).
+          # The old glob `sc-os-arch-*.tar.gz` required a hyphen before `*`, so it only matched
+          # the versioned tarball — the unversioned "latest" pointer was silently dropped from
+          # artifacts and therefore never re-uploaded to dist.simple-container.com. Result:
+          # sc.sh (which downloads the unversioned tarball when SIMPLE_CONTAINER_VERSION is
+          # empty) served stale v2026.3.6 for ~4 weeks after PR #186 merged.
+          path: .sc/stacks/dist/bundle/sc-${{ matrix.os }}-${{ matrix.arch }}*.tar.gz
           retention-days: 1
 
   build-binaries:


### PR DESCRIPTION
## Summary

Fix artifact upload glob in `push.yaml` so the unversioned `sc-{linux,darwin}-*.tar.gz` tarballs are actually uploaded to `dist.simple-container.com`. They have been stale since PR #186 merged on 2026-03-24.

## Root cause

In the `build-platforms` matrix job, two tarballs are created per platform ([`push.yaml:149-150`](.github/workflows/push.yaml#L149-L150)):

```bash
tar -czf .sc/stacks/dist/bundle/sc-${GOOS}-${GOARCH}.tar.gz ...        # unversioned
cp .../sc-${GOOS}-${GOARCH}.tar.gz .../sc-${GOOS}-${GOARCH}-v${VERSION}.tar.gz  # versioned
```

But the `upload-artifact` glob had a hyphen before the wildcard:

```yaml
path: .sc/stacks/dist/bundle/sc-${{ matrix.os }}-${{ matrix.arch }}-*.tar.gz
#                                                                  ^
#                                                      only matches versioned
```

So `sc-linux-amd64.tar.gz` (no hyphen before `.tar.gz`) was dropped from the artifact. `docker-finalize` never saw it, never placed it in the bundle dir, `sc deploy -s dist -e prod` never uploaded it to GCS.

## Impact

`https://dist.simple-container.com/sc-linux-amd64.tar.gz` has `Last-Modified: 2026-03-23 21:14:38 GMT` and contains v2026.3.6. That's the last successful upload — the day before PR #186 merged.

`sc.sh` downloads this unversioned tarball when `$SIMPLE_CONTAINER_VERSION` is empty. Every downstream CI that uses the standard install command:

```bash
bash <(curl -Ls "https://dist.simple-container.com/sc.sh")
```

…has been running **SC v2026.3.6 for 4+ weeks**, silently missing every feature merged since — including PR #104 (container security pipeline: Grype+Trivy scan, Cosign keyless signing, CycloneDX SBOM, SLSA v1.0 provenance, DefectDojo reporting).

Concretely: Integrail EW repos (`everworker`, `baas`, `code-executor`, `storage-service`) all added the `security:` block to their `client.yaml` and merged rollout PRs last week. Zero scans/signatures/SBOMs have been produced because the deployed SC binary predates the security code.

## Fix

Drop the hyphen before the wildcard so the glob matches both versioned and unversioned tarballs:

```diff
- path: .sc/stacks/dist/bundle/sc-${{ matrix.os }}-${{ matrix.arch }}-*.tar.gz
+ path: .sc/stacks/dist/bundle/sc-${{ matrix.os }}-${{ matrix.arch }}*.tar.gz
```

Added a comment explaining the subtlety so it's not re-introduced.

## Verification

After merge, the next push to main will run `push.yaml`. The `docker-finalize` → `sc deploy -s dist -e prod` step will now upload the unversioned tarballs. Check with:

```bash
curl -sIL https://dist.simple-container.com/sc-linux-amd64.tar.gz | grep -i last-modified
# Should show today's date, not 2026-03-23.

curl -sL https://dist.simple-container.com/sc-linux-amd64.tar.gz | tar -xzO sc | head -c 256 | strings | grep -i version
# Should show the new calver version, not 2026.3.6.
```

## Out of scope

The architectural question of whether `sc.sh` should default to "latest" by downloading an unversioned tarball vs. resolving the newest versioned artifact via a manifest is real but separate. This PR is the minimal fix to unbreak the existing contract.