### PR TITLE
Fix/aws static site cli and dnszone

### DIFF
--- a/github-actions-staging.Dockerfile
+++ b/github-actions-staging.Dockerfile
@@ -75,8 +75,10 @@ RUN rm -rf \
 # ── runtime ─────────────────────────────────────────────────────────────────
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
+# aws-cli needed by Pulumi local.Command shell-outs (e.g. `aws s3 sync` in the
+# static-website template at pkg/clouds/pulumi/aws/static_website.go).
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache ca-certificates git openssh-client curl jq bash python3 \
+    && apk add --no-cache ca-certificates git openssh-client curl jq bash python3 aws-cli \
     && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
 COPY --from=builder /opt/pulumi /opt/pulumi
@@ -93,6 +95,7 @@ RUN chmod +x ./github-actions \
 RUN pulumi version > /dev/null \
     && gcloud version > /dev/null \
     && gcloud components list --filter="name:gke-gcloud-auth-plugin" --format="value(name)" | grep -q gke-gcloud-auth-plugin \
+    && aws --version > /dev/null \
     && test -L /usr/local/bin/sc && test -x /usr/local/bin/sc
 
 LABEL org.opencontainers.image.source="https://github.com/simple-container-com/api" \

--- a/github-actions.Dockerfile
+++ b/github-actions.Dockerfile
@@ -87,8 +87,10 @@ RUN rm -rf \
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 # python3 stays — gcloud invokes it. py3-pip / binutils / upx confined to builder.
+# aws-cli needed by Pulumi local.Command shell-outs (e.g. `aws s3 sync` in the
+# static-website template at pkg/clouds/pulumi/aws/static_website.go).
 RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache ca-certificates git openssh-client curl jq bash python3 \
+    && apk add --no-cache ca-certificates git openssh-client curl jq bash python3 aws-cli \
     && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
 COPY --from=builder /opt/pulumi /opt/pulumi
@@ -107,6 +109,7 @@ RUN chmod +x ./github-actions \
 RUN pulumi version > /dev/null \
     && gcloud version > /dev/null \
     && gcloud components list --filter="name:gke-gcloud-auth-plugin" --format="value(name)" | grep -q gke-gcloud-auth-plugin \
+    && aws --version > /dev/null \
     && test -L /usr/local/bin/sc && test -x /usr/local/bin/sc
 
 LABEL org.opencontainers.image.source="https://github.com/simple-container-com/api" \

--- a/pkg/clouds/aws/static_website.go
+++ b/pkg/clouds/aws/static_website.go
@@ -15,6 +15,14 @@ type StaticSiteInput struct {
 	StackName             string `json:"stackName" yaml:"stackName"`
 }
 
+// OverriddenBaseZone implements api.DnsConfigAware so the Cloudflare registrar
+// uses the stack's baseDnsZone instead of the parent stack's default zone —
+// otherwise records get created with the parent zone suffixed (e.g.
+// simple-forge.com → simple-forge.com.simple-container.com).
+func (i *StaticSiteInput) OverriddenBaseZone() string {
+	return i.Site.BaseDnsZone
+}
+
 func ToStaticSiteConfig(tpl any, stackDir, stackName string, stackCfg *api.StackConfigStatic) (any, error) {
 	templateCfg, ok := tpl.(*TemplateConfig)
 	if !ok {


### PR DESCRIPTION
Two independent bugs in the AWS static-website path; both surfaced on the `landing` / `forge-landing` stacks after `simple-container-com/landing@374bce6` switched them to `template: static-site`.

## 1. `aws-cli` missing from `simplecontainer/github-actions` runner image

`pkg/clouds/pulumi/aws/static_website.go:174` shells out to `aws s3 sync` via Pulumi `local.NewCommand`, but neither Dockerfile installed the AWS CLI — every static-site stack run under the image failed with `/bin/sh: aws: not found`. Example: https://github.com/simple-container-com/landing/actions/runs/26192421479

- Adds Alpine `aws-cli` (community repo) to the runtime layer of `github-actions.Dockerfile` and `github-actions-staging.Dockerfile`.
- Extends the build-time smoke test to run `aws --version`.

## 2. `baseDnsZone` ignored for AWS static-site stacks (Cloudflare appends parent zone)

`aws.StaticSiteInput` embeds `api.StackConfigStatic` (which carries `Site.BaseDnsZone`) but never implemented the `api.DnsConfigAware` interface, so the assertion at `pkg/clouds/pulumi/deploy.go:142` fell through. The Cloudflare registrar then fell back to the parent stack's default `cfg.ZoneName` (`simple-container.com`) — Cloudflare appended that suffix, turning intended apex records into `simple-forge.com.simple-container.com`.

- Adds `OverriddenBaseZone()` on `aws.StaticSiteInput`, returning `i.Site.BaseDnsZone`. Restores parity with `gcloud.StaticSiteInput`, `aws.LambdaInput`, `aws.EcsFargateInput`.

## Test plan

- [ ] Build `github-actions-staging.Dockerfile` locally → new smoke step prints aws version
- [ ] Push to `staging` → `build-staging.yml` promotes the image
- [ ] Re-run https://github.com/simple-container-com/landing/actions/runs/26192421479 (or push to landing's main) — `aws s3 sync` succeeds under the action runner
- [ ] Re-deploy `forge-landing` / `landing` → Cloudflare record name stays at the apex (e.g. `simple-forge.com`), no parent-zone suffix
- [ ] Rotate the AWS IAM key that was leaked in plaintext in the failed run's log

🤖 Generated with [Claude Code](https://claude.com/claude-code)