### PR TITLE
fix(k8s): isolate custom-stack namespaces and retain shared ns on destroy

### DIFF
--- a/docs/docs/concepts/kubernetes-namespaces.md
+++ b/docs/docs/concepts/kubernetes-namespaces.md
@@ -1,0 +1,101 @@
+# Kubernetes Namespace Layout
+
+Simple Container's Kubernetes deployments automatically derive the target namespace from the stack and environment, so siblings never collide in the same physical namespace. This page documents the naming rule and what to expect on deploy, redeploy, and destroy.
+
+## The rule
+
+Given a stack definition with `stackName` (the stack directory name) and `stackEnv` (the environment under `stacks:` in `client.yaml`), and an optional `parentEnv` (when the stack inherits from a different parent environment):
+
+| Stack shape | `parentEnv` | `stackEnv` | Resulting namespace |
+|---|---|---|---|
+| **Standard stack** — same env as parent | (unset) or equals `stackEnv` | `<env>` | `<stackName>` |
+| **Custom stack** — sub-env under a different parent env | set, differs from `stackEnv` | `<env>` | `<stackName>-<stackEnv>` |
+
+The namespace name is sanitized to RFC 1123 (lowercase, `_` → `-`, ≤63 chars with FNV-1a truncation hash if needed), so callers can pass arbitrary stack names without worrying about Kubernetes naming constraints.
+
+## Worked example
+
+Given this `client.yaml` deploying to a parent `infrastructure/myproject` with environments `staging` and `production`:
+
+```yaml
+# .sc/stacks/myapp/client.yaml
+stacks:
+  staging:
+    type: cloud-compose
+    parent: infrastructure/myproject
+    # parentEnv defaults to "staging" → standard stack
+    config: { ... }
+
+  production:
+    type: cloud-compose
+    parent: infrastructure/myproject
+    parentEnv: production          # standard stack (parentEnv == stackEnv)
+    config: { ... }
+
+  tenant-a:
+    type: cloud-compose
+    parent: infrastructure/myproject
+    parentEnv: production          # custom stack (parentEnv != stackEnv)
+    config: { ... }
+
+  tenant-b:
+    type: cloud-compose
+    parent: infrastructure/myproject
+    parentEnv: production          # custom stack (parentEnv != stackEnv)
+    config: { ... }
+```
+
+Deployment names → namespaces:
+
+| `sc deploy -s myapp -e ...` | Resulting namespace |
+|---|---|
+| `staging` | `myapp` (in the staging cluster) |
+| `production` | `myapp` (in the production cluster) |
+| `tenant-a` | `myapp-tenant-a` (in the production cluster) |
+| `tenant-b` | `myapp-tenant-b` (in the production cluster) |
+
+`tenant-a` and `tenant-b` are isolated from each other and from `production`, even though they all run under the same parent infrastructure.
+
+## Why this matters
+
+**Destroy safety.** Each custom stack owns its own namespace, so `sc destroy -s myapp -e tenant-a` only removes resources in `myapp-tenant-a`. The parent stack and other siblings are untouched.
+
+**Tenant isolation.** Custom stacks no longer share a namespace, so namespace-scoped RBAC, NetworkPolicy, ResourceQuota, and Secret access are isolated by default.
+
+**Caddy routing follows automatically.** Simple Container's Caddy ingress watches `--all-namespaces` and reads the `simple-container.com/caddyfile-entry` annotation off each Service. New namespaces are picked up on Caddy's next reconcile with no manual config.
+
+## Migrating an existing custom stack
+
+If you have a custom stack that was deployed before Simple Container introduced the per-stackEnv namespace, the next `sc deploy` (or `pulumi up`) will move it to its dedicated namespace. The flow is automatic:
+
+1. Pulumi sees the namespace `metadata.name` change — schedules a Replace.
+2. The new namespace is created (e.g. `myapp-tenant-a`).
+3. The old shared namespace is **retained** (via `RetainOnDelete`) — the parent stack and any siblings still on the old namespace keep running.
+4. All namespace-scoped resources owned by this stack (Deployment, Service, Secret, ConfigMap, HPA, VPA, ImagePullSecret, Jobs, and CloudSQL/init secrets) are Replaced in the new namespace.
+5. Caddy auto-rebuilds its Caddyfile from the moved Service annotation; brief gap during cutover.
+
+You can dry-run the migration with `sc deploy -P -s <stack> -e <env>` to inspect the diff before applying.
+
+### After the last sibling migrates
+
+If you eventually destroy every stack that ever referenced the old shared namespace, the namespace itself lingers (because of `RetainOnDelete`). Clean it up by hand once you've verified nothing depends on it:
+
+```sh
+kubectl get all -n <old-shared-namespace>      # should be empty
+kubectl delete namespace <old-shared-namespace>
+```
+
+### PersistentVolumeClaim caveat
+
+If your custom stack uses `persistentVolumes`, the namespace move triggers a Pulumi Replace on each PVC. Because PVCs are namespace-scoped and not movable, Pulumi creates the new PVC and deletes the old one. **If the StorageClass's `reclaimPolicy` is `Delete` (the default for most dynamic provisioners on AWS/GCP), the underlying PV and its data are destroyed along with the old PVC.**
+
+Before migrating a stateful custom stack:
+
+1. Patch the existing PV's reclaim policy to `Retain`:
+   ```sh
+   kubectl patch pv <pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+   ```
+2. Run `sc deploy -P` to confirm the diff matches expectations.
+3. After the migration, clear `claimRef` on the retained PV and re-bind it to the new PVC if you want to preserve the data — or accept the data is dev-only and let it recreate.
+
+Stacks that don't define `persistentVolumes` (the typical case where state lives in managed services like Cloud SQL, RDS, Memorystore, or external MongoDB Atlas) are unaffected.

