### PR TITLE
fix(caddy): default catch-all returns 503 instead of welcome page

### DIFF
--- a/pkg/clouds/pulumi/kubernetes/caddy.go
+++ b/pkg/clouds/pulumi/kubernetes/caddy.go
@@ -90,11 +90,21 @@ func DeployCaddyService(ctx *sdk.Context, caddy CaddyDeployment, input api.Resou
 	}
 
 	defaultCaddyFileEntryStart := `http:// {`
+	// Default catch-all serves a hard 503 instead of a static "welcome" page.
+	// Rationale: when all Services with a `simple-container.com/caddyfile-entry`
+	// annotation for a given Host vanish (e.g. a cascade-deletion from a
+	// namespace Replace gone wrong), the request used to fall through to a
+	// `file_server /etc/caddy/pages` block and respond with HTTP 200 + "Default
+	// page". External monitoring saw healthy 200s while every backend was gone.
+	// 503 + Retry-After makes the absence of routes loud: CDNs fail over,
+	// uptime checks alert, oncall sees it.
 	defaultCaddyFileEntry := `
   import gzip
-  import handle_static
-  root * /etc/caddy/pages
-  file_server
+  header Cache-Control "no-store"
+  header Retry-After "60"
+  respond "<!doctype html><meta charset=utf-8><title>503 Service Unavailable</title><style>body{font:20px Helvetica,sans-serif;color:#333;text-align:center;padding:120px}h1{font-size:48px}code{background:#eee;padding:2px 6px;border-radius:3px}</style><h1>503 Service Unavailable</h1><p>No backend route is configured for this host.</p><p>If you are an operator, verify the Service has the <code>simple-container.com/caddyfile-entry</code> annotation and that Caddy has been rolled.</p>" 503 {
+    close
+  }
 `
 	// if caddy must respect SSL connections only
 	useSSL := caddy.UseSSL == nil || *caddy.UseSSL


### PR DESCRIPTION
## Why

The Caddy default catch-all `http:// { file_server /etc/caddy/pages }` served HTTP 200 + a static "Default page" for any Host that didn't have a matching Service-annotated site block. When all Services with a `simple-container.com/caddyfile-entry` annotation for a given Host disappeared (e.g. cascade-delete from a namespace Replace gone sideways), every request to that domain came back **200 OK**. Every external monitoring system trusted that 200. CDNs trusted it. Uptime checks trusted it. The outage was invisible to every layer that wasn't deep-inspecting the response body.

PAY-SPACE hit this on 2026-05-10 when the migration from #230 cascade-deleted the shared `support-bot` parent namespace. Every production domain pointing at the cluster served the Caddy welcome page. The outage was only noticed when a human opened a browser tab.

## What this changes

[caddy.go:92-103](https://github.com/simple-container-com/api/blob/main/pkg/clouds/pulumi/kubernetes/caddy.go#L92-L103): the default catch-all now uses `respond ... 503 { close }`:

```caddy
http:// {
  import gzip
  header Cache-Control "no-store"
  header Retry-After "60"
  respond "<!doctype html>... 503 Service Unavailable ..." 503 {
    close
  }
  import hsts   # when useSSL
}
```

- `503` so every monitoring layer alarms when routes vanish
- `Retry-After: 60` so CDNs back off without giving up
- `Cache-Control: no-store` so an aggressive cache doesn't pin the 503 state past route recovery
- HTML body for humans visiting in a browser — now names the problem (`simple-container.com/caddyfile-entry` annotation missing) and tells operators what to check
- `close` so we don't keep dead-end keepalive connections open

## What this does NOT change

- `/etc/caddy/pages/*.html` is still embedded and still used by `handle_bucket_error` + `handle_server_error` snippets for legitimate per-Service error fallbacks (404, 500, 502). The catch-all just stopped serving from there.
- Domain-matching Service site blocks behave exactly as before — only the no-match path changed.

## Verification

`caddy validate` against the full embedded Caddyfile + the new default block + a sample matched site:

```
{"level":"info","msg":"using config from file","file":"/etc/caddy/Caddyfile"}
{"level":"info","logger":"tls.cache.maintenance","msg":"stopped background certificate maintenance"}
Valid configuration
```

End-to-end with `simplecontainer/caddy:latest` serving the test Caddyfile:

```
$ curl -sS -o /dev/null -w "HTTP %{http_code}\n" -H "Host: example.com" http://localhost:18080/
HTTP 200

$ curl -sS -w "HTTP %{http_code}\n" -H "Host: support-bot.pay.space" http://localhost:18080/
HTTP 503

$ curl -sIS -H "Host: support-bot.pay.space" http://localhost:18080/ | grep -iE 'retry-after|cache-control'
Cache-Control: no-store
Retry-After: 60
```

## Compatibility

- No SC consumer documentation references the welcome-page behavior. The catch-all 200 was incidental, not contractual.
- Any caller that *was* depending on `http://<cluster-LB-IP>/` returning 200 (e.g. a misconfigured smoke test) will now see 503 — that's a behavior change but it's a strict improvement; the previous 200 was wrong.

## Related

- #255 — Caddy aggregator dedup. Pairs with this PR as the two halves of the 2026-05-10 outage post-mortem:
  - #255: keep the aggregator from crashlooping during a Service transition (the *visible* failure mode)
  - this: keep the absence of routes loud so cascade-deletes don't masquerade as healthy 200s (the *invisible* failure mode that delayed detection)

## Test plan

- [ ] Merge
- [ ] Branch-preview build picked up by next deploy
- [ ] Trigger a Caddy roll and probe a known-good Host (expect 200) and an arbitrary unmatched Host (expect 503)
- [ ] Confirm Cloudflare / upstream LB respects the 503 — surfaces in monitoring instead of silently passing through