### PR TITLE
docs: suppress default "Made with Material for MkDocs" footer

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -33,6 +33,8 @@ theme:
     - content.code.copy
     - content.code.annotate
 
+  copyright: ""
+
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
## Summary
  Suppresses the default "Made with Material for MkDocs" footer text by setting `copyright: ""` in the theme configuration. Keeps the SC docs footer clean and on-brand.
