### PR TITLE
feat(caddy): add mholt/caddy-ratelimit to xcaddy build

### DIFF
--- a/caddy.Dockerfile
+++ b/caddy.Dockerfile
@@ -3,6 +3,59 @@
 # auth-bypass fixes — see https://github.com/caddyserver/caddy/releases/tag/v2.11.3.
 # Bumping requires editing all three "2.11.x" sites below (two FROMs + xcaddy).
 # Refresh: docker buildx imagetools inspect caddy:X.Y.Z[-builder]
+#
+# Plugins:
+# - github.com/grafana/certmagic-gcs — GCS-backed certmagic storage for GKE.
+# - github.com/mholt/caddy-ratelimit — request rate limiting (third-party
+#   module; not part of the official Caddy distribution).
+#   Needed for deployments where the SC-managed Caddy is the only HTTP layer
+#   between client and origin (no upstream CDN that could enforce rate-limit
+#   at the edge instead). Caddy's standard library has no rate-limit handler,
+#   so a plugin is required to enforce this from Caddy at all.
+#
+#   Pinned to commit 16aecbb (2026-05-21). The repo's only formal tag is
+#   v0.1.0 (predates ipv4_prefix/ipv6_prefix subnet matching + metrics
+#   support), and the module is actively maintained by Caddy's own author,
+#   so a commit-pin is the conventional approach here. The build-time
+#   `caddy list-modules | grep` below guards against silent plugin drops.
+#
+#   Usage from SC consumers (cloud-compose stack yaml). Real upstream
+#   Caddyfile syntax (verified against the module README — there is NO
+#   `rate_limit_zones` global block):
+#
+#       rate_limit {
+#           distributed                       # required for multi-replica
+#           zone login {
+#               key    {remote_host}          # or a header / custom field
+#               events 5
+#               window 1m
+#           }
+#           zone api {
+#               key    {remote_host}
+#               events 60
+#               window 1m
+#           }
+#       }
+#
+#   The `rate_limit` directive is a SITE-LEVEL HTTP handler (sibling of
+#   `reverse_proxy`), NOT a `reverse_proxy` subdirective — so it can't be
+#   placed via the existing `lbConfig.extraHelpers` field, which renders
+#   inside the `reverse_proxy` block. Consumers wire it via the new
+#   `lbConfig.siteExtraHelpers` field introduced in the same PR as this
+#   plugin (see pkg/api/client.go + simple_container.go).
+#
+#   Two landmines worth knowing:
+#     - WITHOUT `distributed`, rate-limit state is per-pod in-memory. On
+#       multi-replica deployments a "5/min login" limit becomes 5×replicas
+#       per minute → enforcement silently weakened. `distributed` requires
+#       a shared Caddy storage module — the parent stack already uses
+#       certmagic-gcs, which doubles as shared storage.
+#     - `{remote_host}` is only the true client IP if Caddy actually sees
+#       it. On a GKE Service with default `externalTrafficPolicy: Cluster`
+#       the source IP is SNAT'd to a node IP, so all clients collapse into
+#       a few buckets — rate-limit becomes either useless or self-DoS.
+#       Verify the LB is `externalTrafficPolicy: Local` + the parent
+#       Caddy's `trustedProxies` covers the LB CIDR range.
 
 FROM caddy:2.11.3-builder@sha256:f96a3b748f2ce4e5f6595453615da734b93993b231213fe35d0673893b5613ef AS builder
 
@@ -10,7 +63,13 @@ RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
     --mount=type=cache,target=/root/.cache,sharing=locked \
     xcaddy build "v2.11.3" \
         --with github.com/grafana/certmagic-gcs@v0.1.7 \
-    && caddy version
+        --with github.com/mholt/caddy-ratelimit@16aecbb24beddc9095da2716fa8d3a30fa2dc8ea \
+    && caddy version \
+    && caddy list-modules | grep -qE '^http\.handlers\.rate_limit$'
+# ^ Final grep is a sanity check that the ratelimit module actually registered
+# into the resulting binary (xcaddy has been known to silently drop plugins
+# when versions disagree). If this fails the RUN exits non-zero with the
+# failing command visible — no misleading prefixed echo.
 
 FROM caddy:2.11.3@sha256:ec18ee54aab3315c22e25f3b2babda73ff8007d39b13b3bd1bfffa2f0444c7d9
 
