### PR TITLE
fix(rds): set StorageEncrypted=true on mysql + postgres instances

### DIFF
--- a/pkg/clouds/aws/rds_mysql.go
+++ b/pkg/clouds/aws/rds_mysql.go
@@ -18,6 +18,19 @@ type MysqlConfig struct {
 	Password        string  `json:"password" yaml:"password"`
 	DatabaseName    *string `json:"databaseName" yaml:"databaseName"`
 	EngineName      *string `json:"engineName,omitempty" yaml:"engineName,omitempty"`
+	// StorageEncrypted opts into AWS-side encryption-at-rest for the
+	// underlying EBS volume. When unset (nil), the instance is created
+	// with the AWS default — currently UNENCRYPTED — preserving exact
+	// behaviour for stacks that pre-date this field. Set `true` to opt
+	// the resource into encryption (uses the AWS-managed `aws/rds` KMS
+	// key by default).
+	//
+	// AWS RDS `storage_encrypted` is IMMUTABLE post-creation. Toggling
+	// this field on an existing unencrypted instance does NOT migrate
+	// data — it is silenced via `pulumi.IgnoreChanges` to prevent a
+	// destructive replacement. To convert an existing unencrypted RDS
+	// to encrypted, snapshot → encrypted-copy → restore → re-import.
+	StorageEncrypted *bool `json:"storageEncrypted,omitempty" yaml:"storageEncrypted,omitempty"`
 }
 
 func ReadRdsMysqlConfig(config *api.Config) (api.Config, error) {

--- a/pkg/clouds/aws/rds_postgres.go
+++ b/pkg/clouds/aws/rds_postgres.go
@@ -18,6 +18,19 @@ type PostgresConfig struct {
 	Password        string  `json:"password" yaml:"password"`
 	DatabaseName    *string `json:"databaseName" yaml:"databaseName"`
 	InitSQL         *string `json:"initSQL,omitempty" yaml:"initSQL,omitempty"`
+	// StorageEncrypted opts into AWS-side encryption-at-rest for the
+	// underlying EBS volume. When unset (nil), the instance is created
+	// with the AWS default — currently UNENCRYPTED — preserving exact
+	// behaviour for stacks that pre-date this field. Set `true` to opt
+	// the resource into encryption (uses the AWS-managed `aws/rds` KMS
+	// key by default).
+	//
+	// AWS RDS `storage_encrypted` is IMMUTABLE post-creation. Toggling
+	// this field on an existing unencrypted instance does NOT migrate
+	// data — it is silenced via `pulumi.IgnoreChanges` to prevent a
+	// destructive replacement. To convert an existing unencrypted RDS
+	// to encrypted, snapshot → encrypted-copy → restore → re-import.
+	StorageEncrypted *bool `json:"storageEncrypted,omitempty" yaml:"storageEncrypted,omitempty"`
 }
 
 func ReadRdsPostgresConfig(config *api.Config) (api.Config, error) {

--- a/pkg/clouds/aws/rds_storage_encrypted_test.go
+++ b/pkg/clouds/aws/rds_storage_encrypted_test.go
@@ -1,0 +1,165 @@
+package aws
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	"github.com/simple-container-com/api/pkg/api"
+)
+
+// Tests for the opt-in `StorageEncrypted` field on MysqlConfig /
+// PostgresConfig. Three states matter:
+//
+//   1. omitted from YAML / JSON → field stays nil → `lo.FromPtr(nil)`
+//      collapses to `false`, which preserves pre-2026.5 SC behaviour
+//      for stacks created without the field.
+//   2. explicit `true` → encrypted instance.
+//   3. explicit `false` → still unencrypted (caller asked for it
+//      explicitly; we don't second-guess).
+//
+// The actual replacement-safety guarantee for existing instances comes
+// from `pulumi.IgnoreChanges([]{"storageEncrypted"})` on the resource
+// opts (see pkg/clouds/pulumi/aws/rds_{mysql,postgres}.go) and is
+// covered by integration / e2e tests, not here.
+
+func TestReadRdsMysqlConfig_StorageEncrypted(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		name    string
+		config  *api.Config
+		wantSet bool
+		wantVal bool
+	}{
+		{
+			name: "omitted → nil (legacy default, encryption off)",
+			config: &api.Config{Config: map[string]any{
+				"instanceClass": "db.t3.micro",
+				"engineVersion": "8.0",
+				"username":      "root",
+				"password":      "root",
+			}},
+			wantSet: false,
+		},
+		{
+			name: "explicit true → encrypted",
+			config: &api.Config{Config: map[string]any{
+				"instanceClass":    "db.t3.micro",
+				"engineVersion":    "8.0",
+				"username":         "root",
+				"password":         "root",
+				"storageEncrypted": true,
+			}},
+			wantSet: true,
+			wantVal: true,
+		},
+		{
+			name: "explicit false → still unencrypted",
+			config: &api.Config{Config: map[string]any{
+				"instanceClass":    "db.t3.micro",
+				"engineVersion":    "8.0",
+				"username":         "root",
+				"password":         "root",
+				"storageEncrypted": false,
+			}},
+			wantSet: true,
+			wantVal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			out, err := ReadRdsMysqlConfig(tt.config)
+			Expect(err).To(BeNil())
+			cfg, ok := out.Config.(*MysqlConfig)
+			Expect(ok).To(BeTrue())
+
+			if !tt.wantSet {
+				Expect(cfg.StorageEncrypted).To(BeNil(),
+					"unset field should round-trip as nil so `lo.FromPtr` resolves to false")
+			} else {
+				Expect(cfg.StorageEncrypted).ToNot(BeNil())
+				Expect(*cfg.StorageEncrypted).To(Equal(tt.wantVal))
+			}
+
+			// `lo.FromPtr(nil)` is `false` — explicitly assert the
+			// resolved Pulumi flag matches the documented contract.
+			resolved := lo.FromPtr(cfg.StorageEncrypted)
+			expected := tt.wantSet && tt.wantVal
+			Expect(resolved).To(Equal(expected),
+				"resolved flag passed to `rds.NewInstance` must match nil → false / true → true / false → false")
+		})
+	}
+}
+
+func TestReadRdsPostgresConfig_StorageEncrypted(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		name    string
+		config  *api.Config
+		wantSet bool
+		wantVal bool
+	}{
+		{
+			name: "omitted → nil (legacy default, encryption off)",
+			config: &api.Config{Config: map[string]any{
+				"instanceClass": "db.t3.micro",
+				"engineVersion": "16",
+				"username":      "postgres",
+				"password":      "postgres",
+			}},
+			wantSet: false,
+		},
+		{
+			name: "explicit true → encrypted",
+			config: &api.Config{Config: map[string]any{
+				"instanceClass":    "db.t3.micro",
+				"engineVersion":    "16",
+				"username":         "postgres",
+				"password":         "postgres",
+				"storageEncrypted": true,
+			}},
+			wantSet: true,
+			wantVal: true,
+		},
+		{
+			name: "explicit false → still unencrypted",
+			config: &api.Config{Config: map[string]any{
+				"instanceClass":    "db.t3.micro",
+				"engineVersion":    "16",
+				"username":         "postgres",
+				"password":         "postgres",
+				"storageEncrypted": false,
+			}},
+			wantSet: true,
+			wantVal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			out, err := ReadRdsPostgresConfig(tt.config)
+			Expect(err).To(BeNil())
+			cfg, ok := out.Config.(*PostgresConfig)
+			Expect(ok).To(BeTrue())
+
+			if !tt.wantSet {
+				Expect(cfg.StorageEncrypted).To(BeNil(),
+					"unset field should round-trip as nil so `lo.FromPtr` resolves to false")
+			} else {
+				Expect(cfg.StorageEncrypted).ToNot(BeNil())
+				Expect(*cfg.StorageEncrypted).To(Equal(tt.wantVal))
+			}
+
+			resolved := lo.FromPtr(cfg.StorageEncrypted)
+			expected := tt.wantSet && tt.wantVal
+			Expect(resolved).To(Equal(expected),
+				"resolved flag passed to `rds.NewInstance` must match nil → false / true → true / false → false")
+		})
+	}
+}

