### PR TITLE
fix(k8s+gcp): thread live Namespace Output to CSQL/init Jobs (closes namespace Replace cascade, follow-up to #255)

### DIFF
--- a/pkg/clouds/pulumi/gcp/cloudsql_proxy.go
+++ b/pkg/clouds/pulumi/gcp/cloudsql_proxy.go
@@ -94,21 +94,17 @@ func NewCloudsqlProxy(ctx *sdk.Context, args CloudSQLProxyArgs, opts ...sdk.Reso
 	}
 
 	opts = append(opts, sdk.Provider(args.KubeProvider))
-	// IgnoreChanges("metadata.namespace") — symmetric with PR #255's IgnoreChanges("metadata.name") on the
-	// Namespace resource itself. PR #230 changed kubernetes.GenerateNamespaceName to suffix custom-stack
-	// namespaces with stackEnv (e.g. "web-app" → "web-app-xcore"), and compute_proc.go feeds that derived
-	// name into args.Metadata.Namespace here. For stacks whose Pulumi state predates #230, the existing
-	// CSQL credential Secret lives in the parent-shared namespace (`web-app`), but the new program wants
-	// `web-app-xcore` — which is immutable on Secret, so Pulumi schedules a Replace. The new Secret then
-	// fails to create because the isolated namespace doesn't exist on the cluster (the Namespace resource
-	// is itself kept in parent-shared by #255's IgnoreChanges). IgnoreChanges suppresses the diff, leaving
-	// the Secret co-located with the consuming pod in the parent namespace — the same trade-off #255 made
-	// for the Namespace. Fresh stacks (no prior state) get the isolated namespace on first create.
+	// args.Metadata.Namespace is the live Namespace.Metadata.Name() Output, threaded
+	// through by compute_proc.go (preprocessor uses kubeArgs.NamespaceNameOutput,
+	// postprocessor uses sc.Namespace). That means this Secret automatically lands
+	// in the same k8s namespace as the consuming pod under both fresh deploys (isolated
+	// name) and migrated stacks where #255's IgnoreChanges("metadata.name") keeps the
+	// Namespace parent-shared — no IgnoreChanges needed here.
 	secretName := util.SanitizeK8sResourceName(args.Name + "-creds")
 	sqlProxySecret, err := v1.NewSecret(ctx, secretName, &v1.SecretArgs{
 		Metadata: args.Metadata,
 		Data:     account.CredentialsSecrets,
-	}, append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))...)
+	}, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clouds/pulumi/gcp/cloudsql_proxy.go
+++ b/pkg/clouds/pulumi/gcp/cloudsql_proxy.go
@@ -94,12 +94,21 @@ func NewCloudsqlProxy(ctx *sdk.Context, args CloudSQLProxyArgs, opts ...sdk.Reso
 	}
 
 	opts = append(opts, sdk.Provider(args.KubeProvider))
