### PR TITLE
fix(caddy): stop 503 page HTML comment from re-leaking the stack identity

### DIFF
--- a/pkg/clouds/pulumi/kubernetes/caddy.go
+++ b/pkg/clouds/pulumi/kubernetes/caddy.go
@@ -123,6 +123,14 @@ func DeployCaddyService(ctx *sdk.Context, caddy CaddyDeployment, input api.Resou
 	// - Operators can override the 503 body by mounting a different ConfigMap
 	//   at /etc/caddy/pages/503.html without touching SC api code.
 	//
+	// Keep pages/503.html generic — it answers every unknown Host for
+	// unauthenticated clients, which cannot be distinguished from operators.
+	// No stack identifiers, internal paths, or remediation runbooks in the
+	// body OR in HTML comments (comments ship in the response too — that was
+	// the bug behind this very page once leaking the caddyfile-entry runbook).
+	// The operator runbook for "no backend route for this Host" is this
+	// comment block plus the generate-caddyfile init-container logs.
+	//
 	// Wrapped in `handle { ... }` so the directives below apply only to the
 	// 503 path and nothing else can short-circuit (e.g. `import hsts` redir
 	// firing before the response). We also intentionally do NOT `import hsts`

--- a/pkg/clouds/pulumi/kubernetes/embed/caddy/pages/503.html
+++ b/pkg/clouds/pulumi/kubernetes/embed/caddy/pages/503.html
@@ -7,15 +7,7 @@
     article { display: block; text-align: left; width: 650px; margin: 0 auto; }
 </style>
 
-<!--
-  Public-facing body only. Do NOT add operator runbooks, stack
-  identifiers (simple-container.com / Caddy / k8s annotations), or
-  remediation hints here: this catch-all answers every unknown Host for
-  unauthenticated clients and cannot distinguish an operator from an
-  attacker. The runbook for "no backend route for this Host" lives in
-  pkg/clouds/pulumi/kubernetes/caddy.go (default 503 block rationale)
-  and in the generate-caddyfile init-container logs.
--->
+<!-- Served to unauthenticated clients on any unknown host. Keep generic: no internal, infrastructure, or diagnostic detail (this comment ships in the response). -->
 <article>
     <h1>503 Service Unavailable</h1>
     <p>This service is temporarily unavailable. Please try again in a few moments.</p>


### PR DESCRIPTION
## Problem

#308 fixed the visible body of the catch-all `503` page, but left this maintainer guard comment **in the served HTML**:

```html
<!--
  ... stack identifiers (simple-container.com / Caddy / k8s annotations) ...
  ... pkg/clouds/pulumi/kubernetes/caddy.go ... generate-caddyfile init-container logs.
-->
```

HTML comments are part of the response body — they are sent to every client. So the comment re-disclosed the exact stack fingerprint (`simple-container.com` / Caddy / k8s) and an internal source path that #308 had just removed from the visible text. `view-source:` on any unknown-host `503` showed it.

## Fix

- Replace the comment with a generic one-liner that names nothing and notes that the comment itself ships in the response.
- Move the detailed rationale — including the "comments are served too" lesson — into the `caddy.go` default-503 block, which is source and never served.

Visible body, `status 503`, `Retry-After`, `Cache-Control` and the `handle` block are all unchanged.