--- a/pkg/clouds/pulumi/aws/rds_mysql.go
+++ b/pkg/clouds/pulumi/aws/rds_mysql.go
@@ -118,6 +118,7 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 		Username:          sdk.String(lo.If(dbConfig.Username != "", dbConfig.Username).Else("root")),
 		Password:          sdk.String(lo.If(dbConfig.Password != "", dbConfig.Password).Else("root")),
 		SkipFinalSnapshot: sdk.Bool(true),
+		StorageEncrypted:  sdk.Bool(true),
 		Tags:              tags,
 	}, opts...)
 	if err != nil {

--- a/pkg/clouds/pulumi/aws/rds_mysql.go
+++ b/pkg/clouds/pulumi/aws/rds_mysql.go
@@ -36,16 +36,20 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 
 	opts := []sdk.ResourceOption{
 		sdk.Provider(params.Provider),
-		// AWS RDS `storage_encrypted` is IMMUTABLE — changing it from
+		// AWS RDS `storage_encrypted` is IMMUTABLE — flipping it from
 		// false to true triggers a full replacement of the instance,
-		// which destroys the underlying volume and all its data. New
-		// instances created from now on get encryption (see
-		// `StorageEncrypted: sdk.Bool(true)` below); existing
-		// pre-encryption instances are left alone via this ignore-
-		// changes so an SC upgrade does not nuke a customer's database.
-		// Customers who want to encrypt an existing instance should
-		// snapshot → copy snapshot with encryption enabled → restore
-		// from the encrypted snapshot, then re-import into Pulumi.
+		// which destroys the underlying volume and all its data.
+		//
+		// The `StorageEncrypted` config field below is opt-in (nil =
+		// keep AWS default = unencrypted, preserving pre-2026.5 SC
+		// behaviour). But even with opt-in semantics on the SC side,
+		// once a customer flips the bit on a stack with a pre-existing
+		// unencrypted instance, Pulumi would still propose a destructive
+		// replacement. This `IgnoreChanges` silences that drift so a
+		// config change does NOT nuke the database. Customers who want
+		// to genuinely migrate an existing unencrypted RDS to encrypted
+		// must do it out-of-band: snapshot → encrypted-copy → restore →
+		// re-import. Documented on `MysqlConfig.StorageEncrypted`.
 		sdk.IgnoreChanges([]string{"storageEncrypted"}),
 	}
 
@@ -129,8 +133,9 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 		Username:          sdk.String(lo.If(dbConfig.Username != "", dbConfig.Username).Else("root")),
 		Password:          sdk.String(lo.If(dbConfig.Password != "", dbConfig.Password).Else("root")),
 		SkipFinalSnapshot: sdk.Bool(true),
-		StorageEncrypted:  sdk.Bool(true),
-		Tags:              tags,
+		// nil → false (legacy default). See MysqlConfig.StorageEncrypted.
+		StorageEncrypted: sdk.Bool(lo.FromPtr(dbConfig.StorageEncrypted)),
+		Tags:             tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create rds mysql instance")

--- a/pkg/clouds/pulumi/aws/rds_mysql.go
+++ b/pkg/clouds/pulumi/aws/rds_mysql.go
@@ -36,6 +36,17 @@ func RdsMysql(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params
 
 	opts := []sdk.ResourceOption{
 		sdk.Provider(params.Provider),
+		// AWS RDS `storage_encrypted` is IMMUTABLE — changing it from
+		// false to true triggers a full replacement of the instance,
+		// which destroys the underlying volume and all its data. New
+		// instances created from now on get encryption (see
+		// `StorageEncrypted: sdk.Bool(true)` below); existing
+		// pre-encryption instances are left alone via this ignore-
+		// changes so an SC upgrade does not nuke a customer's database.
+		// Customers who want to encrypt an existing instance should
+		// snapshot → copy snapshot with encryption enabled → restore
+		// from the encrypted snapshot, then re-import into Pulumi.
+		sdk.IgnoreChanges([]string{"storageEncrypted"}),
 	}
 
 	tags := pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags()

--- a/pkg/clouds/pulumi/aws/rds_postgres.go
+++ b/pkg/clouds/pulumi/aws/rds_postgres.go
@@ -36,16 +36,11 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 
 	opts := []sdk.ResourceOption{
 		sdk.Provider(params.Provider),
-		// AWS RDS `storage_encrypted` is IMMUTABLE — changing it from
-		// false to true triggers a full replacement of the instance,
-		// which destroys the underlying volume and all its data. New
-		// instances created from now on get encryption (see
-		// `StorageEncrypted: sdk.Bool(true)` below); existing
-		// pre-encryption instances are left alone via this ignore-
-		// changes so an SC upgrade does not nuke a customer's database.
-		// Customers who want to encrypt an existing instance should
-		// snapshot → copy snapshot with encryption enabled → restore
-		// from the encrypted snapshot, then re-import into Pulumi.
+		// See rds_mysql.go for the full rationale. Same shape applies
+		// to postgres: opt-in via `PostgresConfig.StorageEncrypted`
+		// (nil = AWS default = unencrypted, pre-2026.5 SC behaviour),
+		// and `IgnoreChanges` silences drift so flipping the bit on
+		// an existing stack does not trigger a destructive replacement.
 		sdk.IgnoreChanges([]string{"storageEncrypted"}),
 	}
 
@@ -122,8 +117,9 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 		Username:          sdk.String(lo.If(postgresCfg.Username != "", postgresCfg.Username).Else("postgres")),
 		Password:          sdk.String(lo.If(postgresCfg.Password != "", postgresCfg.Password).Else("postgres")),
 		SkipFinalSnapshot: sdk.Bool(true),
-		StorageEncrypted:  sdk.Bool(true),
-		Tags:              tags,
+		// nil → false (legacy default). See PostgresConfig.StorageEncrypted.
+		StorageEncrypted: sdk.Bool(lo.FromPtr(postgresCfg.StorageEncrypted)),
+		Tags:             tags,
 	}, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create rds postgres instance")

--- a/pkg/clouds/pulumi/aws/rds_postgres.go
+++ b/pkg/clouds/pulumi/aws/rds_postgres.go
@@ -36,6 +36,17 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 
 	opts := []sdk.ResourceOption{
 		sdk.Provider(params.Provider),
+		// AWS RDS `storage_encrypted` is IMMUTABLE — changing it from
+		// false to true triggers a full replacement of the instance,
+		// which destroys the underlying volume and all its data. New
+		// instances created from now on get encryption (see
+		// `StorageEncrypted: sdk.Bool(true)` below); existing
+		// pre-encryption instances are left alone via this ignore-
+		// changes so an SC upgrade does not nuke a customer's database.
+		// Customers who want to encrypt an existing instance should
+		// snapshot → copy snapshot with encryption enabled → restore
+		// from the encrypted snapshot, then re-import into Pulumi.
+		sdk.IgnoreChanges([]string{"storageEncrypted"}),
 	}
 
 	tags := pApi.BuildTagsFromStackParams(*input.StackParams).ToAWSTags()

--- a/pkg/clouds/pulumi/aws/rds_postgres.go
+++ b/pkg/clouds/pulumi/aws/rds_postgres.go
@@ -111,6 +111,7 @@ func RdsPostgres(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, par
 		Username:          sdk.String(lo.If(postgresCfg.Username != "", postgresCfg.Username).Else("postgres")),
 		Password:          sdk.String(lo.If(postgresCfg.Password != "", postgresCfg.Password).Else("postgres")),
 		SkipFinalSnapshot: sdk.Bool(true),
+		StorageEncrypted:  sdk.Bool(true),
 		Tags:              tags,
 	}, opts...)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds opt-in encryption-at-rest for AWS RDS instances managed by SC. Existing customers get **zero** behaviour change unless they explicitly set the new field.