-	// Sanitize the secret name to comply with Kubernetes 63-character limit
+	// IgnoreChanges("metadata.namespace") — symmetric with PR #255's IgnoreChanges("metadata.name") on the
+	// Namespace resource itself. PR #230 changed kubernetes.GenerateNamespaceName to suffix custom-stack
+	// namespaces with stackEnv (e.g. "web-app" → "web-app-xcore"), and compute_proc.go feeds that derived
+	// name into args.Metadata.Namespace here. For stacks whose Pulumi state predates #230, the existing
+	// CSQL credential Secret lives in the parent-shared namespace (`web-app`), but the new program wants
+	// `web-app-xcore` — which is immutable on Secret, so Pulumi schedules a Replace. The new Secret then
+	// fails to create because the isolated namespace doesn't exist on the cluster (the Namespace resource
+	// is itself kept in parent-shared by #255's IgnoreChanges). IgnoreChanges suppresses the diff, leaving
+	// the Secret co-located with the consuming pod in the parent namespace — the same trade-off #255 made
+	// for the Namespace. Fresh stacks (no prior state) get the isolated namespace on first create.
 	secretName := util.SanitizeK8sResourceName(args.Name + "-creds")
 	sqlProxySecret, err := v1.NewSecret(ctx, secretName, &v1.SecretArgs{
 		Metadata: args.Metadata,
 		Data:     account.CredentialsSecrets,
-	}, opts...)
+	}, append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clouds/pulumi/gcp/compute_proc.go
+++ b/pkg/clouds/pulumi/gcp/compute_proc.go
@@ -215,14 +215,19 @@ func appendUsesPostgresResourceContext(ctx *sdk.Context, params appendParams) er
 
 func addCloudsqlProxySidecarPreProcessor(ctx *sdk.Context, params appendParams) {
 	params.collector.AddPreProcessor(&kubernetes.SimpleContainerArgs{}, func(arg any) error {
-		cloudsqlProxy, err := createCloudsqlProxy(ctx, params)
-		if err != nil {
-			return errors.Wrapf(err, "failed to create cloudsql proxy for %q in stack %q", params.postgresName, params.stack.Name)
-		}
-
 		kubeArgs, ok := arg.(*kubernetes.SimpleContainerArgs)
 		if !ok {
 			return errors.Errorf("arg is not *kubernetes.Args")
+		}
+		// Live Namespace name from the just-created Namespace resource. Using this
+		// Output (instead of recomputing via kubernetes.GenerateNamespaceName) keeps
+		// the CSQL credential Secret in lock-step with the Namespace under both
+		// fresh deploys (Output resolves to the isolated name) and migrated stacks
+		// where #255's IgnoreChanges("metadata.name") keeps the Namespace's k8s
+		// name parent-shared.
+		cloudsqlProxy, err := createCloudsqlProxy(ctx, params, kubeArgs.NamespaceNameOutput)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create cloudsql proxy for %q in stack %q", params.postgresName, params.stack.Name)
 		}
 		kubeArgs.SidecarOutputs = append(kubeArgs.SidecarOutputs, cloudsqlProxy.ProxyContainer.ApplyT(func(arg any) corev1.ContainerArgs {
 			return arg.(corev1.ContainerArgs)
@@ -239,7 +244,7 @@ func addCloudsqlProxySidecarPreProcessor(ctx *sdk.Context, params appendParams) 
 	})
 }
 
-func createCloudsqlProxy(ctx *sdk.Context, params appendParams) (*CloudSQLProxy, error) {
+func createCloudsqlProxy(ctx *sdk.Context, params appendParams, namespaceOutput sdk.StringInput) (*CloudSQLProxy, error) {
 	// Fix for custom stacks: ensure input.StackParams.ParentEnv is set correctly for proper resource naming
 	if params.provisionParams.ParentStack != nil && params.provisionParams.ParentStack.ParentEnv != "" &&
 		params.provisionParams.ParentStack.ParentEnv != params.input.StackParams.Environment {
@@ -251,16 +256,6 @@ func createCloudsqlProxy(ctx *sdk.Context, params appendParams) (*CloudSQLProxy,
 	// This ensures service accounts are unique per environment (e.g., telegram-bot--on-sidecarcsql--production vs telegram-bot--on-sidecarcsql--staging)
 	baseProxyName := fmt.Sprintf("%s-%s-sidecarcsql", params.stack.Name, params.postgresName)
 	cloudsqlProxyName := kubernetes.SanitizeK8sName(params.input.ToResName(baseProxyName))
-	// The CloudSQL proxy emits a Kubernetes Secret (proxy credentials) that must live in
-	// the same namespace as the consuming pod for it to be mountable. For custom stacks
-	// (parentEnv != stackEnv) the pod namespace is `<stackName>-<stackEnv>` per
-	// kubernetes.GenerateNamespaceName, so derive that here.
-	parentEnv := ""
-	if params.provisionParams.ParentStack != nil {
-		parentEnv = params.provisionParams.ParentStack.ParentEnv
-	}
-	derivedNamespace := kubernetes.GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv)
-	sanitizedNamespace := kubernetes.SanitizeK8sName(derivedNamespace)
 	cloudsqlProxy, err := NewCloudsqlProxy(ctx, CloudSQLProxyArgs{
 		Name: cloudsqlProxyName,
 		DBInstance: PostgresDBInstanceArgs{
@@ -270,7 +265,7 @@ func createCloudsqlProxy(ctx *sdk.Context, params appendParams) (*CloudSQLProxy,
 		},
 		GcpProvider:  params.gcpProvider,
 		KubeProvider: params.kubeProvider,
-		Metadata:     cloudsqlProxyMeta(sanitizedNamespace, cloudsqlProxyName, params),
+		Metadata:     cloudsqlProxyMetaFromOutput(namespaceOutput, cloudsqlProxyName, params),
 	})
 	if err != nil {
 		return nil, err
@@ -354,27 +349,25 @@ func createUserForDatabase(ctx *sdk.Context, userName, dbName string, params app
 		// Sanitize names to comply with Kubernetes RFC 1123 requirements (no underscores)
 		cloudsqlProxyName := kubernetes.SanitizeK8sName(util.TrimStringMiddle(fmt.Sprintf("%s-%s-initcsql", userName, params.postgresName), 60, "-"))
 		// Init job + ad-hoc CloudSQL proxy must live in the same namespace as the consuming
-		// pod so the proxy's credential Secret is mountable. For custom stacks the pod is
-		// in `<stackName>-<stackEnv>` per kubernetes.GenerateNamespaceName.
-		parentEnv := ""
-		if params.provisionParams.ParentStack != nil {
-			parentEnv = params.provisionParams.ParentStack.ParentEnv
-		}
-		namespace := kubernetes.SanitizeK8sName(kubernetes.GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv))
+		// pod so the proxy's credential Secret is mountable. Use the live Namespace.Metadata.Name()
+		// Output from the just-deployed SimpleContainer (instead of recomputing via
+		// GenerateNamespaceName), so we follow #255's IgnoreChanges("metadata.name") on the
+		// Namespace: migrated stacks stay parent-shared, fresh stacks get the isolated name.
+		namespaceOutput := sc.Namespace
 		cloudsqlProxy, err := NewCloudsqlProxy(ctx, CloudSQLProxyArgs{
 			Name:         cloudsqlProxyName,
 			DBInstance:   dbInstanceArgs,
 			GcpProvider:  params.gcpProvider,
 			KubeProvider: params.kubeProvider,
 			TimeoutSec:   MaxInitSQLTimeSec,
-			Metadata:     cloudsqlProxyMeta(namespace, cloudsqlProxyName, params),
+			Metadata:     cloudsqlProxyMetaFromOutput(namespaceOutput, cloudsqlProxyName, params),
 		}, sdk.DependsOn([]sdk.Resource{sc}))
 		if err != nil {
 			return errors.Wrapf(err, "failed to init cloudsql proxy")
 		}
 
 		_, err = NewInitDbUserJob(ctx, userName, InitDbUserJobArgs{
-			Namespace: namespace,
+			Namespace: namespaceOutput,
 			User: CloudsqlDbUser{
 				Database: dbName,
 				Username: userName,
@@ -395,9 +388,9 @@ func createUserForDatabase(ctx *sdk.Context, userName, dbName string, params app
 	return password, nil
 }
 
-func cloudsqlProxyMeta(namespace string, cloudsqlProxyName string, params appendParams) *v1.ObjectMetaArgs {
+func cloudsqlProxyMetaFromOutput(namespace sdk.StringInput, cloudsqlProxyName string, params appendParams) *v1.ObjectMetaArgs {
 	return &v1.ObjectMetaArgs{
-		Namespace: sdk.String(namespace),
+		Namespace: namespace,
 		Name:      sdk.String(cloudsqlProxyName),
 		Labels: sdk.StringMap{
 			kubernetes.LabelAppType: sdk.String(kubernetes.AppTypeSimpleContainer),

--- a/pkg/clouds/pulumi/gcp/init_pg_user_job.go
+++ b/pkg/clouds/pulumi/gcp/init_pg_user_job.go
@@ -53,6 +53,14 @@ func NewInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUserJobArgs
 	opts := args.Opts
 	opts = append(opts, sdk.Provider(args.KubeProvider))
 
+	// IgnoreChanges("metadata.namespace") — see the long rationale on the SqlProxySecret call in
+	// cloudsql_proxy.go. Same problem here: PR #230's GenerateNamespaceName flips this Secret/Job
+	// from parent-shared into the per-stack isolated namespace, which is immutable, which triggers
+	// a Replace, which fails because the isolated namespace doesn't exist on the cluster (the
+	// Namespace resource itself is held in parent-shared by #255). Suppress the diff so the
+	// Secret + Job stay co-located with the consuming pod.
+	nsImmutableOpts := append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))
+
 	// Secret creation
 	jobCredsSecret, err := corev1.NewSecret(ctx, jobCredsName, &corev1.SecretArgs{
 		Metadata: &v1.ObjectMetaArgs{
@@ -63,7 +71,7 @@ func NewInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUserJobArgs
 			"PGPASSWORD": sdk.String(args.RootPassword),
 			"MYSQL_PWD":  sdk.String(args.RootPassword),
 		},
-	}, opts...)
+	}, nsImmutableOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +151,7 @@ psql -h localhost -U postgres -d %s -c 'GRANT pg_write_all_data TO "%s";';
 					},
 				},
 			},
-		}, append(opts, sdk.Provider(kubeProvider))...)
+		}, append(nsImmutableOpts, sdk.Provider(kubeProvider))...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/clouds/pulumi/gcp/init_pg_user_job.go
+++ b/pkg/clouds/pulumi/gcp/init_pg_user_job.go
@@ -36,8 +36,13 @@ type InitDbUserJobArgs struct {
 	CloudSQLProxy  *CloudSQLProxy
 	KubeProvider   *sdkK8s.Provider
 	DBInstanceType CloudsqlInstanceType
-	Namespace      string
-	Opts           []sdk.ResourceOption
+	// Namespace is the live Namespace name Output, threaded from
+	// SimpleContainerArgs.NamespaceNameOutput / SimpleContainer.Namespace via
+	// compute_proc.go. Do not re-derive via kubernetes.GenerateNamespaceName —
+	// that drifts from the actual k8s name on migrated stacks where #255's
+	// IgnoreChanges("metadata.name") keeps the Namespace parent-shared.
+	Namespace sdk.StringInput
+	Opts      []sdk.ResourceOption
 }
 
 type InitUserJob struct {
@@ -53,25 +58,17 @@ func NewInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUserJobArgs
 	opts := args.Opts
 	opts = append(opts, sdk.Provider(args.KubeProvider))
 
-	// IgnoreChanges("metadata.namespace") — see the long rationale on the SqlProxySecret call in
-	// cloudsql_proxy.go. Same problem here: PR #230's GenerateNamespaceName flips this Secret/Job
-	// from parent-shared into the per-stack isolated namespace, which is immutable, which triggers
-	// a Replace, which fails because the isolated namespace doesn't exist on the cluster (the
-	// Namespace resource itself is held in parent-shared by #255). Suppress the diff so the
-	// Secret + Job stay co-located with the consuming pod.
-	nsImmutableOpts := append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))
-
 	// Secret creation
 	jobCredsSecret, err := corev1.NewSecret(ctx, jobCredsName, &corev1.SecretArgs{
 		Metadata: &v1.ObjectMetaArgs{
-			Namespace: sdk.String(args.Namespace),
+			Namespace: args.Namespace,
 			Name:      sdk.String(jobCredsName),
 		},
 		StringData: sdk.StringMap{
 			"PGPASSWORD": sdk.String(args.RootPassword),
 			"MYSQL_PWD":  sdk.String(args.RootPassword),
 		},
-	}, nsImmutableOpts...)
+	}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -84,14 +81,14 @@ func NewInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUserJobArgs
 		if args.DBInstanceType == MySQL {
 			initScript = `
                 set -e;
-                apk add --no-cache mysql-client; 
+                apk add --no-cache mysql-client;
                 sleep 20;
                 # MySQL-specific logic here
             `
 		} else {
 			initScript = fmt.Sprintf(`
 set -e;
-apk add --no-cache postgresql-client; 
+apk add --no-cache postgresql-client;
 sleep 20;
 psql -h localhost -U postgres -d %s -c 'GRANT pg_read_all_data TO "%s";';
 psql -h localhost -U postgres -d %s -c 'GRANT pg_write_all_data TO "%s";';
@@ -129,7 +126,7 @@ psql -h localhost -U postgres -d %s -c 'GRANT pg_write_all_data TO "%s";';
 		job, err := batchv1.NewJob(ctx, jobName, &batchv1.JobArgs{
 			Metadata: &v1.ObjectMetaArgs{
 				Name:      sdk.String(jobName),
-				Namespace: sdk.String(namespace),
+				Namespace: namespace,
 				Annotations: sdk.StringMap{
 					"pulumi.com/patchForce": sdk.String("true"),
 				},
@@ -151,7 +148,7 @@ psql -h localhost -U postgres -d %s -c 'GRANT pg_write_all_data TO "%s";';
 					},
 				},
 			},
-		}, append(nsImmutableOpts, sdk.Provider(kubeProvider))...)
+		}, append(opts, sdk.Provider(kubeProvider))...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/clouds/pulumi/kubernetes/compute_proc_mongodb.go
+++ b/pkg/clouds/pulumi/kubernetes/compute_proc_mongodb.go
@@ -130,18 +130,16 @@ func createMongodbUserForDatabase(ctx *sdk.Context, userName, dbName string, par
 	ctx.Export(passwordName, password.Result)
 
 	// The init job must run in the same namespace as the consuming pod so it can be
-	// observed and cleaned up alongside the workload. For custom stacks (parentEnv != stackEnv)
-	// the pod lives in `<stackName>-<stackEnv>` per GenerateNamespaceName, so derive the same
-	// namespace here. Standard stacks keep the existing `<stackName>` namespace.
-	parentEnv := ""
-	if params.provisionParams.ParentStack != nil {
-		parentEnv = params.provisionParams.ParentStack.ParentEnv
-	}
-	namespace := GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv)
-
+	// observed and cleaned up alongside the workload. Use the live Namespace.Metadata.Name()
+	// Output threaded through SimpleContainerArgs.NamespaceNameOutput — see the matching
+	// rationale in compute_proc_postgres.go.
 	params.collector.AddPreProcessor(&SimpleContainerArgs{}, func(c any) error {
+		kubeArgs, ok := c.(*SimpleContainerArgs)
+		if !ok {
+			return errors.Errorf("arg is not *SimpleContainerArgs")
+		}
 		_, err = NewMongodbInitDbUserJob(ctx, userName, InitDbUserJobArgs{
-			Namespace: namespace,
+			Namespace: kubeArgs.NamespaceNameOutput,
 			User: DatabaseUser{
 				Database: dbName,
 				Username: userName,

--- a/pkg/clouds/pulumi/kubernetes/compute_proc_postgres.go
+++ b/pkg/clouds/pulumi/kubernetes/compute_proc_postgres.go
@@ -211,18 +211,18 @@ func createPostgresUserForDatabase(ctx *sdk.Context, userName, dbName string, pa
 	}
 
 	// The init job must run in the same namespace as the consuming pod so it can be
-	// observed and cleaned up alongside the workload. For custom stacks (parentEnv != stackEnv)
-	// the pod lives in `<stackName>-<stackEnv>` per GenerateNamespaceName, so derive the same
-	// namespace here. Standard stacks keep the existing `<stackName>` namespace.
-	parentEnv := ""
-	if params.provisionParams.ParentStack != nil {
-		parentEnv = params.provisionParams.ParentStack.ParentEnv
-	}
-	namespace := GenerateNamespaceName(params.input.StackParams.StackName, params.input.StackParams.Environment, parentEnv)
-
+	// observed and cleaned up alongside the workload. Use the live Namespace.Metadata.Name()
+	// Output threaded through SimpleContainerArgs.NamespaceNameOutput (set by NewSimpleContainer
+	// after the Namespace is created, before this PreProcessor fires) — recomputing via
+	// GenerateNamespaceName would drift from the actual k8s name on migrated stacks where #255's
+	// IgnoreChanges("metadata.name") keeps the Namespace parent-shared.
 	params.collector.AddPreProcessor(&SimpleContainerArgs{}, func(c any) error {
+		kubeArgs, ok := c.(*SimpleContainerArgs)
+		if !ok {
+			return errors.Errorf("arg is not *SimpleContainerArgs")
+		}
 		_, err = NewPostgresInitDbUserJob(ctx, userName, InitDbUserJobArgs{
-			Namespace: namespace,
+			Namespace: kubeArgs.NamespaceNameOutput,
 			User: DatabaseUser{
 				Database: dbName,
 				Username: userName,

--- a/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
+++ b/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
@@ -20,16 +20,10 @@ func NewMongodbInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUser
 	opts := args.Opts
 	opts = append(opts, sdk.Provider(args.KubeProvider))
 
-	// IgnoreChanges("metadata.namespace") — see the rationale on the postgres init Job's matching call
-	// in init_pg_user_job.go. compute_proc_mongodb.go feeds GenerateNamespaceName's custom-stack-suffixed
-	// value here; without IgnoreChanges, existing stacks would Replace this Secret + the Job below into
-	// an isolated namespace that doesn't exist on the cluster.
-	nsImmutableOpts := append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))
-
 	// Secret creation
 	jobCredsSecret, err := corev1.NewSecret(ctx, jobCredsName, &corev1.SecretArgs{
 		Metadata: &v1.ObjectMetaArgs{
-			Namespace: sdk.String(args.Namespace),
+			Namespace: args.Namespace,
 			Name:      sdk.String(jobCredsName),
 		},
 		StringData: sdk.StringMap{
@@ -43,7 +37,7 @@ func NewMongodbInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUser
 			"ROOT_DATABASE": sdk.String("admin"),
 			"REPLICA_SET":   sdk.String(args.InstanceName),
 		},
-	}, nsImmutableOpts...)
+	}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -71,13 +65,12 @@ mongosh "mongodb://${ROOT_USER}:${ROOT_PASSWORD}@${HOST}/${DB_NAME}?authSource=$
 	}
 
 	kubeProvider := args.KubeProvider
-	namespace := args.Namespace
 
 	// Job creation
 	job, err := batchv1.NewJob(ctx, jobName, &batchv1.JobArgs{
 		Metadata: &v1.ObjectMetaArgs{
 			Name:      sdk.String(jobName),
-			Namespace: sdk.String(namespace),
+			Namespace: args.Namespace,
 			Annotations: sdk.StringMap{
 				"pulumi.com/patchForce": sdk.String("true"),
 			},
@@ -91,7 +84,7 @@ mongosh "mongodb://${ROOT_USER}:${ROOT_PASSWORD}@${HOST}/${DB_NAME}?authSource=$
 				},
 			},
 		},
-	}, append(nsImmutableOpts, sdk.Provider(kubeProvider))...)
+	}, append(opts, sdk.Provider(kubeProvider))...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
+++ b/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
@@ -20,6 +20,12 @@ func NewMongodbInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUser
 	opts := args.Opts
 	opts = append(opts, sdk.Provider(args.KubeProvider))
 
+	// IgnoreChanges("metadata.namespace") — see the rationale on the postgres init Job's matching call
+	// in init_pg_user_job.go. compute_proc_mongodb.go feeds GenerateNamespaceName's custom-stack-suffixed
+	// value here; without IgnoreChanges, existing stacks would Replace this Secret + the Job below into
+	// an isolated namespace that doesn't exist on the cluster.
+	nsImmutableOpts := append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))
+
 	// Secret creation
 	jobCredsSecret, err := corev1.NewSecret(ctx, jobCredsName, &corev1.SecretArgs{
 		Metadata: &v1.ObjectMetaArgs{
@@ -37,7 +43,7 @@ func NewMongodbInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUser
 			"ROOT_DATABASE": sdk.String("admin"),
 			"REPLICA_SET":   sdk.String(args.InstanceName),
 		},
-	}, opts...)
+	}, nsImmutableOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +91,7 @@ mongosh "mongodb://${ROOT_USER}:${ROOT_PASSWORD}@${HOST}/${DB_NAME}?authSource=$
 				},
 			},
 		},
-	}, append(opts, sdk.Provider(kubeProvider))...)
+	}, append(nsImmutableOpts, sdk.Provider(kubeProvider))...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
+++ b/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
@@ -50,18 +50,29 @@ func NewMongodbInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUser
 	// guarantees the postgres init scripts already provide via `IF NOT EXISTS`
 	// guards (pkg/clouds/pulumi/db/constants.go) and `GRANT` idempotency
 	// (pkg/clouds/pulumi/gcp/init_pg_user_job.go).
+	//
+	// Credentials read from process.env inside the mongosh eval rather than shell
+	// interpolation. Pulling them via env (a) bypasses shell quoting entirely so
+	// passwords containing spaces/quotes/$ don't bash-word-split or break JS
+	// parsing, (b) keeps the secret out of `ps`/strace visibility on the
+	// command line. The connection URI itself still has to be shell-interpolated
+	// because mongosh consumes it as its first positional argument, but the user
+	// password is the higher-risk value and is now end-to-end env-bound.
 	createUserScript := `
 set -e;
 mongosh "mongodb://${ROOT_USER}:${ROOT_PASSWORD}@${HOST}/${DB_NAME}?authSource=${ROOT_DATABASE}&readPreference=primary&replicaSet=${REPLICA_SET}" --eval '
+  var dbName = process.env.DB_NAME;
+  var dbUser = process.env.DB_USER;
+  var dbPwd  = process.env.DB_PASSWORD;
   var roles = [
-    {db: "'${DB_NAME}'", role: "dbAdmin"},
-    {db: "'${DB_NAME}'", role: "readWrite"},
+    {db: dbName, role: "dbAdmin"},
+    {db: dbName, role: "readWrite"},
     {db: "local", role: "read"}
   ];
-  if (db.getUser("'${DB_USER}'") === null) {
-    db.createUser({user: "'${DB_USER}'", pwd: "'${DB_PASSWORD}'", roles: roles});
+  if (db.getUser(dbUser) === null) {
+    db.createUser({user: dbUser, pwd: dbPwd, roles: roles});
   } else {
-    db.updateUser("'${DB_USER}'", {pwd: "'${DB_PASSWORD}'", roles: roles});
+    db.updateUser(dbUser, {pwd: dbPwd, roles: roles});
   }
 '
 `

--- a/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
+++ b/pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go
@@ -41,10 +41,29 @@ func NewMongodbInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUser
 	if err != nil {
 		return nil, err
 	}
+	// Idempotent user provisioning: db.createUser errors with code 51003 (DuplicateKey)
+	// if the user already exists, which would break any re-run of this Job — including
+	// the Replace that happens when a consumer follows #255's documented opt-in
+	// namespace migration (`pulumi stack export | jq 'del(...Namespace urn...)' |
+	// pulumi stack import`). Use createUser-or-updateUser semantics so the Job
+	// succeeds on both the first and any subsequent run. Matches the idempotency
+	// guarantees the postgres init scripts already provide via `IF NOT EXISTS`
+	// guards (pkg/clouds/pulumi/db/constants.go) and `GRANT` idempotency
+	// (pkg/clouds/pulumi/gcp/init_pg_user_job.go).
 	createUserScript := `
 set -e;
-mongosh "mongodb://${ROOT_USER}:${ROOT_PASSWORD}@${HOST}/${DB_NAME}?authSource=${ROOT_DATABASE}&readPreference=primary&replicaSet=${REPLICA_SET}" \
-	--eval "db.createUser({user:'${DB_USER}',pwd:'${DB_PASSWORD}',roles:[{db: '${DB_NAME}', role: 'dbAdmin'}, {db: '${DB_NAME}', role: 'readWrite'}, {db: 'local', role: 'read'}]})"
+mongosh "mongodb://${ROOT_USER}:${ROOT_PASSWORD}@${HOST}/${DB_NAME}?authSource=${ROOT_DATABASE}&readPreference=primary&replicaSet=${REPLICA_SET}" --eval '
+  var roles = [
+    {db: "'${DB_NAME}'", role: "dbAdmin"},
+    {db: "'${DB_NAME}'", role: "readWrite"},
+    {db: "local", role: "read"}
+  ];
+  if (db.getUser("'${DB_USER}'") === null) {
+    db.createUser({user: "'${DB_USER}'", pwd: "'${DB_PASSWORD}'", roles: roles});
+  } else {
+    db.updateUser("'${DB_USER}'", {pwd: "'${DB_PASSWORD}'", roles: roles});
+  }
+'
 `
 	// Job Container creation
 	jobContainer := corev1.ContainerArgs{

--- a/pkg/clouds/pulumi/kubernetes/init_pg_user_job.go
+++ b/pkg/clouds/pulumi/kubernetes/init_pg_user_job.go
@@ -24,11 +24,15 @@ type InitDbUserJobArgs struct {
 	RootUser     string
 	RootPassword string
 	KubeProvider sdk.ProviderResource
-	Namespace    string
-	Host         string
-	Port         string
-	InitSQL      string
-	Opts         []sdk.ResourceOption
+	// Namespace is the live Namespace name Output, threaded through from
+	// SimpleContainerArgs.NamespaceNameOutput via compute_proc_postgres.go and
+	// compute_proc_mongodb.go. Do not re-derive via GenerateNamespaceName —
+	// see the long rationale on the matching field in gcp.InitDbUserJobArgs.
+	Namespace sdk.StringInput
+	Host      string
+	Port      string
+	InitSQL   string
+	Opts      []sdk.ResourceOption
 }
 
 type InitUserJob struct {
@@ -42,20 +46,10 @@ func NewPostgresInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUse
 	opts := args.Opts
 	opts = append(opts, sdk.Provider(args.KubeProvider))
 
-	// IgnoreChanges("metadata.namespace") — symmetric with PR #255's IgnoreChanges("metadata.name")
-	// on the Namespace and the matching GCP CSQL fix in pkg/clouds/pulumi/gcp/. compute_proc_postgres.go
-	// derives the namespace via kubernetes.GenerateNamespaceName (which suffixes custom-stack stackEnv
-	// after #230); for existing stacks whose state predates #230 the previous value was the parent-shared
-	// namespace, so the diff schedules an immutable-namespace Replace that fails because the isolated
-	// namespace was never created (the Namespace itself is held parent-shared by #255). Suppress the diff
-	// so this Secret + the Job below stay co-located with the consuming pod. Fresh stacks still get the
-	// isolated namespace on initial create — IgnoreChanges only suppresses *diff*, not *initial value*.
-	nsImmutableOpts := append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))
-
 	// Secret creation
 	jobCredsSecret, err := corev1.NewSecret(ctx, jobCredsName, &corev1.SecretArgs{
 		Metadata: &v1.ObjectMetaArgs{
-			Namespace: sdk.String(args.Namespace),
+			Namespace: args.Namespace,
 			Name:      sdk.String(jobCredsName),
 		},
 		StringData: sdk.StringMap{
@@ -69,7 +63,7 @@ func NewPostgresInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUse
 			"PGDATABASE":  sdk.String("postgres"),
 			"INIT_SQL":    sdk.String(args.InitSQL),
 		},
-	}, nsImmutableOpts...)
+	}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -92,13 +86,12 @@ func NewPostgresInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUse
 	}
 
 	kubeProvider := args.KubeProvider
-	namespace := args.Namespace
 
 	// Job creation
 	job, err := batchv1.NewJob(ctx, jobName, &batchv1.JobArgs{
 		Metadata: &v1.ObjectMetaArgs{
 			Name:      sdk.String(jobName),
-			Namespace: sdk.String(namespace),
+			Namespace: args.Namespace,
 			Annotations: sdk.StringMap{
 				"pulumi.com/patchForce": sdk.String("true"),
 			},
@@ -112,7 +105,7 @@ func NewPostgresInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUse
 				},
 			},
 		},
-	}, append(nsImmutableOpts, sdk.Provider(kubeProvider))...)
+	}, append(opts, sdk.Provider(kubeProvider))...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clouds/pulumi/kubernetes/init_pg_user_job.go
+++ b/pkg/clouds/pulumi/kubernetes/init_pg_user_job.go
@@ -42,6 +42,16 @@ func NewPostgresInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUse
 	opts := args.Opts
 	opts = append(opts, sdk.Provider(args.KubeProvider))
 
+	// IgnoreChanges("metadata.namespace") — symmetric with PR #255's IgnoreChanges("metadata.name")
+	// on the Namespace and the matching GCP CSQL fix in pkg/clouds/pulumi/gcp/. compute_proc_postgres.go
+	// derives the namespace via kubernetes.GenerateNamespaceName (which suffixes custom-stack stackEnv
+	// after #230); for existing stacks whose state predates #230 the previous value was the parent-shared
+	// namespace, so the diff schedules an immutable-namespace Replace that fails because the isolated
+	// namespace was never created (the Namespace itself is held parent-shared by #255). Suppress the diff
+	// so this Secret + the Job below stay co-located with the consuming pod. Fresh stacks still get the
+	// isolated namespace on initial create — IgnoreChanges only suppresses *diff*, not *initial value*.
+	nsImmutableOpts := append(opts, sdk.IgnoreChanges([]string{"metadata.namespace"}))
+
 	// Secret creation
 	jobCredsSecret, err := corev1.NewSecret(ctx, jobCredsName, &corev1.SecretArgs{
 		Metadata: &v1.ObjectMetaArgs{
@@ -59,7 +69,7 @@ func NewPostgresInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUse
 			"PGDATABASE":  sdk.String("postgres"),
 			"INIT_SQL":    sdk.String(args.InitSQL),
 		},
-	}, opts...)
+	}, nsImmutableOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +112,7 @@ func NewPostgresInitDbUserJob(ctx *sdk.Context, stackName string, args InitDbUse
 				},
 			},
 		},
