### PR TITLE
fix(caddy): patch parent-env Caddy deployment for sub-env client stacks

### DIFF
--- a/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
+++ b/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
@@ -218,10 +218,13 @@ func GkeAutopilotStack(ctx *sdk.Context, stack api.Stack, input api.ResourceInpu
 			return nil, errors.Wrapf(err, "failed to unmarshal caddy config from parent stack: JSON was %q", caddyConfigJson)
 		}
 
-		// Attempt to patch caddy deployment annotations (non-critical - skip if it fails)
-		// Use deployment name override if specified, otherwise generate using single-dash convention
-		// to match the actual Caddy deployment naming (e.g., "caddy-staging" not "caddy--staging")
-		defaultDeploymentName := kubernetes.GenerateCaddyDeploymentName(input.StackParams.Environment)
+		// Attempt to patch caddy deployment annotations (non-critical - skip if it fails).
+		// Use deployment name override if specified, otherwise resolve via the parent-aware helper
+		// so sub-env client stacks (parentEnv != stackEnv) target the parent's caddy-<parentEnv>
+		// deployment instead of a non-existent caddy-<stackEnv>.
+		// input.StackParams.ParentEnv is reliably populated for this code path by the
+		// custom-stack fix-up at the top of this function.
+		defaultDeploymentName := kubernetes.CaddyDeploymentNameForChild(input.StackParams.Environment, input.StackParams.ParentEnv)
 		deploymentName := lo.If(caddyCfg.DeploymentName != nil, lo.FromPtr(caddyCfg.DeploymentName)).Else(defaultDeploymentName)
 		namespace := lo.If(caddyCfg.Namespace != nil, lo.FromPtr(caddyCfg.Namespace)).Else("caddy")
 

--- a/pkg/clouds/pulumi/kubernetes/kube_run.go
+++ b/pkg/clouds/pulumi/kubernetes/kube_run.go
@@ -195,10 +195,14 @@ func KubeRun(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params 
 	}
 
 	if caddyConfig != nil {
-		// Attempt to patch caddy deployment annotations (non-critical - skip if it fails)
-		// Use deployment name override if specified, otherwise generate using single-dash convention
-		// to match the actual Caddy deployment naming (e.g., "caddy-staging" not "caddy--staging")
-		defaultCaddyName := GenerateCaddyDeploymentName(input.StackParams.Environment)
+		// Attempt to patch caddy deployment annotations (non-critical - skip if it fails).
+		// Use deployment name override if specified, otherwise resolve via the parent-aware helper
+		// so sub-env client stacks (parentEnv != stackEnv) target the parent's caddy-<parentEnv>
+		// deployment instead of a non-existent caddy-<stackEnv>.
+		// parentEnv lives on params.ParentStack — input.StackParams.ParentEnv is empty for client
+		// stack deploys (matches the pattern in aws/compute_proc.go and gcp/compute_proc.go).
+		parentEnv := lo.FromPtr(params.ParentStack).ParentEnv
+		defaultCaddyName := CaddyDeploymentNameForChild(input.StackParams.Environment, parentEnv)
 		caddyServiceName := lo.If(caddyConfig.DeploymentName != nil, lo.FromPtr(caddyConfig.DeploymentName)).Else(defaultCaddyName)
 
 		// Cast params.Provider to Kubernetes provider for patch operations

--- a/pkg/clouds/pulumi/kubernetes/naming.go
+++ b/pkg/clouds/pulumi/kubernetes/naming.go
@@ -81,3 +81,21 @@ func GenerateCaddyDeploymentName(stackEnv string) string {
 	}
 	return "caddy"
 }
+
+// CaddyDeploymentNameForChild returns the Caddy deployment name a *child* (client) stack
+// must target when patching annotations to trigger a Caddy rolling restart.
+//
+// Caddy is provisioned by the parent infra stack, so its deployment name is keyed on
+// parentEnv (e.g. caddy-production). For sub-env client stacks where parentEnv differs
+// from stackEnv (e.g. parentEnv=production, stackEnv=gl-pay), passing stackEnv would
+// produce caddy-gl-pay — which doesn't exist — and the patch would fail silently.
+// For single-env stacks (parentEnv empty or equal to stackEnv) this falls back to stackEnv.
+//
+// Note: this is the call site asymmetric to GenerateCaddyDeploymentName, which is used
+// from the parent stack's own provisioning where Environment is the correct input.
+func CaddyDeploymentNameForChild(stackEnv, parentEnv string) string {
+	if isCustomStack(stackEnv, parentEnv) {
+		return GenerateCaddyDeploymentName(parentEnv)
+	}
+	return GenerateCaddyDeploymentName(stackEnv)
+}