| File | Change |
|---|---|
| `pkg/clouds/aws/rds_mysql.go` | `MysqlConfig.StorageEncrypted *bool` (new optional field) |
| `pkg/clouds/aws/rds_postgres.go` | `PostgresConfig.StorageEncrypted *bool` (same) |
| `pkg/clouds/pulumi/aws/rds_mysql.go` | `StorageEncrypted: sdk.Bool(lo.FromPtr(dbConfig.StorageEncrypted))` + `sdk.IgnoreChanges([]string{"storageEncrypted"})` |
| `pkg/clouds/pulumi/aws/rds_postgres.go` | same |
| `pkg/clouds/aws/rds_storage_encrypted_test.go` | new — unit tests for the opt-in semantics |

## Opt-in behaviour (per Ilya's review feedback)

| Customer config | `dbConfig.StorageEncrypted` | Pulumi `StorageEncrypted` | Effect |
|---|---|---|---|
| Field omitted (legacy stacks) | `nil` | `false` | UNENCRYPTED — preserves pre-2026.5 behaviour |
| `storageEncrypted: true` | `&true` | `true` | Encrypted (AWS-managed `aws/rds` KMS key) |
| `storageEncrypted: false` | `&false` | `false` | Explicit unencrypted (respect the call) |

This means **no customer gets encryption silently** — they have to opt in.

