### PR TITLE
fix(docker): disable AddPreviousOutputInEnv on security-report

### DIFF
--- a/pkg/clouds/pulumi/docker/build_and_push.go
+++ b/pkg/clouds/pulumi/docker/build_and_push.go
@@ -252,6 +252,35 @@ func executeSecurityOperations(ctx *sdk.Context, stack api.Stack, dockerImage *d
 			}
 			return fmt.Sprintf("sh %s", shellQuote(path))
 		}).(sdk.StringOutput),
+
+		// Disable the default behaviour of passing the previous run's
+		// stdout/stderr back as PULUMI_COMMAND_STDOUT / PULUMI_COMMAND_STDERR
+		// env vars on Update. pulumi-command's
+		// `run()` builds envp with:
+		//
+		//   if in.AddPreviousOutputInEnv == nil || *in.AddPreviousOutputInEnv {
+		//     if out.Stdout != "" {
+		//       cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s",
+		//         util.PulumiCommandStdout, out.Stdout))
+		//     }
+		//     ...
+		//   }
+		//
+		// The security-report script writes the full rendered vulnerability
+		// table to stdout for inline build-log visibility. On a chrome-base-
+		// derived image that's a 150-200 KB markdown table (thousands of CVE
+		// rows). pulumi-command captures that into the resource's `Stdout`
+		// output, which is then echoed back as a SINGLE envp entry on the
+		// next Update. Kernel ARG_MAX (~128 KB on Linux) covers argv+envp
+		// combined, so the next deploy fails at `fork/exec /bin/sh: argument
+		// list too long` — even though our argv is now ~80 bytes thanks to
+		// tempfile staging.
+		//
+		// Our security scripts don't read PULUMI_COMMAND_STDOUT; turning
+		// this off is purely a no-op for the script's behaviour. The
+		// stdout is still captured into state for `pulumi stack output` and
+		// downstream resource references, just not re-injected into envp.
+		AddPreviousOutputInEnv: sdk.Bool(false),
 	}, sdk.DependsOn(reportDeps))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create security report for image %q", imageName)


### PR DESCRIPTION
Root-cause fix for the post-v2026.5.43 E2BIG failure observed in [integrail/baas run 26690935574](https://github.com/Integrail/baas/actions/runs/26690935574).

## What we saw

SC v2026.5.43 deploy retry on baas — tempfile staging from #303 was in effect (Create was the short `sh '/tmp/sc-security-report-…sh'`, ~80 bytes), yet kernel still returned E2BIG. Pulumi diff showed an in-place update on `command:local:Command::security-report-baas--test/baas` and a coincidental provider URN upgrade (`default → default_1_2_1`). My first instinct was the migration was carrying old state somewhere — wrong.

## Actual root cause

Reading `pulumi-command/provider/pkg/provider/local/commandOutputs.go::run()`:

```go
if in.AddPreviousOutputInEnv == nil || *in.AddPreviousOutputInEnv {
    if out.Stdout != "" {
        cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s",
            util.PulumiCommandStdout, out.Stdout))
    }
    if out.Stderr != "" { ... }
}
```

**`AddPreviousOutputInEnv` defaults to true.** On every Update, the provider injects the previous run's full stdout as a single `PULUMI_COMMAND_STDOUT=<…>` env var.

The security-report script writes the rendered vulnerability table (thousands of CVE rows from Trivy + Grype merged) to stdout for inline build-log visibility — on a chrome-base-derived image, ~150-200 KB. pulumi-command captures that into the resource's `Stdout` output. On the next Update, kernel ARG_MAX (~128 KB on Linux, covering argv + envp combined) trips at fork/exec — even though our argv is the ~80-byte `sh '/tmp/...'`.

The earlier suspect (provider migration) was a red herring. Update path reads `news.Create`, not `olds.Create`:

```go
// commandController.go
func (c *Command) Update(ctx, req) {
    cmd := news.Create   // not olds.Create
    err := run(ctx, *cmd, state.BaseInputs, ...)
}
```

## Empirical signature this matches

- `scan-baas--test/baas-merged` Update **succeeded** before security-report failed. Both used the same provider migration; the difference is scan-merged's stdout is a short summary (~few KB).
- `security-report-baas--test/baas` Update **failed** with E2BIG. Its stdout is the full ~150 KB table.
- Argv shown in the error is short. The bloat is envp, not argv.

## Fix

`AddPreviousOutputInEnv: sdk.Bool(false)` on the security-report `CommandArgs`. The security script doesn't read `PULUMI_COMMAND_STDOUT`, so disabling the env injection is a no-op for script behaviour. Stdout is still captured into Pulumi state for `pulumi stack output` and downstream references — just not re-injected into envp.

## Why this is better than `ReplaceOnChanges + DeleteBeforeReplace`

The first draft of this PR used those options. They happen to work (replace creates a fresh resource with empty `out.Stdout`, so the env injection has nothing to pass) — but for the wrong reason:

1. Replace cycle every time report content changes (every deploy with new CVEs) is wasteful churn.
2. Doesn't address the actual root cause; if pulumi-command ever passes state by other means we'd regress.
3. Replace-vs-update in operator-visible Pulumi diffs is noise.

`AddPreviousOutputInEnv: false` is surgical and pinpoints the real issue.

## Blast radius

Audited every `local.NewCommand` site in SC's docker package:

| Resource | Stdout size | Risk | Action |
|---|---|---|---|
| `security-report-<image>` | Unbounded (rendered CVE table) | **HIGH** | **Fix in this PR** |
| `scan-<image>-merged` / `scan-<image>-<tool>` | Bounded (~few KB summary) | Low | Worth defense-in-depth follow-up |
| `registry-login-<image>` | ~zero | Safe | — |
| `sign-<image>` / `verify-<image>` / `sbom-<image>` / `provenance-<image>` (via `newSecurityCommand`) | Bounded (cosign/syft output) | Low | Worth defense-in-depth follow-up |

Defense-in-depth across all security commands is a follow-up; this PR addresses the bug that's currently breaking deploys.

## Test plan

- [x] `go build ./pkg/clouds/pulumi/docker/...` clean
- [x] `go test ./pkg/clouds/pulumi/docker/...` — all 9 existing tests pass
- [x] `go vet ./pkg/clouds/pulumi/docker/...` clean
- [x] Read pulumi-command source to confirm root cause
- [x] Cross-reference scan-merged success vs security-report failure to validate the stdout-size hypothesis
- [ ] CI on this PR
- [ ] Release + install-sc bump + retry baas deploy 26690935574 → confirm security-report Pulumi resource completes