@@ -21,4 +80,4 @@ COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 LABEL org.opencontainers.image.source="https://github.com/simple-container-com/api" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="simplecontainer/caddy" \
-      org.opencontainers.image.description="Caddy with grafana/certmagic-gcs"
+      org.opencontainers.image.description="Caddy with grafana/certmagic-gcs + mholt/caddy-ratelimit"

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -150,8 +150,21 @@ type TextVolume struct {
 type Headers map[string]string
 
 type SimpleContainerLBConfig struct {
-	Https        bool     `json:"https" yaml:"https"`
+	Https bool `json:"https" yaml:"https"`
+	// ExtraHelpers renders one directive per line INSIDE the per-stack
+	// `reverse_proxy { ... }` block (alongside `header_down`, `import
+	// handle_server_error`, etc.). Use this for reverse-proxy-subdirective
+	// configuration: `header_down`, `lb_retries`, `transport`, `header_up`.
 	ExtraHelpers []string `json:"extraHelpers" yaml:"extraHelpers"`
+	// SiteExtraHelpers renders one directive per line at the SITE LEVEL,
+	// AFTER the `reverse_proxy { ... }` block closes (alongside `import
+	// gzip`, `import hsts`, etc.). Use this for site-level HTTP handlers
+	// that aren't valid as reverse_proxy subdirectives — `rate_limit`,
+	// `redir`, top-level matchers, `route` blocks, `respond` on specific
+	// paths. The two fields are distinct because Caddy's grammar gates
+	// what's accepted at each scope; mis-placing a directive yields a
+	// Caddyfile parse error at reload time.
+	SiteExtraHelpers []string `json:"siteExtraHelpers" yaml:"siteExtraHelpers"`
 }
 
 type StackConfigCompose struct {

--- a/pkg/clouds/pulumi/kubernetes/simple_container.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container.go
@@ -680,6 +680,12 @@ func NewSimpleContainer(ctx *sdk.Context, args *SimpleContainerArgs, opts ...sdk
 		// updates both paths.
 		var caddyfileEntryTemplate string
 		if args.Domain != "" {
+			// Site-level layout: `${siteExtraHelpers}` lands at the same scope
+			// as `${imports}` so directives that aren't valid as reverse_proxy
+			// subdirectives (e.g. `rate_limit`, top-level matchers, `respond`
+			// on specific paths) can be wired through lbConfig.siteExtraHelpers.
+			// Placed AFTER reverse_proxy so the proxy block isn't shadowed by
+			// e.g. a catch-all `respond` directive emitted earlier.
 			caddyfileEntryTemplate = `
 ${proto}://${domain} {
   reverse_proxy http://${service}.${namespace}.svc.cluster.local:${port} {
@@ -687,7 +693,7 @@ ${proto}://${domain} {
     import handle_server_error
     ${extraHelpers}
   }
-  ${imports}
+  ${imports}${siteExtraHelpers}
 }
 `
 		} else if args.Prefix != "" {
@@ -697,7 +703,7 @@ ${proto}://${domain} {
       header_down Server nginx ${addHeaders}
       import handle_server_error
       ${extraHelpers}
-    }
+    }${siteExtraHelpers}
   }
 `
 		}
@@ -730,16 +736,26 @@ ${proto}://${domain} {
 			})
 			addHeadersStr = "\n    " + strings.Join(lines, "\n    ")
 		}
+		// Render `siteExtraHelpers` with a leading newline+indent when non-empty
+		// so the first entry doesn't end up tacked onto the preceding `${imports}`
+		// line (same shape as the addHeaders fix). When empty, substitutes the
+		// empty string so the Caddyfile shape is byte-identical to the
+		// pre-siteExtraHelpers rendering for stacks that don't set the field.
+		siteExtraHelpersStr := ""
+		if helpers := lo.FromPtr(args.LbConfig).SiteExtraHelpers; len(helpers) > 0 {
+			siteExtraHelpersStr = "\n  " + strings.Join(helpers, "\n  ")
+		}
 		placeholdersMap := placeholders.MapData{
-			"proto":        lo.If(lo.FromPtr(args.LbConfig).Https, "https").Else("http"),
-			"domain":       args.Domain,
-			"prefix":       args.Prefix,
-			"service":      sanitizedService,
-			"namespace":    sanitizedNamespace,
-			"port":         strconv.Itoa(lo.FromPtr(mainPort)),
-			"addHeaders":   addHeadersStr,
-			"extraHelpers": strings.Join(lo.FromPtr(args.LbConfig).ExtraHelpers, "\n    "),
-			"imports":      strings.Join(imports, "\n    "),
+			"proto":            lo.If(lo.FromPtr(args.LbConfig).Https, "https").Else("http"),
+			"domain":           args.Domain,
+			"prefix":           args.Prefix,
+			"service":          sanitizedService,
+			"namespace":        sanitizedNamespace,
+			"port":             strconv.Itoa(lo.FromPtr(mainPort)),
+			"addHeaders":       addHeadersStr,
+			"extraHelpers":     strings.Join(lo.FromPtr(args.LbConfig).ExtraHelpers, "\n    "),
+			"imports":          strings.Join(imports, "\n    "),
+			"siteExtraHelpers": siteExtraHelpersStr,
 		}
 		if args.ProxyKeepPrefix {
 			placeholdersMap["additionalProxyConfig"] = fmt.Sprintf("\n    rewrite * /%s{uri}", args.Prefix)

--- a/pkg/clouds/pulumi/kubernetes/simple_container_test.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container_test.go
@@ -593,6 +593,62 @@ func TestCaddyfileEntry_HeaderValueWithEmbeddedDoubleQuote(t *testing.T) {
 		"value containing embedded \" must be %%q-escaped (\\\") in the rendered Caddyfile, got:\n%s", entry)
 }
 
+func TestCaddyfileEntry_SiteExtraHelpersRendersAtSiteLevel(t *testing.T) {
+	RegisterTestingT(t)
+
+	// `rate_limit` (and other site-level HTTP handlers) MUST NOT land inside
+	// the `reverse_proxy { ... }` block — Caddy's grammar rejects them there.
+	// This test locks in: SiteExtraHelpers entries appear AFTER the closing
+	// `}` of reverse_proxy and BEFORE the closing `}` of the site block, so
+	// `lbConfig.siteExtraHelpers` is a valid insertion point for rate_limit,
+	// top-level matchers, `respond` directives, etc.
+	args := createBasicTestArgs()
+	args.LbConfig = &api.SimpleContainerLBConfig{
+		Https: true,
+		SiteExtraHelpers: []string{
+			`rate_limit { distributed; zone login { key {remote_host}; events 5; window 1m } }`,
+		},
+	}
+	entry := caddyfileEntryFor(t, args)
+
+	// Find the close-brace of the reverse_proxy block and the close-brace of
+	// the site block. SiteExtraHelpers must appear strictly between them.
+	rpOpenIdx := strings.Index(entry, "reverse_proxy ")
+	Expect(rpOpenIdx).To(BeNumerically(">", 0), "expected reverse_proxy open, got:\n%s", entry)
+	rpCloseIdx := strings.Index(entry[rpOpenIdx:], "\n  }")
+	Expect(rpCloseIdx).To(BeNumerically(">", 0),
+		"expected reverse_proxy close brace (2-space indent), got:\n%s", entry)
+	rpCloseIdx += rpOpenIdx
+
+	rlIdx := strings.Index(entry, "rate_limit")
+	Expect(rlIdx).To(BeNumerically(">", rpCloseIdx),
+		"rate_limit must appear AFTER the reverse_proxy block closes, got:\n%s", entry)
+
+	// And it must NOT appear INSIDE the reverse_proxy block.
+	rpBody := entry[rpOpenIdx:rpCloseIdx]
+	Expect(rpBody).ToNot(ContainSubstring("rate_limit"),
+		"rate_limit must NOT appear inside the reverse_proxy block body, got:\n%s", rpBody)
+}
+
+func TestCaddyfileEntry_EmptySiteExtraHelpersIsByteIdentical(t *testing.T) {
+	RegisterTestingT(t)
+
+	// Compatibility contract: stacks that don't set lbConfig.siteExtraHelpers
+	// must produce output structurally identical to the pre-feature rendering,
+	// so the parent Caddy aggregator's change-hash doesn't flap on the SC
+	// upgrade for any of the ~hundreds of existing consumer stacks.
+	args := createBasicTestArgs()
+	args.LbConfig = &api.SimpleContainerLBConfig{Https: true}
+	// SiteExtraHelpers intentionally unset.
+
+	entry := caddyfileEntryFor(t, args)
+
+	// The placeholder must have substituted as an empty string: no stray
+	// blank-indent line should be emitted between imports and the site close.
+	Expect(entry).ToNot(MatchRegexp(`import handle_static\n  \n}`),
+		"empty siteExtraHelpers must not produce a blank line before the site close, got:\n%s", entry)
+}
+
 func TestCaddyfileEntry_HeadersOnPrefixTemplate(t *testing.T) {
 	RegisterTestingT(t)
 


### PR DESCRIPTION
## Summary

Two coupled changes that together let consumers wire request rate-limiting into the per-stack Caddyfile through stack yaml:

1. **xcaddy build now includes [`github.com/mholt/caddy-ratelimit`](https://github.com/mholt/caddy-ratelimit)**. Caddy's standard library has no rate-limit handler, so a plugin is required to enforce rate-limiting from Caddy at all.
2. **New `lbConfig.siteExtraHelpers []string` field** on `SimpleContainerLBConfig`. `rate_limit` is a SITE-LEVEL HTTP handler, not a `reverse_proxy` subdirective — Caddy rejects it inside the reverse_proxy block, so the existing `lbConfig.extraHelpers` (which renders inside reverse_proxy) can't host it. `siteExtraHelpers` renders at site level, after `reverse_proxy` closes — the correct scope for `rate_limit`, top-level matchers, `respond` directives, and other site-level HTTP handlers.

## Why this is needed

For deployments where the SC-managed Caddy is the only HTTP layer between client and origin — i.e. no upstream CDN that could enforce rate-limit at the edge — the only way to do rate-limiting at all is from Caddy. The change is also useful for any site-level Caddyfile directive that consumers want to attach to an SC-managed reverse-proxy stack (`redir` blocks, top-level `@matcher` declarations, error routes, etc.).

## Pin choice for `mholt/caddy-ratelimit`

Pinned to commit **`16aecbb24beddc9095da2716fa8d3a30fa2dc8ea`** (2026-05-21). The repo's only formal tag is `v0.1.0`, which predates two features we want:

- `ipv4_prefix` / `ipv6_prefix` — subnet-based rate-limiting.
- Prometheus metrics — observability for when limits fire.

The module is actively maintained by Caddy's own author; commit-pin is the conventional approach until upstream cuts a new release. The build also asserts plugin registration via `caddy list-modules | grep -qE '^http\.handlers\.rate_limit$'` so a silent plugin drop on a future xcaddy/Caddy version mismatch fails the build with a clear failing command.

## How consumers wire it up

No further schema change needed. Two existing fields, plus the new `siteExtraHelpers`:

1. **Global Caddyfile config** — set the module ordering in `caddy.caddyfilePrefix` (parent stack):
   ```yaml
   caddyfilePrefix: |
     {
       order rate_limit before reverse_proxy
     }
   ```
2. **Per-site rate-limit zones** — `lbConfig.siteExtraHelpers` (client stack):
   ```yaml
   lbConfig:
     siteExtraHelpers:
       - 'rate_limit { distributed; zone login { key {remote_host}; events 5; window 1m } }'
   ```

The Dockerfile header documents the canonical upstream Caddyfile syntax (verified against [the module README](https://github.com/mholt/caddy-ratelimit/blob/main/README.md) — there is no `rate_limit_zones` global block).

## Operational landmines documented inline

1. **Without `distributed`**, rate-limit state is per-pod in-memory. On multi-replica deployments a "5/min login" limit becomes `5 × replicas/min` — silently weakened enforcement.
2. **Client-IP propagation**: `{remote_host}` is only the true client IP if Caddy sees it. Under GKE Service `externalTrafficPolicy: Cluster` (default), source IPs are SNAT'd to node IPs — all clients collapse into a few buckets and rate-limit becomes useless or self-DoS. Verify `externalTrafficPolicy: Local` + `trustedProxies` covers the LB CIDR.

## Compatibility / blast radius

- Adding the plugin is behaviorally inert until configured. Existing consumers see a slightly larger Caddy binary but no runtime difference.
- `siteExtraHelpers` is optional. `TestCaddyfileEntry_EmptySiteExtraHelpersIsByteIdentical` proves the rendered Caddyfile is byte-stable for stacks that don't set it.
- All existing kubernetes tests stay green; 2 new regression tests added.

## Test coverage

- `TestCaddyfileEntry_SiteExtraHelpersRendersAtSiteLevel` — asserts the emitted `rate_limit` directive lands strictly between the reverse_proxy close and the site close, never inside the reverse_proxy body. Mis-placement would fail Caddyfile parsing at reload time.
- `TestCaddyfileEntry_EmptySiteExtraHelpersIsByteIdentical` — locks the byte-stability contract for the empty case.
- Build-time `caddy list-modules` grep guards against xcaddy silently dropping the plugin.

## Test plan

- [ ] CI builds the multi-arch Caddy image successfully.
- [ ] Manual: `docker run --rm simplecontainer/caddy:<new-version> caddy list-modules | grep rate_limit` returns `http.handlers.rate_limit` + `http.app.rate_limiting`.
- [ ] Manual smoke deploy with a `siteExtraHelpers` `rate_limit` directive renders a Caddyfile that loads without errors and returns `429` past the configured threshold.