## Why `IgnoreChanges` is still required

`storage_encrypted` is **immutable post-creation** in AWS RDS. Without `IgnoreChanges`, the moment a customer flips the new field to `true` on a stack with a pre-existing unencrypted instance, Pulumi would propose a **destructive replacement** (drop + recreate, data loss + downtime).

`sdk.IgnoreChanges([]string{"storageEncrypted"})` silences that drift. Behaviour:
- ✅ NEW instance + `storageEncrypted: true` → created encrypted from the start.
- ✅ EXISTING unencrypted instance + customer flips to `true` → no diff, no replacement; the customer's data is safe but the existing instance stays unencrypted. They have to migrate out-of-band (see below).
- ✅ EXISTING unencrypted instance + field stays `nil` → no diff. Pre-2026.5 behaviour preserved exactly.

## Migration path for existing unencrypted instances

`sc deploy` will not migrate automatically — the AWS encryption switch is destructive. The standard AWS path:

1. Take a snapshot of the unencrypted instance.
2. `CopyDBSnapshot` with encryption enabled (`KmsKeyId` set).
3. Restore from the encrypted snapshot to a new instance.
4. Cut traffic over (DNS / app config), then delete the old instance.
5. Re-import the new instance into the SC Pulumi stack.

Documented inline next to the `IgnoreChanges` line so a future maintainer doesn't accidentally remove the safety.

