### PR TITLE
fix(ci): drop root `contents: write` to `contents: read` (CIS GHA 1.2)

### DIFF
--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -7,8 +7,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege root (CIS GHA 1.2). Tag-pushing / deploy jobs grant
+# `contents: write` per-job below: `publish-sc-preview` (welder deploy),
+# `publish-git-tag` (git push tag), and `finalize` (notify/comment).
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   prepare:
@@ -276,6 +279,8 @@ jobs:
     # Does not need docker-build — SC binary publishing is independent of the Docker image.
     # Runs in parallel with publish-git-tag.
     needs: [prepare, build-setup, build-platforms, test]
+    permissions:
+      contents: write  # welder deploy reads release artifacts + updates dist
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -328,6 +333,8 @@ jobs:
     # Only needs docker-build — the tag must point to a commit referencing a published Docker image.
     # Does not need build-platforms or publish-sc-preview. Runs in parallel with publish-sc-preview.
     needs: [prepare, docker-build]
+    permissions:
+      contents: write  # commits the release branch + pushes the preview tag
     # GH_TOKEN must be visible to every step that runs git (checkout, commit,
     # push) because `gh auth setup-git` installs `gh auth git-credential` as
     # the credential helper — and that helper reads $GH_TOKEN from the

--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -15,8 +15,11 @@ on:
       - 'main'
       - 'staging'
 
+# Least-privilege root: every job inherits read-only unless it explicitly
+# grants more (CIS GHA 1.2). Only `finalize` actually needs `contents: write`
+# (sticky comment / notify), and it grants that itself further down.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-setup:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,8 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Least-privilege root (CIS GHA 1.2). Only `docker-finalize` (welder
+# tag-release + deploy) and `finalize` (notify) need `contents: write`;
+# both grant it per-job below.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   prepare:
@@ -364,6 +367,8 @@ jobs:
     name: Docker finalize (tag-release, deploy)
     runs-on: blacksmith-8vcpu-ubuntu-2204
     needs: [prepare, build-setup, build-platforms, build-binaries, build-github-actions-staging, test, build-docs, docker-build]
+    permissions:
+      contents: write  # `welder run tag-release` pushes the release git tag
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Tightens root workflow permissions on \`branch.yaml\`, \`branch-preview.yaml\`, and \`push.yaml\`.

Before: every job inherited \`contents: write\`. Today only a handful of jobs need it (tag-release, welder deploy, sticky-comment posting); build/test/lint/docker-build are all read-only. This PR drops the root grant and adds explicit per-job \`contents: write\` only where required.

| Workflow | Root | Per-job writes |
|---|---|---|
| `branch.yaml` | `read` | `finalize` (already had it) |
| `branch-preview.yaml` | `read` | `publish-sc-preview`, `publish-git-tag`, `finalize` |
| `push.yaml` | `read` | `docker-finalize` (tag-release), `finalize` |

## Verification

- SC Semgrep ruleset (\`simple-container-com/actions/semgrep-scan/rules/github-actions.yml\`) scanned across all 5 workflows: **0 findings**.
- All \`actions/checkout\` instances retain \`persist-credentials: false\` (preserved from #238).
- No OIDC \`id-token: write\` was set anywhere previously — none added (no cosign / aws-oidc usage yet).
- The \`branch.yaml\` PPE caveat (\`pull_request\` trigger + \`secrets.SC_CONFIG\`) is intentionally **out of scope** here. PR #238 added a documented \`nosemgrep\` + comment marking it as accepted defense-in-depth risk for trusted contributors, with the proper \`workflow_run\`-gated split tracked separately. This PR only tightens permissions, not triggers.

## Frameworks satisfied

| Framework | Control |
|---|---|
| CIS GitHub Actions Benchmark | §1.2 (restrict workflow permissions) |
| OWASP Top 10 CI/CD | CICD-SEC-1 (insufficient flow control), CICD-SEC-5 (PBAC) |
| NIST SP 800-218 SSDF | PS.1 (protect all forms of code) |
| OpenSSF Scorecard | Token-Permissions check |

## Test plan

- [x] Semgrep clean on all 5 workflows
- [ ] CI green on this branch (build, test, docker-build, docker-finalize all complete)
- [ ] No tag-release / publish step fails for permission reasons