--- a/pkg/clouds/pulumi/kubernetes/naming_test.go
+++ b/pkg/clouds/pulumi/kubernetes/naming_test.go
@@ -434,6 +434,56 @@ func TestNamespaceIsStackName(t *testing.T) {
 	}
 }
 
+func TestCaddyDeploymentNameForChild(t *testing.T) {
+	tests := []struct {
+		name      string
+		stackEnv  string
+		parentEnv string
+		expected  string
+	}{
+		{
+			name:      "single-env stack falls back to stackEnv",
+			stackEnv:  "production",
+			parentEnv: "",
+			expected:  "caddy-production",
+		},
+		{
+			name:      "self-reference falls back to stackEnv",
+			stackEnv:  "staging",
+			parentEnv: "staging",
+			expected:  "caddy-staging",
+		},
+		{
+			name:      "sub-env stack targets parent's caddy",
+			stackEnv:  "gl-pay",
+			parentEnv: "production",
+			expected:  "caddy-production",
+		},
+		{
+			name:      "preview env targets parent staging caddy",
+			stackEnv:  "staging-preview",
+			parentEnv: "staging",
+			expected:  "caddy-staging",
+		},
+		{
+			name:      "empty stackEnv with parentEnv still resolves to parent",
+			stackEnv:  "",
+			parentEnv: "production",
+			expected:  "caddy-production",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CaddyDeploymentNameForChild(tt.stackEnv, tt.parentEnv)
+			if result != tt.expected {
+				t.Errorf("CaddyDeploymentNameForChild(%q, %q) = %v, expected %v",
+					tt.stackEnv, tt.parentEnv, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestIsCustomStack(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Problem

When a sub-env client stack (`parentEnv: production`, `env: gl-pay`/`payhey`/etc.) is deployed, the Caddy patch that triggers a rolling restart targets `caddy-<stackEnv>` — a deployment that doesn't exist. Caddy is owned by the parent infra stack and named `caddy-<parentEnv>` (e.g. `caddy-production`).

The patch fails silently (logged at `Warn`, deploy reports ✅ green), so the `simple-container.com/caddy-update-hash` annotation never gets bumped, Caddy pods never roll, the `generate-caddyfile` init container never re-runs, and **the new domain serves Caddy's default page instead of the backend.**

This is the root cause behind a recurring "default page after deploying new SC stack" gotcha at PAY-SPACE — the documented manual workaround was `kubectl rollout restart deployment/caddy-<parentEnv> -n caddy`.

### Symptom from a real deploy

```
❌ PATCH ERROR: failed to patch deployment pod-template annotations
   caddy/caddy-caddy-test: deployments.apps "caddy-caddy-test" not found
```

```
$ curl https://caddy-test.pay.space/
<title>Default page</title>
```

## Fix

Two patch call sites depending on which template handles the deploy:

- `pkg/clouds/pulumi/kubernetes/kube_run.go:201` — generic `kubernetes-cloudrun` path
- `pkg/clouds/pulumi/gcp/gke_autopilot_stack.go:224` — GKE Autopilot path (this is the one PAY-SPACE actually hits)

Both routed through a new exported helper:

```go
// CaddyDeploymentNameForChild — resolves to caddy-<parentEnv> for sub-env
// client stacks, falls back to caddy-<stackEnv> for single-env stacks.
func CaddyDeploymentNameForChild(stackEnv, parentEnv string) string
```

ParentEnv source differs per call site (matches existing patterns in `aws/compute_proc.go:51` and `gcp/compute_proc.go:243-247`):

- `kube_run.go` reads `params.ParentStack.ParentEnv` directly (`input.StackParams.ParentEnv` is empty for client deploys until compute_proc mutates it).
- `gke_autopilot_stack.go` reads `input.StackParams.ParentEnv` — reliably populated by the custom-stack fix-up at the top of that function (lines 49-54).

## Test plan
- [x] `go test ./pkg/clouds/pulumi/kubernetes/... ./pkg/clouds/pulumi/gcp/...` passes
- [x] 5-case unit test for the helper covering single-env, self-reference, sub-env, preview env, and empty-stackEnv cases
- [x] **End-to-end validation on PAY-SPACE production:** built preview from this branch, pinned wallet's deploy workflow, deployed a fresh `caddy-test` sub-env stack (parentEnv: production, env: caddy-test). Deploy log shows `✅ Caddy deployment patched: caddy/caddy-production` (not `caddy/caddy-caddy-test`), Caddy auto-rolls, `caddy-test.pay.space` serves the wallet without manual kubectl rollout. Stack then destroyed.