## Why surfaced now

`simple-container-com/actions` PR #7 adds a new semgrep rule `go-aws-rds-no-storage-encryption` (ERROR severity). Walking the api codebase to write that rule revealed two pre-existing instances with unset encryption defaults. Originally I went with hard-coded `StorageEncrypted: true`; per review feedback this is now opt-in.

The semgrep rule on actions repo treats `StorageEncrypted: pulumi.Bool(true)` literal as "OK", and `StorageEncrypted: pulumi.Bool(false)` literal as "still ERROR". Our generated value uses `lo.FromPtr` which the rule sees textually as `pulumi.Bool(...)` — but it's `sdk.Bool` here. Verified: rule's `pattern-not-regex: 'StorageEncrypted:\s*\w+\.Bool\(true\)'` does NOT match `sdk.Bool(lo.FromPtr(...))` because the function inside `Bool(...)` isn't `true`. So this code WILL still trigger the rule when scanned with PR #7's ruleset — by design. The rule is conservative; it can't statically prove `lo.FromPtr` resolves to true. Acceptable trade-off: code is conservatively flagged, reviewer eyeballs the call site, confirms the opt-in plumbing is correct, dismisses or fixes.

## KMS

`StorageEncrypted: sdk.Bool(true)` without `KmsKeyId` uses AWS-managed `aws/rds`. Customer-managed key per stack is a follow-up — the immediate-controls bar is encrypt-at-all when the customer opts in.

## Test plan

### Unit (in this PR — green)
- [x] `go test ./pkg/clouds/aws/...` — `TestReadRdsMysqlConfig_StorageEncrypted` and `TestReadRdsPostgresConfig_StorageEncrypted`, 6 subtests total covering all three states for both engines
- [x] Full `go test ./...` — clean

### Integration (manual, after merge)
- [ ] **Brand-new stack, no opt-in**: `pulumi preview` shows `+ Instance` with `storage_encrypted: false` (legacy behaviour preserved).
- [ ] **Brand-new stack with opt-in**: same preview shows `storage_encrypted: true`, KmsKeyId resolves to the AWS-managed default.
- [ ] **Existing customer post-upgrade, no config change**: `pulumi preview` shows **no diff** on the RDS instance (this is the critical migration-safety test — proves IgnoreChanges + nil default both kick in).
- [ ] **Existing customer flipping the field to true**: `pulumi preview` shows **no diff** (silenced by `IgnoreChanges` — explicit demonstration of the safety net).

### E2E (manual, sandbox AWS account)
- [ ] Variant A (no opt-in): create RDS, `aws rds describe-db-instances --query '[*].StorageEncrypted'` → `false`.
- [ ] Variant B (opt-in true): same query → `true`.
- [ ] Variant C (legacy → upgrade simulation): create with old code unencrypted, then `sc deploy` with new code (no config change) → describe → `StorageEncrypted` still `false`, instance ID unchanged.
- [ ] Tear down.

## Out of scope
- Customer-managed KMS key (`KmsKeyId`) — follow-up.
- Schema-version-style bundling of multiple hardening defaults — only one knob today; mongodb-atlas precedent (`NamingStrategyVersion`) exists if the count grows.
- Migrating already-deployed unencrypted instances on customer fleets — manual, out-of-band, documented above.