### PR TITLE
fix(caddy): correct caddy-ratelimit commit SHA pin

### DIFF
--- a/caddy.Dockerfile
+++ b/caddy.Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
     --mount=type=cache,target=/root/.cache,sharing=locked \
     xcaddy build "v2.11.3" \
         --with github.com/grafana/certmagic-gcs@v0.1.7 \
-        --with github.com/mholt/caddy-ratelimit@16aecbb24beddc9095da2716fa8d3a30fa2dc8ea \
+        --with github.com/mholt/caddy-ratelimit@16aecbbcb8ca07dc1c671e263379606ff9493c55 \
     && caddy version \
     && caddy list-modules | grep -qE '^http\.handlers\.rate_limit$'
 # ^ Final grep is a sanity check that the ratelimit module actually registered


### PR DESCRIPTION
## Summary

The xcaddy `--with` line in `caddy.Dockerfile` pinned `github.com/mholt/caddy-ratelimit` at an **invalid 40-char SHA**: `16aecbb24beddc9095da2716fa8d3a30fa2dc8ea`. The first 7 characters match the real commit, but the rest of the SHA was not a real revision in the upstream repository.

The correct full SHA for the "Add ipv4_prefix and ipv6_prefix options for subnet-based rate limiting" commit (2026-05-21) is **`16aecbbcb8ca07dc1c671e263379606ff9493c55`**.

Verified:

```bash
$ curl -s "https://api.github.com/repos/mholt/caddy-ratelimit/commits/16aecbb" | jq '.sha'
"16aecbbcb8ca07dc1c671e263379606ff9493c55"
```

## Effect on the 2026.5.42 release

`go get` rejected the bad revision (`go: github.com/mholt/caddy-ratelimit@...: invalid version: unknown revision`), the `Docker build and push caddy` matrix entry failed, and the other three matrix entries (`kubectl`, `github-actions`, `cloud-helpers-aws`) got cancelled mid-flight. The release tag was published but **no docker images were pushed for `2026.5.42`** → any consumer pointing wrappers at `@2026.5.42` would fail at image pull.

Failed run: https://github.com/simple-container-com/api/actions/runs/26684021578

## Why earlier preview builds passed

Most likely Go module proxy caching on short-SHA prefix lookups masked the issue intermittently — preview builds aren't a reliable signal for commit-pin correctness because xcaddy + the Go module proxy can sometimes accept a fabricated full SHA that prefix-matches a real one if a cache hit exists. The production-path build (no cache) failed loudly.

## Fix

One-line change: replace the fabricated SHA with the real one. No behavior change beyond restoring the build.

## Test plan

- [ ] `Docker build and push caddy` succeeds in the matrix.
- [ ] All four docker images push for the new release tag (`2026.5.43` or whatever calver lands).
- [ ] `docker run --rm simplecontainer/caddy:<new-tag> caddy list-modules | grep http.handlers.rate_limit` returns the module.