--- a/docs/docs/guides/parent-gcp-gke-autopilot.md
+++ b/docs/docs/guides/parent-gcp-gke-autopilot.md
@@ -300,6 +300,15 @@ sc deploy -s myservice -e staging
 
 ✅ The service is **automatically deployed to GKE Autopilot** using the defined settings.
 
+### **Namespace layout**
+
+Simple Container derives the Kubernetes namespace automatically from `stackName` and `stackEnv`:
+
+- **Standard stacks** (no `parentEnv`, or `parentEnv` equals `stackEnv`) deploy to `<stackName>`.
+- **Custom stacks** (`parentEnv` differs from `stackEnv`, e.g. tenant-style sub-envs under one parent) deploy to `<stackName>-<stackEnv>`, so siblings never share a namespace.
+
+This isolation is automatic and is what makes `sc destroy -s myservice -e <env>` safe — it only removes resources in that env's own namespace, leaving the parent stack and other siblings untouched. See **[Kubernetes Namespace Layout](../concepts/kubernetes-namespaces.md)** for the full rule, worked examples, and migration notes for stacks deployed before this behavior was introduced.
+
 ---
 
 # **7️⃣ Advanced Configuration: Vertical Pod Autoscaler (VPA)**

--- a/docs/docs/guides/parent-pure-kubernetes.md
+++ b/docs/docs/guides/parent-pure-kubernetes.md
@@ -233,6 +233,15 @@ sc deploy -s myservice -e production
 
 ✅ The service is **automatically deployed to Kubernetes** using the defined settings.
 
+### **Namespace layout**
+
+Simple Container derives the Kubernetes namespace automatically from `stackName` and `stackEnv`:
+
+- **Standard stacks** (no `parentEnv`, or `parentEnv` equals `stackEnv`) deploy to `<stackName>`.
+- **Custom stacks** (`parentEnv` differs from `stackEnv`, e.g. tenant-style sub-envs under one parent) deploy to `<stackName>-<stackEnv>`, so siblings never share a namespace.
+
+This isolation is automatic and is what makes `sc destroy -s myservice -e <env>` safe — it only removes resources in that env's own namespace, leaving the parent stack and other siblings untouched. See **[Kubernetes Namespace Layout](../concepts/kubernetes-namespaces.md)** for the full rule, worked examples, and migration notes for stacks deployed before this behavior was introduced.
+
 ---
 
 # **6️⃣ Summary**

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - Main Concepts: concepts/main-concepts.md
     - Template Placeholders: concepts/template-placeholders.md
     - Advanced Template Placeholders: concepts/template-placeholders-advanced.md
+    - Kubernetes Namespace Layout: concepts/kubernetes-namespaces.md
     - Why Simple Container: concepts/motivation.md
   - Guides:
     - Deployment Guides: guides/index.md

