### PR TITLE
fix(gke): plumb UseSSL through GKE Autopilot deploy path

### DIFF
--- a/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
+++ b/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
@@ -147,6 +147,30 @@ func GkeAutopilotStack(ctx *sdk.Context, stack api.Stack, input api.ResourceInpu
 		params.Log.Info(ctx.Context(), "🔍 DEBUG: gkeAutopilotInput.Deployment.Affinity is nil")
 	}
 
+	// UseSSL gates two SC outputs in the kubernetes.Args contract:
+	//   1. `import hsts` in the per-stack Caddyfile entry → the parent
+	//      Caddy's `(hsts)` snippet then sets Strict-Transport-Security
+	//      site-level AND redirects HTTP→HTTPS on X-Forwarded-Proto: http.
+	//   2. The `ingress.kubernetes.io/ssl-redirect: false` annotation on
+	//      the Ingress (Caddy owns the redirect, so the ingress shouldn't).
+	//
+	// We derive it from `lbConfig.https` (a per-stack yaml field that the
+	// consumer already sets when their stack is HTTPS-fronted) rather than
+	// introducing a new template-level knob — same signal, fewer concepts.
+	// Net behaviour: stacks declaring `lbConfig.https: true` opt into the
+	// HSTS snippet; everything else stays plain HTTP and the snippet stays
+	// inert (its `redir @httpReq` would otherwise loop on origins without
+	// a TLS cert).
+	//
+	// Pre-this-fix, the field was unset on the kubernetes.Args struct, so
+	// it landed at the bool zero value and `import hsts` was never added —
+	// silently dropping HSTS on every GKE Autopilot deploy regardless of
+	// the consumer's lbConfig.https setting.
+	var useSSL bool
+	if sc := gkeAutopilotInput.Deployment.StackConfig; sc != nil {
+		useSSL = lo.FromPtr(sc.LBConfig).Https
+	}
+
 	kubeArgs := kubernetes.Args{
 		Input:                  input,
 		Deployment:             gkeAutopilotInput.Deployment,
@@ -154,6 +178,7 @@ func GkeAutopilotStack(ctx *sdk.Context, stack api.Stack, input api.ResourceInpu
 		Params:                 params,
 		KubeProvider:           kubeProvider,
 		ComputeContext:         params.ComputeContext,
+		UseSSL:                 useSSL,
 		GenerateCaddyfileEntry: domain != "",
 		Annotations: map[string]string{
 			"pulumi.com/patchForce": "true",


### PR DESCRIPTION
## Summary

The GKE Autopilot cloud-compose deploy path silently omits `import hsts` from every per-stack Caddyfile entry because `kubernetes.Args.UseSSL` is never set — it lands at the Go bool zero value (`false`), and `simple_container.go` gates `import hsts` on `args.UseSSL`. Result: the parent Caddy's `(hsts)` snippet never fires for GKE Autopilot deploys, no matter what `lbConfig.https` the consumer declares.

Asymmetric with the Cloudrun deploy path (`kube_run.go:102`), which already wires `args.UseSSL` correctly.

## Purpose

Make HSTS work out of the box on the GKE Autopilot deploy path for any stack that declares it's HTTPS-fronted. Today, consumers who set `lbConfig.https: true` in their stack yaml get the `https://` site-block protocol (and TLS termination on Caddy), but **not** the corresponding `import hsts` — they have to add `header_down Strict-Transport-Security` manually via `lbConfig.extraHelpers` to get any HSTS, and even then it only fires on proxied responses (not static assets / error pages).

After this fix, `lbConfig.https: true` is the single user-facing signal that turns on **both** the HTTPS site block **and** the HSTS snippet — same intent, same knob.

## Root cause

`kubernetes.Args` in [`pkg/clouds/pulumi/gcp/gke_autopilot_stack.go`](https://github.com/simple-container-com/api/blob/main/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go) was constructed without `UseSSL`:

```go
kubeArgs := kubernetes.Args{
    Input:                  input,
    Deployment:             gkeAutopilotInput.Deployment,
    Images:                 images,
    Params:                 params,
    KubeProvider:           kubeProvider,
    ComputeContext:         params.ComputeContext,
    // UseSSL: unset, defaults to false
    GenerateCaddyfileEntry: domain != "",
    ...
}
```

`if args.UseSSL { imports = append(imports, "import hsts") }` → never executes for GKE → `(hsts)` snippet inert → no HSTS header on responses.

Verified by reading a live Service annotation: `import gzip` + `import handle_static` present, `import hsts` missing.

## Fix

In `gke_autopilot_stack.go`, derive `useSSL` from the consumer's `lbConfig.https` setting (the same per-stack yaml field that already controls the site-block protocol in the same rendering pass) and pass it through to `kubernetes.Args`:

```go
var useSSL bool
if sc := gkeAutopilotInput.Deployment.StackConfig; sc != nil {
    useSSL = lo.FromPtr(sc.LBConfig).Https
}
```

One signal in, two aligned outputs (site-block protocol + `import hsts`).

## Approach choice

Considered adding a separate `UseSSL *bool` field on `GkeAutopilotTemplate` (mirror `CloudrunTemplate.UseSSL` exactly). Rejected because:

- `lbConfig.https` is already the consumer-facing declaration of HTTPS intent — adding a second knob at the template level would duplicate the signal.
- Per-stack granularity is more useful than per-template (different consumers may want different defaults).
- Smaller diff, less API surface, no new schema or test scaffolding.

The CloudrunTemplate path keeps its independent `UseSSL` knob for now (out of scope for this fix); future work could harmonize, but no behaviour change there.

## Compatibility

- Stacks with `lbConfig.https: true` now get `import hsts` automatically. The parent `(hsts)` snippet (in `embed/caddy/Caddyfile`) sets `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` site-level and redirects HTTP→HTTPS on `X-Forwarded-Proto: http`.
- Stacks **without** `lbConfig.https: true` continue to get no HSTS — byte-identical behaviour to today's broken state. No silent default flip; no risk to plain-HTTP GKE deployments.
- The `(hsts)` snippet's `redir` is gated on `X-Forwarded-Proto: http` (matched only when an upstream proxy sets it), so HTTP-only origins that aren't fronted by such a proxy see no redirect loop. The always-on Strict-Transport-Security header is the sticky bit — only fires on stacks that explicitly opted into HTTPS via `lbConfig.https: true`, which is exactly the right consent model.

## Test plan

- [x] Existing kubernetes test suite green (`pkg/clouds/pulumi/kubernetes/...`).
- [x] SC preview build (`branch-preview.yaml`) tagged — see linked verification comment.
- [x] After pinning a downstream consumer's staging deploy to the preview SC version, the rendered `caddyfile-entry` annotation on the K8s Service now contains `import hsts` alongside `import gzip` + `import handle_static`. Pre-fix that line was missing on the same Service.

## Reviewer feedback addressed

Original revision of this PR added a `UseSSL *bool` field to `GkeAutopilotTemplate` (mirroring CloudrunTemplate). Reviewer feedback flagged this as adding unnecessary API surface when `lbConfig.https` already carried the HTTPS-intent signal. This revision drops the new field and derives directly from the existing per-stack flag.