-	}, append(opts, sdk.Provider(kubeProvider))...)
+	}, append(nsImmutableOpts, sdk.Provider(kubeProvider))...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clouds/pulumi/kubernetes/namespace_threading_test.go
+++ b/pkg/clouds/pulumi/kubernetes/namespace_threading_test.go
@@ -87,19 +87,31 @@ func TestDownstreamCallSitesDoNotRecomputeNamespace(t *testing.T) {
 					if !ok {
 						return true
 					}
-					var ident *ast.Ident
+					// Match only the package-level function in the `kubernetes` pkg, not arbitrary
+					// methods that happen to share the name (e.g. mockClient.GenerateNamespaceName()).
+					// Two valid call shapes:
+					//   - bare identifier:        GenerateNamespaceName(...)            // same-package
+					//   - qualified selector:     kubernetes.GenerateNamespaceName(...) // cross-pkg
 					switch fun := call.Fun.(type) {
 					case *ast.Ident:
-						ident = fun
+						if fun.Name != "GenerateNamespaceName" {
+							return true
+						}
 					case *ast.SelectorExpr:
-						ident = fun.Sel
+						if fun.Sel.Name != "GenerateNamespaceName" {
+							return true
+						}
+						pkg, ok := fun.X.(*ast.Ident)
+						if !ok || pkg.Name != "kubernetes" {
+							return true
+						}
+					default:
+						return true
 					}
-					if ident != nil && ident.Name == "GenerateNamespaceName" {
-						t.Errorf(
-							"%s:%d: %s() calls GenerateNamespaceName — see PR #258. %s",
-							s.file, fset.Position(call.Pos()).Line, fn.Name.Name, s.reason,
-						)
-					}
+					t.Errorf(
+						"%s:%d: %s() calls kubernetes.GenerateNamespaceName — see PR #258. %s",
+						s.file, fset.Position(call.Pos()).Line, fn.Name.Name, s.reason,
+					)
 					return true
 				})
 			}

