### PR TITLE
fix(caddy): stop catch-all 503 page from leaking stack + operator runbook

### DIFF
--- a/pkg/clouds/pulumi/kubernetes/embed/caddy/pages/503.html
+++ b/pkg/clouds/pulumi/kubernetes/embed/caddy/pages/503.html
@@ -5,13 +5,18 @@
     h1 { font-size: 50px; }
     body { font: 20px Helvetica, sans-serif; color: #333; }
     article { display: block; text-align: left; width: 650px; margin: 0 auto; }
-    code { background: #eee; padding: 2px 6px; border-radius: 3px; font-size: 16px; }
 </style>
 
+<!--
+  Public-facing body only. Do NOT add operator runbooks, stack
+  identifiers (simple-container.com / Caddy / k8s annotations), or
+  remediation hints here: this catch-all answers every unknown Host for
+  unauthenticated clients and cannot distinguish an operator from an
+  attacker. The runbook for "no backend route for this Host" lives in
+  pkg/clouds/pulumi/kubernetes/caddy.go (default 503 block rationale)
+  and in the generate-caddyfile init-container logs.
+-->
 <article>
     <h1>503 Service Unavailable</h1>
-    <p>No backend route is configured for this host.</p>
-    <p>If you are an operator, verify the Service has the
-       <code>simple-container.com/caddyfile-entry</code> annotation and that
-       Caddy has been rolled.</p>
+    <p>This service is temporarily unavailable. Please try again in a few moments.</p>
 </article>


### PR DESCRIPTION
## Problem

The catch-all `503` page introduced in #255 (which correctly replaced the old silent-`200` white-screen so monitoring/CDN failover works) serves an **information-disclosure body** to every unauthenticated client that hits an unknown `Host`:

```
503 Service Unavailable
No backend route is configured for this host.
If you are an operator, verify the Service has the
simple-container.com/caddyfile-entry annotation and that Caddy has been rolled.
```

This leaks:
- the **stack identity** (`simple-container.com` -> Caddy -> Kubernetes) — a fingerprinting gift for an attacker
- an **operator remediation runbook** published on the open internet

## Fix

Keep the page **clearly recognizable as a 503** (English heading + copy, the same style as the existing `404.html` / `500.html`) but strip the stack identifier and the operator runbook:

```html
<h1>503 Service Unavailable</h1>
<p>This service is temporarily unavailable. Please try again in a few moments.</p>
```

A public catch-all answers every unknown Host for unauthenticated clients and **cannot distinguish an operator from an attacker**, so the runbook cannot safely live in the response (body, header, or even an HTML comment).

**Unchanged** — `status 503`, `Retry-After`, `Cache-Control: no-store`, and the catch-all `handle` block in `caddy.go`. CDN failover, uptime checks, and on-call signal behave exactly as #255 intended.

**Where the runbook went** — it stays in the `caddy.go` default-503 rationale comment and the `generate-caddyfile` init-container logs, where only operators can see it. A guard comment in the page warns the next editor not to re-add disclosure.

No tests assert the page body; the two remaining `caddyfile-entry` hits in `caddy.go` are internal bash comments that are never served.

## Rollout note

The page ships inside the SC-api binary's embed FS, so this only takes effect once a release with this change is cut and consumers bump their pinned SC version.
