### PR TITLE
fix(sc-preview): cloudtrail helper-image phantom diff + branch-preview release tag

### DIFF
--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -495,13 +495,24 @@ jobs:
           RELEASE_BRANCH="release/${VERSION}"
           git checkout -b "${RELEASE_BRANCH}"
 
-          # Replace :staging image tag with the preview version tag in all action.yml files
+          # Rewrite whatever tag the action.yml files currently pin (latest,
+          # staging, …) to the preview version. Matching a fixed base tag is
+          # brittle: #284 switched :staging -> :latest and silently broke every
+          # preview build, because this sed still looked for :staging — the
+          # rewrite became a no-op, leaving "nothing to commit" downstream.
           find .github/actions -name "action.yml" | while read f; do
-            sed -i "s|docker://simplecontainer/github-actions:staging|docker://simplecontainer/github-actions:${VERSION}|g" "$f"
+            sed -i -E "s|(docker://simplecontainer/github-actions):[A-Za-z0-9._-]+|\1:${VERSION}|g" "$f"
           done
 
           echo "Updated action.yml files:"
           grep -r "docker://simplecontainer/github-actions:" .github/actions/
+
+          # Fail loudly if the rewrite matched nothing (base-tag drift again),
+          # instead of producing a confusing empty-commit error in the next step.
+          if ! grep -rq "docker://simplecontainer/github-actions:${VERSION}" .github/actions/; then
+            echo "::error::No action.yml image tag was rewritten to ${VERSION} — the base image tag pattern drifted. Update the sed above."
+            exit 1
+          fi
       - name: commit, tag and push
         env:
           VERSION: ${{ needs.prepare.outputs.version }}

--- a/pkg/clouds/pulumi/aws/alerts.go
+++ b/pkg/clouds/pulumi/aws/alerts.go
@@ -97,13 +97,23 @@ func pushHelpersImageToECR(ctx *sdk.Context, cfg helperCfg) (*docker.Image, erro
 	cfg.provisionParams.Log.Info(ctx.Context(), "pushing cloud-helpers image...")
 	ecrImage, err := docker.NewImage(ctx, helpersImageName, &docker.ImageArgs{
 		Build: &docker.DockerBuildArgs{
-			Context:    sdk.String("."),
+			// The generated Dockerfile only does `FROM ${SOURCE_IMAGE}` + a
+			// VERSION label and COPYs nothing, so the build context is
+			// irrelevant to the output. Point it at the temp dir holding the
+			// Dockerfile rather than "." — otherwise Pulumi hashes the entire
+			// project directory and reports `build: update` on every preview
+			// the moment any unrelated repo file changes.
+			Context:    sdk.String(filepath.Dir(dockerFilePath)),
 			Dockerfile: sdk.String(dockerFilePath),
 			Args: sdk.StringMap{
 				"SOURCE_IMAGE": chImage.Name,
 				"VERSION":      sdk.String(version),
 			},
 		},
+		// SkipPush stays true during preview (no push side effect) and false
+		// during up. That makes the desired value differ from the deployed
+		// state every preview, so IgnoreChanges below stops Pulumi reporting a
+		// permanent phantom `skipPush: update` diff.
 		SkipPush:  sdk.Bool(ctx.DryRun()),
 		ImageName: imageFullUrl,
 		Registry: docker.RegistryArgs{
@@ -111,7 +121,7 @@ func pushHelpersImageToECR(ctx *sdk.Context, cfg helperCfg) (*docker.Image, erro
 			Username: sdk.String("AWS"), // Use 'AWS' for ECR registry authentication
 			Password: ecrRepo.Password,
 		},
-	}, cfg.opts...)
+	}, append(cfg.opts, sdk.IgnoreChanges([]string{"skipPush"}))...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two related SC-preview fixes (bundled).

## 1. Phantom diff on the cloudtrail helper image (`pkg/clouds/pulumi/aws/alerts.go`)

The `cloudtrail-security-{audit,critical}--prod-security-helpers-image` resources showed as **2 to update** (`build: update, skipPush: update`) on every PR preview:
- `SkipPush: ctx.DryRun()` — true in preview / false in up → permanent `skipPush: update`. Kept it (no push during preview) + added `IgnoreChanges(["skipPush"])`.
- `Context: "."` — Dockerfile `COPY`s nothing, so the whole-project context is irrelevant, but Pulumi hashes it and reports `build: update` on any unrelated file change. Narrowed to the Dockerfile's temp dir.

## 2. branch-preview release step (`.github/workflows/branch-preview.yaml`)

`branch-preview.yaml`'s release step seds for `:staging`, but **#284** switched all `action.yml` image refs to `:latest`. Since then the rewrite is a no-op → `git add` stages nothing → "nothing to commit" → **every preview build fails at the tag step** (binary + images publish, but no `v$VERSION` tag). Now rewrites whatever tag is pinned and fails loudly on future drift.

## Validation
- `go build ./...` passes; `branch-preview.yaml` YAML valid; sed verified against both `:latest` and `:staging`.
- Re-running the branch-preview build on this branch exercises fix #2 (should now produce a `v$VERSION` tag), which in turn unblocks CI-side validation of fix #1.