--- a/pkg/clouds/pulumi/kubernetes/namespace_threading_test.go
+++ b/pkg/clouds/pulumi/kubernetes/namespace_threading_test.go
@@ -1,0 +1,125 @@
+package kubernetes
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+// TestDownstreamCallSitesDoNotRecomputeNamespace is a regression guard for #258.
+//
+// Before #258, four downstream Secret/Job call sites independently re-derived their
+// k8s namespace via kubernetes.GenerateNamespaceName(stackName, stackEnv, parentEnv).
+// That recomputation drifted from the live Namespace resource's metadata.Name on any
+// migrated stack (where #255's IgnoreChanges keeps the Namespace in parent-shared
+// state), scheduled an immutable-namespace Pulumi Replace, and failed because the
+// isolated namespace doesn't exist on the cluster.
+//
+// #258 replaced the recomputation with Output-threading: NewSimpleContainer sets
+// SimpleContainerArgs.NamespaceNameOutput from namespace.Metadata.Name().Elem()
+// before RunPreProcessors fires, and the four downstream consumers now read that
+// Output (preprocessor path) or sc.Namespace (postprocessor path) instead.
+//
+// This test fails if a future change reintroduces GenerateNamespaceName inside any
+// of those consumer functions. If the test breaks, do NOT call GenerateNamespaceName
+// from the listed functions — thread the namespace Output through
+// SimpleContainerArgs / SimpleContainer instead. The recomputation hazard is
+// documented in #258's commit history and in the long comment in simple_container.go
+// next to the Namespace resource.
+func TestDownstreamCallSitesDoNotRecomputeNamespace(t *testing.T) {
+	type site struct {
+		file      string
+		forbidden []string
+		reason    string
+	}
+
+	sites := []site{
+		{
+			file:      filepath.Join("..", "gcp", "compute_proc.go"),
+			forbidden: []string{"createCloudsqlProxy", "createUserForDatabase"},
+			reason: "GCP CSQL sidecar/init proxy consumers must consume the namespace Output threaded " +
+				"via kubernetes.SimpleContainerArgs.NamespaceNameOutput (preprocessor path) or " +
+				"SimpleContainer.Namespace (postprocessor path), not recompute it.",
+		},
+		{
+			file:      "compute_proc_postgres.go",
+			forbidden: []string{"createPostgresUserForDatabase"},
+			reason: "On-cluster postgres init Job consumer must consume the namespace Output threaded " +
+				"via SimpleContainerArgs.NamespaceNameOutput, not recompute it.",
+		},
+		{
+			file:      "compute_proc_mongodb.go",
+			forbidden: []string{"createMongodbUserForDatabase"},
+			reason: "On-cluster mongodb init Job consumer must consume the namespace Output threaded " +
+				"via SimpleContainerArgs.NamespaceNameOutput, not recompute it.",
+		},
+	}
+
+	for _, s := range sites {
+		s := s
+		t.Run(filepath.Base(s.file), func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, s.file, nil, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse %s: %v", s.file, err)
+			}
+
+			forbidden := make(map[string]struct{}, len(s.forbidden))
+			for _, fn := range s.forbidden {
+				forbidden[fn] = struct{}{}
+			}
+			covered := make(map[string]bool, len(s.forbidden))
+
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				if _, watched := forbidden[fn.Name.Name]; !watched {
+					continue
+				}
+				covered[fn.Name.Name] = true
+
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					var ident *ast.Ident
+					switch fun := call.Fun.(type) {
+					case *ast.Ident:
+						ident = fun
+					case *ast.SelectorExpr:
+						ident = fun.Sel
+					}
+					if ident != nil && ident.Name == "GenerateNamespaceName" {
+						t.Errorf(
+							"%s:%d: %s() calls GenerateNamespaceName — see PR #258. %s",
+							s.file, fset.Position(call.Pos()).Line, fn.Name.Name, s.reason,
+						)
+					}
+					return true
+				})
+			}
+
+			for _, want := range s.forbidden {
+				if !covered[want] {
+					t.Errorf("function %s not found in %s — was it renamed or removed? Update this test.", want, s.file)
+				}
+			}
+		})
+	}
+}
+
+// TestSimpleContainerArgsCarriesNamespaceNameOutput is a compile-time-style guard
+// that SimpleContainerArgs exposes the NamespaceNameOutput field. The four
+// downstream consumers (see TestDownstreamCallSitesDoNotRecomputeNamespace) read
+// namespaces from this field; removing or renaming it silently regresses #258. If
+// this test fails, preserve the field name (and the assignment in
+// NewSimpleContainer) or update the four consumer call sites in lock-step.
+func TestSimpleContainerArgsCarriesNamespaceNameOutput(t *testing.T) {
+	var args SimpleContainerArgs
+	_ = args.NamespaceNameOutput // compile-time field presence check
+}

