### PR TITLE
hotfix(sc.sh): drop invalid --yes on cosign verify-blob (production outage — installs broken since #264)

### DIFF
--- a/sc.sh
+++ b/sc.sh
@@ -434,13 +434,23 @@ verify_sc_tarball() {
   # the only workflow allowed to publish tarballs to dist. Staging /
   # preview tarballs do not land at dist.simple-container.com, so a
   # single anchored regex suffices here. Mirror this in SECURITY.md.
-  if ! COSIGN_EXPERIMENTAL=1 cosign verify-blob --yes \
+  #
+  # IMPORTANT: do NOT pass --yes here. cosign 2.x only accepts --yes on
+  # sign-blob (skip interactive confirmation); on verify-blob it errors
+  # out with "unknown flag: --yes" — which is what broke every install
+  # after Phase 2c shipped. Capture cosign's stderr (don't /dev/null it)
+  # so future failures surface the real error instead of a generic
+  # message.
+  local cosign_err
+  if ! cosign_err=$(COSIGN_EXPERIMENTAL=1 cosign verify-blob \
       --bundle "$bundle_path" \
       --certificate-identity-regexp '^https://github\.com/simple-container-com/api/\.github/workflows/push\.yaml@refs/heads/main$' \
       --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-      "$tarball_path" >/dev/null 2>&1; then
+      "$tarball_path" 2>&1); then
     echo "❌"
     echo "❌ Signature verification FAILED for $tarball_path"
+    echo "    cosign output:"
+    echo "$cosign_err" | sed 's/^/      /'
     echo "    The tarball does not bear a valid signature from the SC"
     echo "    production publish workflow. This could mean: tarball was"
     echo "    tampered in transit, CDN was compromised, or the signing"


### PR DESCRIPTION
## 🚨 Production outage

**Every `curl -sSL https://dist.simple-container.com/sc.sh | bash` install has been failing** since PR #264 (Phase 2c sc.sh verify) shipped. Reported by Integrail/EverWorker agents stuck on v2026.5.18 — full failure log: https://github.com/Integrail/everworker/actions/runs/26046140460/job/76570739894

## Root cause

PR #264's `verify_sc_tarball` invokes:

```bash
cosign verify-blob --yes --bundle ... <tarball>
```

But `--yes` is **NOT** a flag of `cosign verify-blob`. It's a `cosign sign-blob` flag (skip Fulcio interactive confirmation). On `verify-blob`, every cosign version returns:

```
Error: unknown flag: --yes
```

Worse: the original script redirected cosign's stderr to `/dev/null`, so users saw a generic *"Signature verification FAILED — could be tampering / CDN compromise / identity rotation"* message that misdirected away from the real cause.

## Empirical verification

Repro on the actual broken v2026.5.18 artifact:

```
$ cosign verify-blob --yes --bundle b.cosign-bundle ... t.tar.gz
Error: unknown flag: --yes

$ cosign verify-blob       --bundle b.cosign-bundle ... t.tar.gz
Verified OK
```

Cert identity on the bundle matches sc.sh's expected regex exactly:

| Field | sc.sh expected | Bundle actual |
|---|---|---|
| Cert identity | `^https://github\.com/simple-container-com/api/\.github/workflows/push\.yaml@refs/heads/main$` | `https://github.com/simple-container-com/api/.github/workflows/push.yaml@refs/heads/main` ✅ |
| OIDC issuer | `https://token.actions.githubusercontent.com` | `https://token.actions.githubusercontent.com` ✅ |

**No signing-side issue.** Only the verify call was malformed.

## The fix (1-file, ~12 lines)

1. Drop `--yes` from the `cosign verify-blob` call.
2. Capture cosign's stderr into a local variable instead of discarding it via `>/dev/null 2>&1`. Future verify failures will now surface the real cosign error to the user instead of a generic blame-the-CDN message.

## Smoke test

Local run with the patched function against the actual broken v2026.5.18 artifact on dist:

```
🔏 Fetching signature bundle... ✅
🔍 Verifying tarball signature against build-workflow identity... ✅
```

## Republish plan

- ✅ **Existing artifacts** (v2026.5.16 / .17 / .18 / .19 tarballs + bundles) are **valid** — no re-signing needed. The fix is consumer-side only.
- ⚠️ **Existing sc.sh on dist** is broken. The script is republished as part of every production release.
- 🚀 **Next steps after merge**:
  1. Merge this hotfix to `main`
  2. The push.yaml workflow runs → creates v2026.5.20, publishes new (fixed) sc.sh to dist
  3. Integrail/EverWorker bumps to 2026.5.20 in `integrail/devops/.github/actions/install-sc/install.sh`
  4. Installs unblock

## Why this slipped through

- The Phase 2c PR #264 was preview-build-tested but the preview build doesn't actually run `sc.sh` end-to-end against the published artifact — it only validates the workflow shape.
- The `>/dev/null 2>&1` hid the real cosign error, so review caught the wrong things.
- The first signed release after #264 merged was v2026.5.16, but no smoke test ran the new sc.sh against that release.

Follow-up for SECURITY.md/HARDENING.md test plans: any sc.sh change must include "run the script against the most recent production release on a clean runner with cosign installed" as a pre-merge check.

## Review

- One-line removal of an invalid flag + error-surface improvement
- No semantic change to the trust model
- Empirically validated against the actual broken artifact