--- a/pkg/clouds/pulumi/gcp/compute_proc.go
+++ b/pkg/clouds/pulumi/gcp/compute_proc.go
@@ -251,8 +251,16 @@ func createCloudsqlProxy(ctx *sdk.Context, params appendParams) (*CloudSQLProxy,
 	// This ensures service accounts are unique per environment (e.g., telegram-bot--on-sidecarcsql--production vs telegram-bot--on-sidecarcsql--staging)
 	baseProxyName := fmt.Sprintf("%s-%s-sidecarcsql", params.stack.Name, params.postgresName)
 	cloudsqlProxyName := kubernetes.SanitizeK8sName(params.input.ToResName(baseProxyName))
-	// Sanitize namespace name as well
-	sanitizedNamespace := kubernetes.SanitizeK8sName(params.input.StackParams.StackName)
+	// The CloudSQL proxy emits a Kubernetes Secret (proxy credentials) that must live in
+	// the same namespace as the consuming pod for it to be mountable. For custom stacks
+	// (parentEnv != stackEnv) the pod namespace is `<stackName>-<stackEnv>` per
+	// kubernetes.GenerateNamespaceName, so derive that here.
+	parentEnv := ""
+	if params.provisionParams.ParentStack != nil {
+		parentEnv = params.provisionParams.ParentStack.ParentEnv
+	}
+	derivedNamespace := kubernetes.GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv)
+	sanitizedNamespace := kubernetes.SanitizeK8sName(derivedNamespace)
 	cloudsqlProxy, err := NewCloudsqlProxy(ctx, CloudSQLProxyArgs{
 		Name: cloudsqlProxyName,
 		DBInstance: PostgresDBInstanceArgs{
@@ -345,7 +353,14 @@ func createUserForDatabase(ctx *sdk.Context, userName, dbName string, params app
 		}
 		// Sanitize names to comply with Kubernetes RFC 1123 requirements (no underscores)
 		cloudsqlProxyName := kubernetes.SanitizeK8sName(util.TrimStringMiddle(fmt.Sprintf("%s-%s-initcsql", userName, params.postgresName), 60, "-"))
-		namespace := kubernetes.SanitizeK8sName(params.input.StackParams.StackName)
+		// Init job + ad-hoc CloudSQL proxy must live in the same namespace as the consuming
+		// pod so the proxy's credential Secret is mountable. For custom stacks the pod is
+		// in `<stackName>-<stackEnv>` per kubernetes.GenerateNamespaceName.
+		parentEnv := ""
+		if params.provisionParams.ParentStack != nil {
+			parentEnv = params.provisionParams.ParentStack.ParentEnv
+		}
+		namespace := kubernetes.SanitizeK8sName(kubernetes.GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv))
 		cloudsqlProxy, err := NewCloudsqlProxy(ctx, CloudSQLProxyArgs{
 			Name:         cloudsqlProxyName,
 			DBInstance:   dbInstanceArgs,

--- a/pkg/clouds/pulumi/kubernetes/compute_proc_mongodb.go
+++ b/pkg/clouds/pulumi/kubernetes/compute_proc_mongodb.go
@@ -129,7 +129,15 @@ func createMongodbUserForDatabase(ctx *sdk.Context, userName, dbName string, par
 	}
 	ctx.Export(passwordName, password.Result)
 
-	namespace := params.input.StackParams.StackName
+	// The init job must run in the same namespace as the consuming pod so it can be
+	// observed and cleaned up alongside the workload. For custom stacks (parentEnv != stackEnv)
+	// the pod lives in `<stackName>-<stackEnv>` per GenerateNamespaceName, so derive the same
+	// namespace here. Standard stacks keep the existing `<stackName>` namespace.
+	parentEnv := ""
+	if params.provisionParams.ParentStack != nil {
+		parentEnv = params.provisionParams.ParentStack.ParentEnv
+	}
+	namespace := GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv)
 
 	params.collector.AddPreProcessor(&SimpleContainerArgs{}, func(c any) error {
 		_, err = NewMongodbInitDbUserJob(ctx, userName, InitDbUserJobArgs{

--- a/pkg/clouds/pulumi/kubernetes/compute_proc_postgres.go
+++ b/pkg/clouds/pulumi/kubernetes/compute_proc_postgres.go
@@ -210,7 +210,15 @@ func createPostgresUserForDatabase(ctx *sdk.Context, userName, dbName string, pa
 		return nil, errors.Wrapf(err, "failed to parse postgres url for database %q", dbName)
 	}
 
-	namespace := params.input.StackParams.StackName
+	// The init job must run in the same namespace as the consuming pod so it can be
+	// observed and cleaned up alongside the workload. For custom stacks (parentEnv != stackEnv)
+	// the pod lives in `<stackName>-<stackEnv>` per GenerateNamespaceName, so derive the same
+	// namespace here. Standard stacks keep the existing `<stackName>` namespace.
+	parentEnv := ""
+	if params.provisionParams.ParentStack != nil {
+		parentEnv = params.provisionParams.ParentStack.ParentEnv
+	}
+	namespace := GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv)
 
 	params.collector.AddPreProcessor(&SimpleContainerArgs{}, func(c any) error {
 		_, err = NewPostgresInitDbUserJob(ctx, userName, InitDbUserJobArgs{

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -63,8 +63,13 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		parentEnv = args.Params.ParentStack.ParentEnv
 	}
 
-	// Determine namespace - always use stack name as namespace (service name)
-	namespace := lo.If(args.Namespace == "", stackName).Else(args.Namespace)
+	// Derive namespace via GenerateNamespaceName: standard stacks keep the stackName-based
+	// namespace; custom stacks (parentEnv != stackEnv) get a stackEnv-suffixed namespace so
+	// sibling sub-envs no longer share a physical namespace. See the helper's docstring for
+	// migration semantics. The shared parent namespace stays intact through the per-stack
+	// migration thanks to RetainOnDelete on the namespace resource.
+	baseNamespace := lo.If(args.Namespace == "", stackName).Else(args.Namespace)
+	namespace := GenerateNamespaceName(baseNamespace, stackEnv, parentEnv)
 
 	// Generate deployment name with environment suffix for custom stacks
 	baseDeploymentName := lo.If(args.DeploymentName == "", stackName).Else(args.DeploymentName)

--- a/pkg/clouds/pulumi/kubernetes/helpers.go
+++ b/pkg/clouds/pulumi/kubernetes/helpers.go
@@ -45,7 +45,10 @@ func sanitizeK8sName(name string) string {
 }
 
 func ensureNamespace(ctx *sdk.Context, input api.ResourceInput, params pApi.ProvisionParams, namespace string) (*corev1.Namespace, error) {
-	opts := []sdk.ResourceOption{sdk.Provider(params.Provider)}
+	// RetainOnDelete: see the rationale at simple_container.go's NewNamespace call —
+	// helm operator stacks share namespaces across sibling stacks the same way client
+	// stacks do, so the destroy-cascade hazard is identical here.
+	opts := []sdk.ResourceOption{sdk.Provider(params.Provider), sdk.RetainOnDelete(true)}
 	sanitizedNamespace := sanitizeK8sName(namespace)
 	return corev1.NewNamespace(ctx, fmt.Sprintf("create-ns-%s-%s", sanitizedNamespace, input.ToResName(input.Descriptor.Name)), &corev1.NamespaceArgs{
 		Metadata: &metav1.ObjectMetaArgs{

--- a/pkg/clouds/pulumi/kubernetes/naming.go
+++ b/pkg/clouds/pulumi/kubernetes/naming.go
@@ -71,6 +71,36 @@ func isCustomStack(stackEnv, parentEnv string) bool {
 	return parentEnv != "" && parentEnv != stackEnv
 }
 
+// GenerateNamespaceName derives the physical k8s namespace name for a stack.
+// Standard stacks (parentEnv unset, or parentEnv == stackEnv) keep baseNamespace
+// (typically the stackName). Custom stacks (parentEnv set and differing from
+// stackEnv, e.g. parentEnv=production with stackEnv=tenant-a/tenant-b/...) get
+// baseNamespace suffixed with stackEnv, mirroring the per-stackEnv suffix every
+// other resource type (Deployment, Service, Secret, ConfigMap, HPA, VPA,
+// ImagePullSecret) already gets via generateResourceName.
+//
+// The result is sanitized to comply with Kubernetes RFC 1123 (lowercase
+// alphanumeric and `-`, ≤63 chars with FNV-1a truncation hash) so callers can
+// pass it directly into `metadata.namespace` without an extra sanitization
+// step. Sanitization is idempotent — callers that pre-sanitize their inputs
+// see no behavioural change.
+//
+// Without this isolation, sibling sub-env stacks share one physical namespace,
+// and any `pulumi destroy` on a sub-env cascade-deletes every sibling's resources
+// via the k8s namespace delete API. Migrating an existing custom stack to its
+// dedicated namespace is automatic on the next `pulumi up`: Pulumi sees the
+// namespace metadata.Name change and Replaces the namespace plus its
+// namespace-scoped resources. The namespace is created with RetainOnDelete (see
+// NewSimpleContainer), so the parent's shared namespace is left in place — the
+// parent stack's resources continue running through the migration.
+func GenerateNamespaceName(baseNamespace, stackEnv, parentEnv string) string {
+	name := baseNamespace
+	if isCustomStack(stackEnv, parentEnv) {
+		name = fmt.Sprintf("%s-%s", baseNamespace, stackEnv)
+	}
+	return SanitizeK8sName(name)
+}
+
 // GenerateCaddyDeploymentName creates the Caddy deployment name with environment suffix
 // Caddy deployments always include the environment suffix for backwards compatibility
 // This is exported so it can be used by both kubernetes and gcp packages for consistency
@@ -87,8 +117,8 @@ func GenerateCaddyDeploymentName(stackEnv string) string {
 //
 // Caddy is provisioned by the parent infra stack, so its deployment name is keyed on
 // parentEnv (e.g. caddy-production). For sub-env client stacks where parentEnv differs
-// from stackEnv (e.g. parentEnv=production, stackEnv=gl-pay), passing stackEnv would
-// produce caddy-gl-pay — which doesn't exist — and the patch would fail silently.
+// from stackEnv (e.g. parentEnv=production, stackEnv=tenant-a), passing stackEnv would
+// produce caddy-tenant-a — which doesn't exist — and the patch would fail silently.
 // For single-env stacks (parentEnv empty or equal to stackEnv) this falls back to stackEnv.
 //
 // Note: this is the call site asymmetric to GenerateCaddyDeploymentName, which is used

--- a/pkg/clouds/pulumi/kubernetes/naming_test.go
+++ b/pkg/clouds/pulumi/kubernetes/naming_test.go
@@ -455,7 +455,7 @@ func TestCaddyDeploymentNameForChild(t *testing.T) {
 		},
 		{
 			name:      "sub-env stack targets parent's caddy",
-			stackEnv:  "gl-pay",
+			stackEnv:  "tenant-a",
 			parentEnv: "production",
 			expected:  "caddy-production",
 		},
@@ -530,6 +530,121 @@ func TestIsCustomStack(t *testing.T) {
 				t.Errorf("isCustomStack() = %v, expected %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestGenerateNamespaceName covers the namespace derivation that gives custom stacks
+// (parentEnv != stackEnv) their own physical k8s namespace, while leaving standard
+// stacks on the stackName-based namespace. Includes regression cases for the
+// shared-namespace outage class where production parentEnv plus several sibling
+// sub-env stacks (tenant-a/tenant-b/tenant-c/preview-test/...) all collided in one
+// namespace, so destroying any sibling cascade-deleted the rest.
+func TestGenerateNamespaceName(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseNamespace string
+		stackEnv      string
+		parentEnv     string
+		expected      string
+	}{
+		{
+			name:          "standard stack - no parentEnv",
+			baseNamespace: "myapp",
+			stackEnv:      "staging",
+			parentEnv:     "",
+			expected:      "myapp",
+		},
+		{
+			name:          "self-reference - parentEnv equals stackEnv",
+			baseNamespace: "myapp",
+			stackEnv:      "production",
+			parentEnv:     "production",
+			expected:      "myapp",
+		},
+		{
+			name:          "custom stack - sub-env under production",
+			baseNamespace: "myapp",
+			stackEnv:      "tenant-a",
+			parentEnv:     "production",
+			expected:      "myapp-tenant-a",
+		},
+		{
+			// Realistic stackNames often contain underscores; the namespace must be
+			// sanitized to RFC 1123 so callers can pass the result directly into
+			// metadata.namespace without their own sanitization step.
+			name:          "underscores in stackName get normalized",
+			baseNamespace: "my_app",
+			stackEnv:      "tenant-a",
+			parentEnv:     "production",
+			expected:      "my-app-tenant-a",
+		},
+		{
+			name:          "uppercase gets lowercased",
+			baseNamespace: "MyApp",
+			stackEnv:      "TenantA",
+			parentEnv:     "production",
+			expected:      "myapp-tenanta",
+		},
+		{
+			name:          "custom stack - PR preview under staging",
+			baseNamespace: "api",
+			stackEnv:      "staging-pr-123",
+			parentEnv:     "staging",
+			expected:      "api-staging-pr-123",
+		},
+		{
+			name:          "custom stack - throwaway test sibling",
+			baseNamespace: "myapp",
+			stackEnv:      "preview-test",
+			parentEnv:     "production",
+			expected:      "myapp-preview-test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateNamespaceName(tt.baseNamespace, tt.stackEnv, tt.parentEnv)
+			if got != tt.expected {
+				t.Errorf("GenerateNamespaceName(%q, %q, %q) = %q, expected %q",
+					tt.baseNamespace, tt.stackEnv, tt.parentEnv, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGenerateNamespaceName_SiblingsAreUnique is the direct regression test for the
+// shared-namespace outage: every sub-env stack under one stackName must resolve to
+// a distinct namespace, while the parent (parentEnv == stackEnv) keeps its existing
+// namespace. This mirrors the production scenario where one parent env hosted
+// multiple tenant sub-envs plus a throwaway test sub-env, all sharing one namespace.
+func TestGenerateNamespaceName_SiblingsAreUnique(t *testing.T) {
+	baseNamespace := "myapp"
+	parentEnv := "production"
+
+	siblings := []struct {
+		stackEnv         string
+		expectedNamespace string
+	}{
+		{"production", "myapp"},
+		{"tenant-a", "myapp-tenant-a"},
+		{"tenant-b", "myapp-tenant-b"},
+		{"tenant-c", "myapp-tenant-c"},
+		{"tenant-d", "myapp-tenant-d"},
+		{"preview-test", "myapp-preview-test"},
+	}
+
+	seen := make(map[string]string)
+	for _, s := range siblings {
+		got := GenerateNamespaceName(baseNamespace, s.stackEnv, parentEnv)
+		if got != s.expectedNamespace {
+			t.Errorf("stackEnv=%q: got namespace %q, expected %q",
+				s.stackEnv, got, s.expectedNamespace)
+		}
+		if prior, dup := seen[got]; dup {
+			t.Errorf("stackEnv=%q produced namespace %q already used by stackEnv=%q — "+
+				"siblings must not share a namespace", s.stackEnv, got, prior)
+		}
+		seen[got] = s.stackEnv
 	}
 }
 

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -216,7 +216,25 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	// Sanitize namespace name to comply with Kubernetes RFC 1123 requirements
 	sanitizedNamespace := sanitizeK8sName(args.Namespace)
 	// Use deployment name as Pulumi resource name to ensure uniqueness across environments
-	// while keeping the actual K8s namespace name as specified by the user
+	// while keeping the actual K8s namespace name as specified by the user.
+	//
+	// RetainOnDelete: in legacy deploys, sub-env client stacks (e.g. parentEnv=production
+	// with stackEnv=tenant-a/tenant-b/...) shared one physical K8s namespace because the
+	// namespace metadata.Name was derived from stackName, not from stackEnv. Each stack
+	// tracked its own Pulumi Namespace resource with a unique URN, but they all referenced
+	// the same physical k8s namespace. Without RetainOnDelete, destroying any single
+	// sub-env stack would cascade-delete the shared namespace and wipe every sibling
+	// stack's resources (Deployments, Services, Secrets) — a real production outage when
+	// a throwaway sub-env destroy took down all live siblings.
+	//
+	// GenerateNamespaceName now isolates custom stacks per-stackEnv, but RetainOnDelete
+	// remains load-bearing for the migration step: when a pre-existing custom stack
+	// first runs `pulumi up` after this version, Pulumi Replaces the namespace, and the
+	// old shared namespace must NOT be deleted because the parent stack still lives
+	// there. Post-migration, RetainOnDelete continues to defend against any case where
+	// multiple stacks legitimately share a namespace (helm operators, explicit
+	// `Namespace` overrides). Empty namespaces left after the last referencing stack
+	// is destroyed must be cleaned up by hand.
 	namespaceResourceName := fmt.Sprintf("%s-ns", sanitizedDeployment)
 	namespace, err := corev1.NewNamespace(ctx, namespaceResourceName, &corev1.NamespaceArgs{
 		Metadata: &metav1.ObjectMetaArgs{
@@ -224,7 +242,7 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 			Labels:      sdk.ToStringMap(appLabels),
 			Annotations: sdk.ToStringMap(appAnnotations),
 		},
-	}, opts...)
+	}, append(opts, sdk.RetainOnDelete(true))...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

Sub-env client stacks (`parentEnv: production`, `stackEnv: tenant-a`/`tenant-b`/...) were deriving their k8s namespace name from `stackName` via [pkg/clouds/pulumi/kubernetes/deployment.go:67](pkg/clouds/pulumi/kubernetes/deployment.go#L67):

```go
namespace := lo.If(args.Namespace == "", stackName).Else(args.Namespace)
```

So every sibling under the same `stackName` ended up pointing at the same physical namespace. Each Pulumi stack independently tracked its own `Namespace` resource for that `metadata.Name` with a unique URN suffix, but they all referenced the same physical namespace. Every other resource type (Deployment, Service, Secret, ConfigMap, HPA, VPA, ImagePullSecret) was already correctly env-suffixed via [generateResourceName](pkg/clouds/pulumi/kubernetes/naming.go#L7) — the namespace was the one piece left non-isolated.

When **any** sibling stack was destroyed, Pulumi ran the delete for its tracked Namespace resource — which calls k8s to delete the namespace by `metadata.Name`. K8s obliged and cascade-deleted **every** resource in that namespace, including everything owned by the other live sibling stacks.

### Real outage

Destroying a throwaway sub-env stack on a production cluster wiped every live sibling's Deployments, Services, and namespace-scoped Secrets in one shot. Recovery required redeploying all of them plus rolling Caddy.

## Fix — three layers

### 1. Per-stackEnv namespace for custom stacks

New helper `GenerateNamespaceName(baseNS, stackEnv, parentEnv)` exported from `naming.go`. For custom stacks (`parentEnv != stackEnv`) the namespace is suffixed with `-{stackEnv}`, mirroring the suffix every other resource already gets. Standard stacks (`parentEnv` unset, or `parentEnv == stackEnv`) keep the existing `stackName`-based namespace, so the parent stack is untouched.

The result is RFC 1123-sanitized inside the helper (lowercase, `_` → `-`, ≤63 chars with FNV-1a truncation), so direct callers can pass it straight into `metadata.namespace` without their own sanitization step. Sanitization is idempotent — pre-sanitized inputs see no change.

Behavior matrix:

| Stack | parentEnv | stackEnv | Namespace | Change |
|---|---|---|---|---|
| `production` | production | production | `<stackName>` | unchanged |
| `tenant-a` | production | tenant-a | `<stackName>-tenant-a` | NEW |
| `tenant-b` | production | tenant-b | `<stackName>-tenant-b` | NEW |
| `preview-test` | production | preview-test | `<stackName>-preview-test` | NEW |
| `staging` | (defaults to staging) | staging | `<stackName>` | unchanged |

### 2. Dependency-resource processors aligned with the new namespace

The init-job and CloudSQL-proxy code paths previously hardcoded `params.input.StackParams.StackName` as the namespace — fine when the pod also lived in `<stackName>`, but stranded after the change above. Updated three call sites to derive the namespace via `kubernetes.GenerateNamespaceName(stackName, stackEnv, parentEnv)`:

- [compute_proc_postgres.go](pkg/clouds/pulumi/kubernetes/compute_proc_postgres.go) — Postgres init-DB-user job
- [compute_proc_mongodb.go](pkg/clouds/pulumi/kubernetes/compute_proc_mongodb.go) — MongoDB init-DB-user job
- [gcp/compute_proc.go](pkg/clouds/pulumi/gcp/compute_proc.go) (two sites) — CloudSQL proxy sidecar Secret + ad-hoc init proxy

Without these updates, custom-stack pods would fail to mount the CloudSQL proxy credential Secret (which would have been created in the now-different parent namespace).

### 3. `RetainOnDelete(true)` on namespace resources

Both `corev1.NewNamespace` call sites pass `sdk.RetainOnDelete(true)`:

- [simple_container.go:232](pkg/clouds/pulumi/kubernetes/simple_container.go#L232) — client stacks
- [helpers.go:53](pkg/clouds/pulumi/kubernetes/helpers.go#L53) — helm operator stacks (same hazard)

Pulumi keeps the resource in state but skips the k8s delete API call on destroy. This is **critical during migration**: when an existing custom stack first runs `pulumi up` with this version, Pulumi sees the namespace `metadata.Name` change, schedules a Replace, creates the new namespace, and *would* delete the old shared namespace (wiping the parent stack and any siblings still on the old NS) — except that `RetainOnDelete` skips the delete. The parent's resources keep running through the migration.

`RetainOnDelete` also continues to defend against accidental destroy of any namespace that legitimately ends up holding multiple stacks' resources (helm operators, anyone who explicitly sets the same `Namespace` on multiple stacks). Same pattern is already used elsewhere in the codebase for shared resources (see [cloudflare/registrar.go:143,320](pkg/clouds/pulumi/cloudflare/registrar.go#L143)).

## Migration semantics

Any deploy that uses `parentEnv != stackEnv` will Replace its namespace-scoped resources on the next `pulumi up` — Pulumi creates them in the new namespace and deletes the old ones. The parent stack is unaffected because its resources sit in a different Pulumi stack with different URNs.

**Caddy routing follows automatically:**
- Caddy uses `kubectl get services --all-namespaces` ([caddy.go:189](pkg/clouds/pulumi/kubernetes/caddy.go#L189)) to discover services with the `simple-container.com/caddyfile-entry` annotation
- The Caddyfile entry template ([simple_container.go:602](pkg/clouds/pulumi/kubernetes/simple_container.go#L602)) encodes `${namespace}` in the upstream URL
- New namespaces are picked up on Caddy's next config rebuild; the rolling-restart annotation patch ([kube_run.go:204](pkg/clouds/pulumi/kubernetes/kube_run.go#L204)) triggers it

**Server-Side Apply** is enabled on the k8s provider ([provider.go:23](pkg/clouds/pulumi/kubernetes/provider.go#L23)), so subsequent `pulumi up` runs against any retained namespace patch the existing object via SSA rather than throwing `AlreadyExists`. Refresh, import, and replace flows are unaffected — `RetainOnDelete` only changes the destroy path.

The empty parent namespace lingers only if the *last* stack referencing it is destroyed; manual cleanup. Right trade vs. silent cascade.

## ⚠️ PersistentVolumeClaim migration caveat

If a custom stack uses `persistentVolumes` ([simple_container.go:397](pkg/clouds/pulumi/kubernetes/simple_container.go#L397) creates PVCs), the namespace move triggers a Pulumi Replace on each PVC. Because PVCs are namespace-scoped and not movable, Pulumi creates the new PVC and deletes the old one. **If the StorageClass's `reclaimPolicy` is `Delete` (default for dynamic volumes on GCP/AWS), the underlying PV and its data are destroyed.**

Mitigations for any consumer with stateful custom stacks before merging this:
1. Patch the existing PV's `persistentVolumeReclaimPolicy: Retain` first (`kubectl patch pv ... --patch ...`)
2. Optionally `kubectl edit pv <name>` to clear `claimRef` and reattach to the new PVC after the migration
3. Or accept that the data is dev-only and let it recreate

Stacks that don't define `persistentVolumes` (the typical case where state lives in managed services like Cloud SQL / RDS / Redis) are unaffected.

## Tests
- [x] `TestGenerateNamespaceName` — table-driven coverage of standard / self-reference / custom-stack derivation including underscore normalization and case folding
- [x] `TestGenerateNamespaceName_SiblingsAreUnique` — direct regression for the shared-namespace outage scenario (parent + 4 tenant sub-envs + preview-test all resolve to distinct namespaces)
- [x] `go test ./pkg/clouds/pulumi/kubernetes/...` and `./pkg/clouds/pulumi/gcp/...` pass
- [x] `go build ./...` clean
- [ ] Branch-preview build + `pulumi preview` against a real custom-stack consumer to validate the migration plan

## Breaking change scope

Any SC consumer with a deploy where `parentEnv != stackEnv` will see their custom stacks recreate-in-new-ns on next `pulumi up`. Brief gap during the namespace cutover; `RetainOnDelete` keeps the old namespace alive so the parent stack continues to serve regardless. Stateful custom stacks should follow the PVC caveat above.

## Reviews
- **Codex** (final pass v4): "No actionable correctness issues were found in the reviewed diff against origin/main."
- **Gemini 2.5 Pro** (v3): APPROVE — confirmed semantics, migration flow, PVC mitigation via docs is the right call, and no new edge cases from exporting `GenerateNamespaceName`.