--- a/pkg/clouds/pulumi/kubernetes/namespace_threading_test.go
+++ b/pkg/clouds/pulumi/kubernetes/namespace_threading_test.go
@@ -5,8 +5,39 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
+
+// kubernetesPkgPath is the import path of *this* package. The AST regression
+// guard below resolves whichever local name a consumer file imports it under
+// (default `kubernetes`, or any alias like `k8s "<path>"`) so the strict
+// selector check also catches `<alias>.GenerateNamespaceName(...)` and not
+// only the un-aliased form.
+const kubernetesPkgPath = "github.com/simple-container-com/api/pkg/clouds/pulumi/kubernetes"
+
+// kubernetesPkgAliases parses the file's import block and returns the set of
+// local identifiers that bind to kubernetesPkgPath. Same-package files (no
+// import of self) return an empty set — the caller falls back to matching the
+// bare-identifier `GenerateNamespaceName(...)` form for those.
+func kubernetesPkgAliases(file *ast.File) map[string]bool {
+	aliases := map[string]bool{}
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != kubernetesPkgPath {
+			continue
+		}
+		name := "kubernetes"
+		if imp.Name != nil {
+			name = imp.Name.Name
+		}
+		aliases[name] = true
+	}
+	return aliases
+}
 
 // TestDownstreamCallSitesDoNotRecomputeNamespace is a regression guard for #258.
 //
