### PR TITLE
fix(ci): filter download-artifact pattern in push.yaml docker-finalize

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -588,9 +588,19 @@ jobs:
           ${{ secrets.SC_CONFIG }}
           EOF
           sc secrets reveal
-      - name: download all build artifacts
+      - name: download sc tarball artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
+          # Filter to sc-* artifacts only — without a pattern, this step
+          # also pulls the build-push-action's internal `*.dockerbuild`
+          # cache artifacts (one per matrix item, often 100+ MB each) and
+          # the `image-digest-*` artifacts we publish for
+          # verify-attestations.yml to consume. None of those are needed
+          # here, and the .dockerbuild ones flake the parallel-download
+          # path: PR #257's first prod release (run 25959575686) failed
+          # at this step with "Artifact download failed after 5 retries"
+          # because the unfiltered download saturated the runner.
+          pattern: sc-*
           path: artifacts
       - name: download bin tools artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0


### PR DESCRIPTION
## Hotfix — first prod release after PR #257 failed

The first signed prod release that fired on PR #257's merge ([run 25959575686](https://github.com/simple-container-com/api/actions/runs/25959575686), commit `62185dc`) **failed** at the `download all build artifacts` step in `docker-finalize`. Net effect:

- ✅ Images **shipped to Docker Hub** with cosign signatures + SBOM + SLSA provenance
- ❌ SC CLI tarballs **never reached** `dist.simple-container.com`
- ❌ No git release tag pushed
- ❌ Welder deploy didn't run

## Root cause

The step ran `actions/download-artifact@v4` with no `pattern:`, so it tried to pull **every** artifact in the run. PR #257 added two artifact classes this step doesn't need:

1. `image-digest-<image>` (4 per release) — small, consumed by `verify-attestations.yml`.
2. `*.dockerbuild` (4 per release) — **auto-uploaded by `docker/build-push-action@v7.1.0`** as build-cache artifacts, often 100+ MB each.

The unfiltered parallel download started ~15 artifacts in parallel; one of the large `.dockerbuild` artifacts flaked beyond the 5-retry budget → whole step failed.

`branch-preview.yaml`'s `publish-sc-preview` already filters via `pattern: sc-*` (added when that workflow was set up). `push.yaml docker-finalize` didn't. Matching the pattern here.

## Fix

```yaml
- name: download sc tarball artifacts
  uses: actions/download-artifact@<SHA>
  with:
    pattern: sc-*        # ← added
    path: artifacts
```

One-line change. The two subsequent `download-artifact` steps in the same job already filter by name (`bin-tools`, `docs-site`), so they're unaffected.

## Recovery plan

- Merging this hotfix retriggers `push.yaml` on `main` → produces the actual first signed prod release with tarballs on dist + git release tag.
- Docker Hub images from the failed run are already signed (verified manually with `cosign verify`); the new run will produce a new calver version that supersedes.
- After this run goes green: run the documented consumer verification commands against the freshly-shipped tarballs, then proceed with the OpenSSF score work.

## Why this wasn't caught by the 7 review rounds + 3 preview empirical runs

- The preview path (`branch-preview.yaml`) **already had** `pattern: sc-*`. Empirical preview runs exercised the filtered path.
- The unfiltered path lived in `push.yaml` `docker-finalize`, which was reachable only by an actual merge to `main`.
- `actionlint` + `semgrep` don't flag missing `pattern:` on `download-artifact`.

Test plan for future: any new artifact-uploading step should be cross-checked against every `download-artifact` consumer for unintended pickup.