### PR TITLE
chore(ci): drop wildcard push trigger from fuzz + codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,10 +11,18 @@ name: CodeQL
 
 on:
   push:
-    # Run on every branch push so Scorecard's "% of commits scanned by SAST"
-    # check sees coverage on intermediate / feature commits, not just main.
-    # The concurrency group below cancels superseded runs on the same ref.
-    branches: ['**']
+    # Direct pushes to main only (post-merge). PR commits are covered
+    # by the pull_request event below.
+    #
+    # Scorecard's SAST check counts merged PRs on the default branch
+    # and asks whether a SAST tool ran successfully on each PR's HEAD
+    # commit. Every commit landing in main arrives via a merged PR
+    # (pull_request scan) or a direct push (push scan), so coverage is
+    # complete without the `['**']` net that triggered duplicate runs
+    # for every PR commit — push and pull_request fired on the same
+    # SHA, one was cancelled by the concurrency group, leaving noisy
+    # "cancelled" entries on every PR's checks page.
+    branches: [main]
   pull_request:
     branches: [main]
   schedule:
@@ -22,14 +30,10 @@ on:
     - cron: '23 4 * * 0'
   workflow_dispatch:
 
-# Cancel in-progress runs for the same commit when a new event lands.
-# Key on commit SHA (PR head when triggered by pull_request, pushed SHA
-# otherwise) instead of github.ref. With `push: branches: ['**']` and
-# `pull_request: branches: [main]` both active, a single PR commit
-# triggers two runs — one for the push event (refs/heads/<branch>) and
-# one for the PR event (refs/pull/N/merge). Keying on ref leaves both
-# in distinct groups, so neither cancels the other. SHA-keyed grouping
-# dedups them. Codex round-2 P2 catch on PR #264.
+# SHA-keyed dedup so a manual rerun on the same commit supersedes the
+# in-flight one. With push restricted to main + pull_request on PRs,
+# a single commit no longer fires two events; no PR-side cancellation
+# noise.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,10 +27,13 @@ name: Go Fuzz
 
 on:
   push:
-    # Run on every branch push so fuzz coverage is contiguous, not just
-    # at PR-open and merge. Concurrency group below cancels superseded
-    # runs on the same ref.
-    branches: ['**']
+    # Direct pushes to main only (post-merge). PR commits are covered
+    # by the pull_request event below; the weekly cron picks up corpus
+    # the per-PR 30s budget cannot reach. Scorecard's Fuzzing check is
+    # static-detection only ("is there a *_fuzz_test.go using
+    # testing.F wired into CI") — it doesn't measure run frequency, so
+    # restricting to main does not affect the Fuzzing score.
+    branches: [main]
   pull_request:
     branches: [main]
   schedule:
@@ -39,11 +42,9 @@ on:
     - cron: '17 7 * * 1'
   workflow_dispatch:
 
-# Cancel in-progress runs for the same commit when a new event lands.
-# SHA-keyed (PR head SHA or push SHA) instead of ref-keyed, so a single
-# PR commit doesn't run twice — once for the push:[**] event and once
-# for the pull_request event with different github.ref values. Same
-# fix as codeql.yml. Codex round-2 P2 catch on PR #264.
+# SHA-keyed dedup so a manual rerun on the same commit supersedes the
+# in-flight one. With push restricted to main + pull_request on PRs,
+# a single commit no longer fires two events.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Eliminates the "cancelled" workflow runs that appeared on every PR's
checks page for CodeQL and Go Fuzz. The cancellations were the
SHA-keyed concurrency group dedup'ing two events fired on the same PR
commit — `push: ['**']` and `pull_request: [main]` — and were not
real failures.

## What was happening

Every PR commit:

```
push          <SHA>  cancelled  ← always the dedup'd twin
pull_request  <SHA>  success    ← actual scan
```

Confirmed via run-history audit on the last 10 runs of both
workflows — every SHA-pair follows this exact pattern. The
`pull_request` event consistently wins; the `push` event is
consistently cancelled. No real CI failures.

## Why the `['**']` was there

A previous change added `push: branches: ['**']` based on the
assumption that scanning every branch push helps Scorecard's SAST
coverage. Reading the Scorecard SAST check source
([`checks/raw/sast.go`](https://github.com/ossf/scorecard/blob/main/checks/raw/sast.go))
shows it actually scopes to **merged PRs on the default branch**, and
asks whether SAST ran successfully on each PR's HEAD commit. Pushes
to feature branches outside a PR are out of scope.

## What this PR does

- `.github/workflows/codeql.yml`: `push: branches: [main]` (was `['**']`).
- `.github/workflows/fuzz.yml`: same.

The `pull_request: [main]` trigger is unchanged in both — every PR
commit still gets a CodeQL + fuzz run. The post-merge `push: [main]`
trigger picks up direct pushes to main.

The SHA-keyed concurrency group is kept as-is so a manual rerun on
the same commit still supersedes any in-flight run.

## Score impact

**Zero.**

- Scorecard SAST: every merged PR still has a successful CodeQL run
  on its HEAD via `pull_request`, which is what the SAST check counts.
- Scorecard Fuzzing: this check is static-detection only — it asks
  whether a `*_fuzz_test.go` using `testing.F` exists and is wired
  into a workflow. Frequency of execution does not affect the score.

## Test plan

- [ ] CI green on this PR (only `pull_request` runs — no `push` twin to cancel)
- [ ] After merge: open a follow-up PR and confirm the CodeQL + Go Fuzz check entries appear exactly once (not twice with a cancellation)
- [ ] Next Scorecard run after merge: SAST + Fuzzing scores unchanged

## Related

- PR #264: original Codex round-2 SHA-keyed-dedup catch (kept; still
  correct for manual reruns).
- PR #270 / #271: most recent Scorecard climb (7.8 → 9.3) — this PR
  is a UI/UX cleanup only, no climb expected.