@@ -61,7 +92,12 @@ func TestDownstreamCallSitesDoNotRecomputeNamespace(t *testing.T) {
 		s := s
 		t.Run(filepath.Base(s.file), func(t *testing.T) {
 			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, s.file, nil, parser.SkipObjectResolution)
+			file, err := parser.ParseFile(fset, s.file, nil, parser.SkipObjectResolution|parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse imports of %s: %v", s.file, err)
+			}
+			aliases := kubernetesPkgAliases(file)
+			file, err = parser.ParseFile(fset, s.file, nil, parser.SkipObjectResolution)
 			if err != nil {
 				t.Fatalf("parse %s: %v", s.file, err)
 			}
@@ -91,7 +127,10 @@ func TestDownstreamCallSitesDoNotRecomputeNamespace(t *testing.T) {
 					// methods that happen to share the name (e.g. mockClient.GenerateNamespaceName()).
 					// Two valid call shapes:
 					//   - bare identifier:        GenerateNamespaceName(...)            // same-package
-					//   - qualified selector:     kubernetes.GenerateNamespaceName(...) // cross-pkg
+					//   - qualified selector:     <alias>.GenerateNamespaceName(...)    // cross-pkg
+					// where <alias> is resolved from the file's import block via kubernetesPkgAliases.
+					// Default name is `kubernetes` when no alias is set; the test still flags imports
+					// renamed as e.g. `k8s "<path>"`.
 					switch fun := call.Fun.(type) {
 					case *ast.Ident:
 						if fun.Name != "GenerateNamespaceName" {
@@ -102,7 +141,7 @@ func TestDownstreamCallSitesDoNotRecomputeNamespace(t *testing.T) {
 							return true
 						}
 						pkg, ok := fun.X.(*ast.Ident)
-						if !ok || pkg.Name != "kubernetes" {
+						if !ok || !aliases[pkg.Name] {
 							return true
 						}
 					default:

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -141,6 +141,18 @@ type SimpleContainerArgs struct {
 	UseSSL                        bool
 	EphemeralSize                 string
 	TerminationGracePeriodSeconds *int
+
+	// NamespaceNameOutput is the live k8s name of the Namespace resource — set by
+	// NewSimpleContainer right after the Namespace is created and before
+	// RunPreProcessors fires. Pre/post-processors (e.g. CSQL sidecar in
+	// pkg/clouds/pulumi/gcp/compute_proc.go) must use this Output instead of
+	// recomputing the namespace via kubernetes.GenerateNamespaceName(stackName,
+	// stackEnv, parentEnv): the Namespace carries IgnoreChanges("metadata.name")
+	// (see #255), so its k8s name is the *state* name (parent-shared for
+	// migrated stacks, isolated for fresh stacks), not whatever
+	// GenerateNamespaceName would derive. Consuming this Output keeps
+	// downstream resources in lock-step with the Namespace through both modes.
+	NamespaceNameOutput sdk.StringOutput
 }
 
 type SimpleContainer struct {
@@ -269,6 +281,12 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	if err != nil {
 		return nil, err
 	}
+
+	// Expose the live Namespace name to pre/post-processors. See the comment on
+	// NamespaceNameOutput in SimpleContainerArgs: GCP CSQL and K8s on-cluster
+	// init Jobs need this Output (not GenerateNamespaceName) to land in the
+	// same namespace as the consuming pod under both fresh and migrated state.
+	args.NamespaceNameOutput = namespace.Metadata.Name().Elem()
 
 	// run pre-processors after namespace is created, but before deployment is created
 	if args.ComputeContext != nil {

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -264,21 +264,28 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	//    migrated consumers continue using the shared one. Combined with
 	//    RetainOnDelete this keeps both modes safe.
 	//
-	//    Downstream Secret/Job resources created by pre/post-processors (GCP
-	//    CloudSQL credentials in pkg/clouds/pulumi/gcp/cloudsql_proxy.go +
-	//    gcp/init_pg_user_job.go; on-cluster postgres + mongo init Jobs in
-	//    pkg/clouds/pulumi/kubernetes/init_{pg,mongo}_user_job.go) consume the
-	//    live namespace via SimpleContainerArgs.NamespaceNameOutput (set a few
-	//    lines below from namespace.Metadata.Name().Elem()) rather than
-	//    recomputing it via GenerateNamespaceName. That keeps them in lock-step
-	//    with whatever metadata.Name is in state — fresh stacks get the
-	//    isolated namespace, migrated stacks stay parent-shared — without
-	//    needing IgnoreChanges("metadata.namespace") on every individual
-	//    Secret/Job. Migrating an existing custom stack from parent-shared to
-	//    isolated namespace is therefore automatic via `pulumi stack export |
-	//    jq 'del(... namespace urn ...)' | pulumi stack import` (forget the
-	//    Namespace resource, then `pulumi up` creates a fresh Namespace at the
-	//    isolated name and the downstream consumers follow it). See PR #258.
+	//    Downstream Secret/Job resources consume the live namespace via
+	//    SimpleContainerArgs.NamespaceNameOutput (set a few lines below from
+	//    namespace.Metadata.Name().Elem()) rather than recomputing it via
+	//    GenerateNamespaceName. The three pre/post-processor call sites that
+	//    consume this Output live in:
+	//
+	//      pkg/clouds/pulumi/gcp/compute_proc.go                 (GCP CSQL sidecar + init proxies)
+	//      pkg/clouds/pulumi/kubernetes/compute_proc_postgres.go (on-cluster postgres init Job)
+	//      pkg/clouds/pulumi/kubernetes/compute_proc_mongodb.go  (on-cluster mongo init Job)
+	//
+	//    From there the namespace flows into NewCloudsqlProxy /
+	//    NewPostgresInitDbUserJob / NewMongodbInitDbUserJob as an
+	//    sdk.StringInput, so the leaf Secret/Job ObjectMeta.Namespace tracks
+	//    the live Output. That keeps them in lock-step with whatever
+	//    metadata.Name is in state — fresh stacks get the isolated namespace,
+	//    migrated stacks stay parent-shared — without needing
+	//    IgnoreChanges("metadata.namespace") on every individual Secret/Job.
+	//    Migrating an existing custom stack from parent-shared to isolated
+	//    namespace is therefore automatic via `pulumi stack export | jq
+	//    'del(... namespace urn ...)' | pulumi stack import` (forget the
+	//    Namespace resource, then `pulumi up` creates a fresh Namespace at
+	//    the isolated name and the downstream consumers follow it). See PR #258.
 	namespaceResourceName := fmt.Sprintf("%s-ns", sanitizedDeployment)
 	namespace, err := corev1.NewNamespace(ctx, namespaceResourceName, &corev1.NamespaceArgs{
 		Metadata: &metav1.ObjectMetaArgs{

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -231,8 +231,8 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	// while keeping the actual K8s namespace name as specified by the user.
 	//
 	// Namespace-handling has two protections against the destroy/Replace cascade
-	// hazard discovered in pre-PR-230 deploys (see PR #230 and the 2026-05-10
-	// PAY-SPACE + 2026-05-12 fulldiveVR outages):
+	// hazard discovered in pre-PR-230 deploys (see PR #230 and the consumer-side
+	// outages tracked in #255):
 	//
 	// 1. RetainOnDelete(true). In legacy deploys, sub-env client stacks
 	//    (parentEnv=<prod> with stackEnv=tenant-a/tenant-b/...) shared one
@@ -264,12 +264,21 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 	//    migrated consumers continue using the shared one. Combined with
 	//    RetainOnDelete this keeps both modes safe.
 	//
-	//    Consumers who want to migrate an existing custom stack to the
-	//    isolated namespace name opt in by running
-	//      pulumi stack export | jq 'del(... namespace urn ...)' | pulumi stack import
-	//    (forget the namespace resource — k8s namespace itself stays put),
-	//    then the next pulumi up registers a fresh Namespace at the isolated
-	//    name. Documented in the PR description.
+	//    Downstream Secret/Job resources created by pre/post-processors (GCP
+	//    CloudSQL credentials in pkg/clouds/pulumi/gcp/cloudsql_proxy.go +
+	//    gcp/init_pg_user_job.go; on-cluster postgres + mongo init Jobs in
+	//    pkg/clouds/pulumi/kubernetes/init_{pg,mongo}_user_job.go) consume the
+	//    live namespace via SimpleContainerArgs.NamespaceNameOutput (set a few
+	//    lines below from namespace.Metadata.Name().Elem()) rather than
+	//    recomputing it via GenerateNamespaceName. That keeps them in lock-step
+	//    with whatever metadata.Name is in state — fresh stacks get the
+	//    isolated namespace, migrated stacks stay parent-shared — without
+	//    needing IgnoreChanges("metadata.namespace") on every individual
+	//    Secret/Job. Migrating an existing custom stack from parent-shared to
+	//    isolated namespace is therefore automatic via `pulumi stack export |
+	//    jq 'del(... namespace urn ...)' | pulumi stack import` (forget the
+	//    Namespace resource, then `pulumi up` creates a fresh Namespace at the
+	//    isolated name and the downstream consumers follow it). See PR #258.
 	namespaceResourceName := fmt.Sprintf("%s-ns", sanitizedDeployment)
 	namespace, err := corev1.NewNamespace(ctx, namespaceResourceName, &corev1.NamespaceArgs{
 		Metadata: &metav1.ObjectMetaArgs{


### PR DESCRIPTION
## Status

Five commits, sanitized. Verified end-to-end on a real downstream deploy (custom-env stack consuming GCP CloudSQL with `parentEnv != stackEnv`). Codex + Gemini reviewed each commit independently; final commit (`6c5f2ab`) clean on both.

## Problem

#255 added `IgnoreChanges("metadata.name")` to the Namespace resource so PR #230's "isolated namespace per custom stack" rename no longer cascade-deletes the parent-shared namespace. But 8 downstream resources still recomputed their own `namespace` field via `kubernetes.GenerateNamespaceName(...)`:

| Path | Resources |
| --- | --- |
| GCP CloudSQL (`pkg/clouds/pulumi/gcp/`) | sidecar-proxy creds Secret, init-time proxy creds Secret, db-user-init creds Secret, db-user-init Job |
| K8s on-cluster Postgres (`pkg/clouds/pulumi/kubernetes/init_pg_user_job.go`) | jobCredsSecret, Job |
| K8s on-cluster MongoDB (`pkg/clouds/pulumi/kubernetes/init_mongo_user_job.go`) | jobCredsSecret, Job |

On a migrated stack the recomputed name diverged from the (now-frozen by #255) Namespace name. `namespace` is immutable on Secret/Job → Pulumi schedules Replace → fails because the isolated namespace doesn't exist (the Namespace itself is held parent-shared by #255).

Observed Pulumi plan on the affected stack:

```
~ Namespace <stack>-ns
    [id=<stack>]                              ← held parent-shared by #255

+- Secret postgres-…-sidecarcsql-…-creds     namespace: "<stack>" => "<stack>-<custom-env>"
+- Secret postgres-…-initcsql-creds          namespace: "<stack>" => "<stack>-<custom-env>"
+- Secret db-user-init-creds                 namespace: "<stack>" => "<stack>-<custom-env>"
+- Job    db-user-init                       namespace: "<stack>" => "<stack>-<custom-env>"
```

All four Replace operations fail identically:
```
Retry #5; creation failed: namespaces "<stack>-<custom-env>" not found
error: update failed
```

## Commits

| SHA | Title | Why |
| --- | --- | --- |
| `9b57aa3` | hotfix: `IgnoreChanges(metadata.namespace)` on 4 GCP CSQL resources | First-line containment so affected deploys unblock |
| `29e5be1` | extend hotfix to 4 K8s on-cluster init resources (postgres + mongo) | Same pattern, surfaced by Gemini review |
| `8fc73fa` | **ROOT-CAUSE**: thread `Namespace.Metadata.Name()` Output, drop all `IgnoreChanges` | Closes the migration-path edge case Codex flagged on the hotfix — downstream resources track the live Namespace name dynamically |
| `c16b2fc` | Mongo init Job idempotency: `createUser`-or-`updateUser` | Now that the Mongo Job Replaces during opt-in migration, `createUser` would fail with DuplicateKey on second run |
| `6c5f2ab` | Mongo: read credentials via `process.env` in mongosh | Shell single-quote-breakout pattern was word-split-vulnerable for unusual passwords |

## Final state by scenario

| Scenario | `Namespace.Metadata.Name()` resolves to | Downstream secrets land in | Outcome |
| --- | --- | --- | --- |
| Fresh custom-env stack | isolated name (first create) | isolated namespace | Co-located with pod ✓ |
| Migrated stack (state predates #230) | parent-shared name, frozen by #255 | parent-shared namespace | No diff, no Replace ✓ |
| Documented opt-in migration (`jq del Namespace urn`) | isolated name after fresh create | isolated namespace (Mongo init now idempotent so it survives the Replace) | Pod and Secrets move together ✓ |

## Review history

| Commit | Codex | Gemini |
| --- | --- | --- |
| `9b57aa3` (hotfix) | P2: opt-in migration broken by IgnoreChanges-pin | — |
| `29e5be1` (k8s extend) | — | P0: K8s provider also affected (now covered) |
| `8fc73fa` (root-cause) | P2: Mongo non-idempotent on opt-in Replace | clean |
| `c16b2fc` (mongo idempotency) | P2: shell quoting | P0: word-split |
| `6c5f2ab` (mongo process.env) | **clean** | **clean** (P2 cosmetic: root URI URL-encoding, pre-existing) |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass except `pkg/security/scan` integration (stale grype DB, environment issue, unrelated)
- [x] Branch-preview builds for every commit
- [x] Codex + Gemini reviewed each commit independently; final commit clean on both
- [x] Codex executed `alpine/mongosh:latest` in Docker to verify `process.env` semantics (`bar baz` test value with whitespace confirmed clean)
- [x] Real downstream deploy on a custom-env stack with GCP CloudSQL `parentEnv != stackEnv`: 5 replace-failures pre-fix → 0 namespace failures post-fix, 2 legitimate Replace operations (stringData diff on config Secret + spec diff on init Job) both succeed. Database / DB user / DB password resources all `same`.

## Out of scope (filed separately)

Gemini final flagged a pre-existing root-URI URL-encoding risk in `init_mongo_user_job.go`:
```
mongosh "mongodb://${ROOT_USER}:${ROOT_PASSWORD}@…"
```
would mis-parse if `ROOT_PASSWORD` contains `@`, `:`, `/`, or `%`. Fix is to switch to `--username` / `--password` flags. Pre-existing on master, not introduced here, not blocking.
