### PR TITLE
fix(sbom): make sc sbom generate fail loudly on syft errors

### DIFF
--- a/pkg/cmd/cmd_sbom/generate.go
+++ b/pkg/cmd/cmd_sbom/generate.go
@@ -67,6 +67,7 @@ func runGenerate(ctx context.Context, opts *generateOptions) error {
 		Enabled: true,
 		SBOM: &security.SBOMConfig{
 			Enabled:   true,
+			Required:  true,
 			Format:    string(format),
 			Generator: "syft",
 			Output: &security.OutputConfig{
@@ -90,9 +91,6 @@ func runGenerate(ctx context.Context, opts *generateOptions) error {
 	generatedSBOM, err := executor.ExecuteSBOM(ctx, opts.image)
 	if err != nil {
 		return fmt.Errorf("failed to generate SBOM: %w", err)
-	}
-	if generatedSBOM == nil {
-		return fmt.Errorf("no SBOM generated")
 	}
 
 	// Print summary


### PR DESCRIPTION
## Summary
- `sc sbom generate` built a `SecurityConfig` with `SBOM.Required=false`, telling the executor to fail-open on syft errors. The executor returned `(nil, nil)` after printing `Warning: SBOM generation failed, continuing`, but the CLI wrapper turned that into `Error: no SBOM generated` and `exit 1` — fail-open semantics with a fail-closed exit code.
- For a user-invoked `sc sbom generate`, the right behavior is fail-loud. Setting `SBOM.Required=true` lets the executor propagate the underlying syft error (`signal: killed` for OOM, registry timeouts, etc.), which the wrapper already maps to `failed to generate SBOM: <reason>`.

## Why this matters
Surfaced by a PAY-SPACE `pay_space_wallet` production deploy where syft was OOM-killed on a large image:

```
Warning: SBOM generation failed, continuing: syft command failed: signal: killed (stderr: )
Error: no SBOM generated
Error: no SBOM generated
error: update failed
```

Pulumi (running `sc sbom generate` as a step) saw `exit 1`, aborted the stack update, and the production deploy hard-failed. The misleading `signal: killed (stderr: )` was the real diagnostic — this PR makes sure it reaches the user instead of being shadowed by the bogus wrapper error.

## Test plan
- [ ] `go build ./pkg/cmd/cmd_sbom/... ./pkg/security/...` — clean
- [ ] CI green
- [ ] On next preview, manually invoke `sc sbom generate` against a known-large image and confirm the real syft stderr (or OOM signal) is surfaced verbatim instead of `no SBOM generated`