### PR TITLE
chore(docs): bump example Dockerfiles to Node 22 LTS + Caddy 2.11, SHA-pinned

### DIFF
--- a/docs/docs/examples/advanced-configs/high-resource/Dockerfile
+++ b/docs/docs/examples/advanced-configs/high-resource/Dockerfile
@@ -1,5 +1,5 @@
 # AI Development Environment Dockerfile
-FROM node:18-alpine
+FROM node:22-alpine@sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c
 
 # Install system dependencies
 RUN apk add --no-cache \

--- a/docs/docs/examples/ecs-deployments/backend-service/Dockerfile
+++ b/docs/docs/examples/ecs-deployments/backend-service/Dockerfile
@@ -1,5 +1,5 @@
 # Node.js backend service Dockerfile
-FROM node:18-alpine
+FROM node:22-alpine@sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c
 
 # Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init curl

--- a/docs/docs/examples/ecs-deployments/blockchain-service/Dockerfile
+++ b/docs/docs/examples/ecs-deployments/blockchain-service/Dockerfile
@@ -1,5 +1,5 @@
 # Node.js blockchain service Dockerfile
-FROM node:18-alpine
+FROM node:22-alpine@sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c
 
 # Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init curl

--- a/docs/docs/examples/ecs-deployments/blog-platform/caddy.Dockerfile
+++ b/docs/docs/examples/ecs-deployments/blog-platform/caddy.Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:2.7-alpine
+FROM caddy:2.11-alpine@sha256:3739ea4f0c877259a693d932693cf8f3408e9a9497c004f031b0e830e93e1546
 
 # Copy custom Caddyfile
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/docs/docs/examples/ecs-deployments/meteor-app/Dockerfile
+++ b/docs/docs/examples/ecs-deployments/meteor-app/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for Meteor.js application
-FROM node:18-alpine AS builder
+FROM node:22-alpine@sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c AS builder
 
 # Install Meteor
 RUN npm install -g meteor
@@ -21,7 +21,7 @@ RUN meteor npm install
 RUN meteor build --directory /app/build --architecture os.linux.x86_64
 
 # Production stage
-FROM node:18-alpine
+FROM node:22-alpine@sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c
 
 # Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init

--- a/docs/docs/examples/kubernetes-native/streaming-platform/Dockerfile
+++ b/docs/docs/examples/kubernetes-native/streaming-platform/Dockerfile
@@ -1,5 +1,5 @@
 # Node.js streaming platform Dockerfile
-FROM node:18-alpine
+FROM node:22-alpine@sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c
 
 # Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init curl

--- a/docs/docs/examples/kubernetes-vpa/Dockerfile
+++ b/docs/docs/examples/kubernetes-vpa/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine@sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why

Docs/examples were teaching consumers an EOL pattern.

- `node:18-alpine` → **EOL April 2025**, last Docker Hub push 2025-03-27 (~14 months ago). No security updates since.
- `node:22-alpine` is the current active LTS (supported until October 2027), refreshed this week.
- `caddy:2.7-alpine` last updated May 2024; `caddy:2.11-alpine` is current stable, refreshed this week.

Two improvements in one pass:

1. **Bump base images** to current LTS / stable across all 7 example Dockerfiles in `docs/docs/examples/`.
2. **Pin every `FROM` by `@sha256:<digest>`** — modeling the secure-by-default practice we recommend for production. Anyone copying these as a starting point now inherits a pinned, deterministic, reproducible build.

## Side benefit — OpenSSF Scorecard

Closes 8 of the `Pinned-Dependencies` warnings (containerImage findings). Score should bump from 6/10 → ~7-8/10 on next Scorecard rescan.

## Digests used

Resolved via Docker Hub registry API on 2026-05-16:

| Image | Tag | Digest |
|---|---|---|
| `node` | `22-alpine` | `sha256:757ec364de4d37cedf30871be2988927660834e656e9aa52aad9ac194814c30c` |
| `caddy` | `2.11-alpine` | `sha256:3739ea4f0c877259a693d932693cf8f3408e9a9497c004f031b0e830e93e1546` |

## Files touched

```
docs/docs/examples/advanced-configs/high-resource/Dockerfile
docs/docs/examples/ecs-deployments/backend-service/Dockerfile
docs/docs/examples/ecs-deployments/blockchain-service/Dockerfile
docs/docs/examples/ecs-deployments/blog-platform/caddy.Dockerfile
docs/docs/examples/ecs-deployments/meteor-app/Dockerfile        (multi-stage: 2 FROM lines)
docs/docs/examples/kubernetes-native/streaming-platform/Dockerfile
docs/docs/examples/kubernetes-vpa/Dockerfile
```

## Test plan

- [x] All Dockerfiles still parse (FROM syntax preserved)
- [ ] mkdocs builds these as documentation pages — no syntax that would break MD rendering (just code blocks)
- [ ] Follow-up after merge: confirm Scorecard rescan picks up the change (next daily cron after merge)

Part of the [OpenSSF score climb plan](https://github.com/simple-container-com/api/issues?q=label%3Aopenssf) documented in HARDENING.md Phase 8.