### PR TITLE
fix(security+k8s): retry cosign sign on Rekor 409 conflict; honor cloudExtras startupProbe + periodSeconds

### DIFF
--- a/docs/docs/guides/parent-gcp-gke-autopilot.md
+++ b/docs/docs/guides/parent-gcp-gke-autopilot.md
@@ -683,6 +683,22 @@ stacks:
           timeoutSeconds: 10
           periodSeconds: 30
           failureThreshold: 3
+
+        # Global startup probe configuration — the cold-start budget.
+        # Readiness/liveness checks are suspended until this probe succeeds,
+        # so a slow first boot (image pull, migrations, JIT warmup) is not
+        # killed mid-start. Total budget here: 10s + 16 × 15s = 250s.
+        # Without it, the startup window defaults to the readiness probe,
+        # whose short thresholds are tuned for steady-state, not first boot.
+        startupProbe:
+          httpGet:
+            path: "/health"
+            port: 8080
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 15
+          failureThreshold: 16
+          successThreshold: 1
 ```
 
 ## **CloudExtras Field Reference**
@@ -697,6 +713,7 @@ stacks:
 | `vpa`                | `object`            | Vertical Pod Autoscaler                      | Native GKE support             |
 | `readinessProbe`     | `object`            | Global readiness probe                       | Full support                   |
 | `livenessProbe`      | `object`            | Global liveness probe                        | Full support                   |
+| `startupProbe`       | `object`            | Global startup probe (cold-start budget)     | Full support                   |
 | `priorityClassName`  | `string`            | Kubernetes PriorityClass for pod scheduling  | Full support                   |
 | `ephemeralVolumes`   | `[]object`          | Generic ephemeral volumes (>10GB storage)    | Full support                   |
 

--- a/docs/docs/troubleshooting/container-security.md
+++ b/docs/docs/troubleshooting/container-security.md
@@ -113,6 +113,30 @@ signing:
    ```
 3. Re-sign image if signature corrupted
 
+### Error: "createLogEntryConflict" (Rekor HTTP 409)
+
+**Problem:** `sc image sign` fails with:
+
+```
+signing bundle: error signing bundle: [POST /api/v1/log/entries][409] createLogEntryConflict
+{"code":409,"message":"an equivalent entry already exists in the transparency log with UUID ..."}
+```
+
+An identical entry is already in the transparency log — typically cosign
+re-uploading an entry whose first attempt timed out client-side but succeeded
+server-side. Common under parallel CI deploys of stacks that share one image.
+The image *is* effectively signed; only the duplicate upload was rejected.
+
+**Solution:**
+
+- `sc` retries the sign automatically with a fresh signature (a fresh
+  invocation cannot conflict with itself), so transient conflicts self-heal.
+- If the error persists after the automatic retries, verify the existing
+  signature instead of re-signing: `cosign tree IMAGE` and `sc image verify`.
+- Persistent conflicts with key-based signing can indicate a deterministic
+  re-sign of an unchanged digest — skip signing when the digest is already
+  signed by the same identity.
+
 ### Warning: "Rekor entry not found"
 
 **Problem:** Keyless signature not in transparency log.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/simple-container-com/api
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/storage v1.62.2

--- a/pkg/clouds/gcloud/gke_autopilot.go
+++ b/pkg/clouds/gcloud/gke_autopilot.go
@@ -107,6 +107,7 @@ func ToGkeAutopilotConfig(tpl any, composeCfg compose.Config, stackCfg *api.Stac
 		deployCfg.VPA = k8sCloudExtras.VPA                             // Extract VPA configuration from CloudExtras
 		deployCfg.ReadinessProbe = k8sCloudExtras.ReadinessProbe       // Extract global readiness probe configuration
 		deployCfg.LivenessProbe = k8sCloudExtras.LivenessProbe         // Extract global liveness probe configuration
+		deployCfg.StartupProbe = k8sCloudExtras.StartupProbe           // Extract global startup probe configuration
 		deployCfg.PriorityClassName = k8sCloudExtras.PriorityClassName // Extract PriorityClass for pod scheduling and preemption
 
 		// Process affinity rules and merge with existing NodeSelector if needed

--- a/pkg/clouds/k8s/kube_run.go
+++ b/pkg/clouds/k8s/kube_run.go
@@ -25,6 +25,7 @@ type CloudExtras struct {
 	VPA               *VPAConfig               `json:"vpa" yaml:"vpa"`
 	ReadinessProbe    *CloudRunProbe           `json:"readinessProbe" yaml:"readinessProbe"`
 	LivenessProbe     *CloudRunProbe           `json:"livenessProbe" yaml:"livenessProbe"`
+	StartupProbe      *CloudRunProbe           `json:"startupProbe" yaml:"startupProbe"`
 	EphemeralVolumes  []GenericEphemeralVolume `json:"ephemeralVolumes" yaml:"ephemeralVolumes"`   // Generic ephemeral volumes for large temp storage
 	PriorityClassName *string                  `json:"priorityClassName" yaml:"priorityClassName"` // Kubernetes PriorityClass for pod scheduling and preemption
 }

--- a/pkg/clouds/k8s/kube_run_probe_test.go
+++ b/pkg/clouds/k8s/kube_run_probe_test.go
@@ -8,10 +8,7 @@ import (
 	"github.com/simple-container-com/api/pkg/api"
 )
 
-// TestStartupProbeExtraction is the regression test for cloudExtras.startupProbe
-// being silently dropped: CloudExtras had no StartupProbe field, so user-supplied
-// startup budgets never reached the cluster and pods fell back to the readiness
-// probe's (short) window during cold starts.
+// Regression: cloudExtras.startupProbe was silently dropped (no struct field).
 func TestStartupProbeExtraction(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -42,9 +39,7 @@ func TestStartupProbeExtraction(t *testing.T) {
 	Expect(*result.StartupProbe.SuccessThreshold).To(Equal(1))
 }
 
-// TestProbePeriodSecondsExtraction covers the k8s-native periodSeconds spelling on
-// the readiness probe. Previously only the duration-typed `interval` key existed,
-// so configs written with periodSeconds silently fell back to the kubelet default.
+// Regression: periodSeconds was an unknown key and fell back to kubelet defaults.
 func TestProbePeriodSecondsExtraction(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -67,7 +62,6 @@ func TestProbePeriodSecondsExtraction(t *testing.T) {
 	Expect(*result.ReadinessProbe.FailureThreshold).To(Equal(3))
 }
 
-// TestStartupProbeAbsent ensures the zero-value path stays nil.
 func TestStartupProbeAbsent(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/pkg/clouds/k8s/kube_run_probe_test.go
+++ b/pkg/clouds/k8s/kube_run_probe_test.go
@@ -3,8 +3,7 @@ package k8s
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/gomega"
 
 	"github.com/simple-container-com/api/pkg/api"
 )
@@ -14,6 +13,8 @@ import (
 // startup budgets never reached the cluster and pods fell back to the readiness
 // probe's (short) window during cold starts.
 func TestStartupProbeExtraction(t *testing.T) {
+	RegisterTestingT(t)
+
 	cloudExtras := map[string]any{
 		"startupProbe": map[string]any{
 			"httpGet": map[string]any{
@@ -30,21 +31,23 @@ func TestStartupProbeExtraction(t *testing.T) {
 
 	result, err := api.ConvertDescriptor(cloudExtras, &CloudExtras{})
 
-	require.NoError(t, err)
-	require.NotNil(t, result.StartupProbe)
-	assert.Equal(t, "/health/", result.StartupProbe.HttpGet.Path)
-	assert.Equal(t, 8000, result.StartupProbe.HttpGet.Port)
-	assert.Equal(t, 10, *result.StartupProbe.InitialDelaySeconds)
-	assert.Equal(t, 5, *result.StartupProbe.TimeoutSeconds)
-	assert.Equal(t, 15, *result.StartupProbe.PeriodSeconds)
-	assert.Equal(t, 16, *result.StartupProbe.FailureThreshold)
-	assert.Equal(t, 1, *result.StartupProbe.SuccessThreshold)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(result.StartupProbe).ToNot(BeNil())
+	Expect(result.StartupProbe.HttpGet.Path).To(Equal("/health/"))
+	Expect(result.StartupProbe.HttpGet.Port).To(Equal(8000))
+	Expect(*result.StartupProbe.InitialDelaySeconds).To(Equal(10))
+	Expect(*result.StartupProbe.TimeoutSeconds).To(Equal(5))
+	Expect(*result.StartupProbe.PeriodSeconds).To(Equal(15))
+	Expect(*result.StartupProbe.FailureThreshold).To(Equal(16))
+	Expect(*result.StartupProbe.SuccessThreshold).To(Equal(1))
 }
 
 // TestProbePeriodSecondsExtraction covers the k8s-native periodSeconds spelling on
 // the readiness probe. Previously only the duration-typed `interval` key existed,
 // so configs written with periodSeconds silently fell back to the kubelet default.
 func TestProbePeriodSecondsExtraction(t *testing.T) {
+	RegisterTestingT(t)
+
 	cloudExtras := map[string]any{
 		"readinessProbe": map[string]any{
 			"httpGet": map[string]any{
@@ -58,16 +61,18 @@ func TestProbePeriodSecondsExtraction(t *testing.T) {
 
 	result, err := api.ConvertDescriptor(cloudExtras, &CloudExtras{})
 
-	require.NoError(t, err)
-	require.NotNil(t, result.ReadinessProbe)
-	assert.Equal(t, 20, *result.ReadinessProbe.PeriodSeconds)
-	assert.Equal(t, 3, *result.ReadinessProbe.FailureThreshold)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(result.ReadinessProbe).ToNot(BeNil())
+	Expect(*result.ReadinessProbe.PeriodSeconds).To(Equal(20))
+	Expect(*result.ReadinessProbe.FailureThreshold).To(Equal(3))
 }
 
 // TestStartupProbeAbsent ensures the zero-value path stays nil.
 func TestStartupProbeAbsent(t *testing.T) {
+	RegisterTestingT(t)
+
 	result, err := api.ConvertDescriptor(map[string]any{}, &CloudExtras{})
 
-	require.NoError(t, err)
-	assert.Nil(t, result.StartupProbe)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(result.StartupProbe).To(BeNil())
 }

--- a/pkg/clouds/k8s/kube_run_probe_test.go
+++ b/pkg/clouds/k8s/kube_run_probe_test.go
@@ -1,0 +1,73 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/simple-container-com/api/pkg/api"
+)
+
+// TestStartupProbeExtraction is the regression test for cloudExtras.startupProbe
+// being silently dropped: CloudExtras had no StartupProbe field, so user-supplied
+// startup budgets never reached the cluster and pods fell back to the readiness
+// probe's (short) window during cold starts.
+func TestStartupProbeExtraction(t *testing.T) {
+	cloudExtras := map[string]any{
+		"startupProbe": map[string]any{
+			"httpGet": map[string]any{
+				"path": "/health/",
+				"port": 8000,
+			},
+			"initialDelaySeconds": 10,
+			"timeoutSeconds":      5,
+			"periodSeconds":       15,
+			"failureThreshold":    16,
+			"successThreshold":    1,
+		},
+	}
+
+	result, err := api.ConvertDescriptor(cloudExtras, &CloudExtras{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.StartupProbe)
+	assert.Equal(t, "/health/", result.StartupProbe.HttpGet.Path)
+	assert.Equal(t, 8000, result.StartupProbe.HttpGet.Port)
+	assert.Equal(t, 10, *result.StartupProbe.InitialDelaySeconds)
+	assert.Equal(t, 5, *result.StartupProbe.TimeoutSeconds)
+	assert.Equal(t, 15, *result.StartupProbe.PeriodSeconds)
+	assert.Equal(t, 16, *result.StartupProbe.FailureThreshold)
+	assert.Equal(t, 1, *result.StartupProbe.SuccessThreshold)
+}
+
+// TestProbePeriodSecondsExtraction covers the k8s-native periodSeconds spelling on
+// the readiness probe. Previously only the duration-typed `interval` key existed,
+// so configs written with periodSeconds silently fell back to the kubelet default.
+func TestProbePeriodSecondsExtraction(t *testing.T) {
+	cloudExtras := map[string]any{
+		"readinessProbe": map[string]any{
+			"httpGet": map[string]any{
+				"path": "/ready/",
+				"port": 8080,
+			},
+			"periodSeconds":    20,
+			"failureThreshold": 3,
+		},
+	}
+
+	result, err := api.ConvertDescriptor(cloudExtras, &CloudExtras{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ReadinessProbe)
+	assert.Equal(t, 20, *result.ReadinessProbe.PeriodSeconds)
+	assert.Equal(t, 3, *result.ReadinessProbe.FailureThreshold)
+}
+
+// TestStartupProbeAbsent ensures the zero-value path stays nil.
+func TestStartupProbeAbsent(t *testing.T) {
+	result, err := api.ConvertDescriptor(map[string]any{}, &CloudExtras{})
+
+	require.NoError(t, err)
+	assert.Nil(t, result.StartupProbe)
+}

--- a/pkg/clouds/k8s/types.go
+++ b/pkg/clouds/k8s/types.go
@@ -30,6 +30,7 @@ type DeploymentConfig struct {
 	VPA               *VPAConfig               `json:"vpa" yaml:"vpa"`                             // Vertical Pod Autoscaler configuration
 	ReadinessProbe    *CloudRunProbe           `json:"readinessProbe" yaml:"readinessProbe"`       // Global readiness probe configuration
 	LivenessProbe     *CloudRunProbe           `json:"livenessProbe" yaml:"livenessProbe"`         // Global liveness probe configuration
+	StartupProbe      *CloudRunProbe           `json:"startupProbe" yaml:"startupProbe"`           // Global startup probe configuration
 	EphemeralVolumes  []GenericEphemeralVolume `json:"ephemeralVolumes" yaml:"ephemeralVolumes"`   // Generic ephemeral volumes for large temp storage
 	PriorityClassName *string                  `json:"priorityClassName" yaml:"priorityClassName"` // Kubernetes PriorityClass for pod scheduling and preemption
 }
@@ -134,6 +135,7 @@ type CloudRunProbe struct {
 	Interval            *time.Duration `json:"interval" yaml:"interval"`
 	InitialDelaySeconds *int           `json:"initialDelaySeconds" yaml:"initialDelaySeconds"`
 	IntervaSeconds      *int           `json:"intervaSeconds" yaml:"intervaSeconds"`
+	PeriodSeconds       *int           `json:"periodSeconds" yaml:"periodSeconds"` // k8s-native spelling; takes precedence over Interval
 	FailureThreshold    *int           `json:"failureThreshold" yaml:"failureThreshold"`
 	SuccessThreshold    *int           `json:"successThreshold" yaml:"successThreshold"`
 	TimeoutSeconds      *int           `json:"timeoutSeconds" yaml:"timeoutSeconds"`

--- a/pkg/clouds/k8s/types.go
+++ b/pkg/clouds/k8s/types.go
@@ -134,8 +134,8 @@ type CloudRunProbe struct {
 	HttpGet             ProbeHttpGet   `json:"httpGet" yaml:"httpGet"`
 	Interval            *time.Duration `json:"interval" yaml:"interval"`
 	InitialDelaySeconds *int           `json:"initialDelaySeconds" yaml:"initialDelaySeconds"`
-	IntervaSeconds      *int           `json:"intervaSeconds" yaml:"intervaSeconds"`
-	PeriodSeconds       *int           `json:"periodSeconds" yaml:"periodSeconds"` // k8s-native spelling; takes precedence over Interval
+	IntervaSeconds      *int           `json:"intervaSeconds" yaml:"intervaSeconds"` // Deprecated: misspelled and never consumed; use periodSeconds
+	PeriodSeconds       *int           `json:"periodSeconds" yaml:"periodSeconds"`   // k8s-native spelling; takes precedence over Interval
 	FailureThreshold    *int           `json:"failureThreshold" yaml:"failureThreshold"`
 	SuccessThreshold    *int           `json:"successThreshold" yaml:"successThreshold"`
 	TimeoutSeconds      *int           `json:"timeoutSeconds" yaml:"timeoutSeconds"`

--- a/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
+++ b/pkg/clouds/pulumi/gcp/gke_autopilot_stack.go
@@ -189,6 +189,7 @@ func GkeAutopilotStack(ctx *sdk.Context, stack api.Stack, input api.ResourceInpu
 		VPA:            gkeAutopilotInput.Deployment.VPA,            // Pass VPA configuration to Kubernetes deployment
 		ReadinessProbe: gkeAutopilotInput.Deployment.ReadinessProbe, // Pass global readiness probe configuration
 		LivenessProbe:  gkeAutopilotInput.Deployment.LivenessProbe,  // Pass global liveness probe configuration
+		StartupProbe:   gkeAutopilotInput.Deployment.StartupProbe,   // Pass global startup probe configuration
 		EphemeralSize:  ephemeralSize,
 	}
 

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -187,7 +187,10 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		}
 		if cStartupProbe == nil && (len(c.Container.Ports) == 1 || c.Container.MainPort != nil) {
 			startupProbe = readinessProbe
-		} else if cStartupProbe != nil && (len(c.Container.Ports) == 1 || c.Container.MainPort != nil) {
+		} else if cStartupProbe != nil {
+			// An explicit probe carries its own port resolution (httpGet.port /
+			// mainPort / first port) — mirror the readiness behavior instead of
+			// dropping it on multi-port containers.
 			startupProbe = toProbeArgs(c, cStartupProbe)
 		}
 

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -46,6 +46,7 @@ type Args struct {
 	VPA                    *k8s.VPAConfig     // Vertical Pod Autoscaler configuration
 	ReadinessProbe         *k8s.CloudRunProbe // Global readiness probe configuration
 	LivenessProbe          *k8s.CloudRunProbe // Global liveness probe configuration
+	StartupProbe           *k8s.CloudRunProbe // Global startup probe configuration
 	EphemeralSize          string
 	// TerminationGracePeriodSeconds overrides pod-level terminationGracePeriodSeconds.
 	TerminationGracePeriodSeconds *int
@@ -177,10 +178,17 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		}
 
 		var startupProbe *corev1.ProbeArgs
-		if c.Container.StartupProbe == nil && (len(c.Container.Ports) == 1 || c.Container.MainPort != nil) {
+		cStartupProbe := c.Container.StartupProbe
+		// Use global startup probe if container doesn't have one AND it's the ingress container,
+		// mirroring the readiness/liveness fallback above. Without this, a slow-booting service
+		// is stuck with the readiness probe's (short) window as its startup budget.
+		if cStartupProbe == nil && args.StartupProbe != nil && isIngressContainer {
+			cStartupProbe = args.StartupProbe
+		}
+		if cStartupProbe == nil && (len(c.Container.Ports) == 1 || c.Container.MainPort != nil) {
 			startupProbe = readinessProbe
-		} else if c.Container.StartupProbe != nil && (len(c.Container.Ports) == 1 || c.Container.MainPort != nil) {
-			startupProbe = toProbeArgs(c, c.Container.StartupProbe)
+		} else if cStartupProbe != nil && (len(c.Container.Ports) == 1 || c.Container.MainPort != nil) {
+			startupProbe = toProbeArgs(c, cStartupProbe)
 		}
 
 		var resources corev1.ResourceRequirementsArgs
@@ -325,8 +333,14 @@ func toProbeArgs(c *ContainerImage, probe *k8s.CloudRunProbe) *corev1.ProbeArgs 
 		probePort = c.Container.Ports[0]
 	}
 
+	// periodSeconds (k8s-native spelling) wins over the legacy duration-typed interval;
+	// duration values only survive YAML conversion when given as Go duration strings.
+	periodSeconds := probe.PeriodSeconds
+	if periodSeconds == nil && probe.Interval != nil {
+		periodSeconds = lo.ToPtr(int(lo.FromPtr(probe.Interval).Seconds()))
+	}
 	probeArgs := &corev1.ProbeArgs{
-		PeriodSeconds:       sdk.IntPtrFromPtr(lo.If(probe.Interval != nil, lo.ToPtr(int(lo.FromPtr(probe.Interval).Seconds()))).Else(nil)),
+		PeriodSeconds:       sdk.IntPtrFromPtr(periodSeconds),
 		InitialDelaySeconds: sdk.IntPtrFromPtr(probe.InitialDelaySeconds),
 		FailureThreshold:    sdk.IntPtrFromPtr(probe.FailureThreshold),
 		SuccessThreshold:    sdk.IntPtrFromPtr(probe.SuccessThreshold),

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -179,18 +179,14 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 
 		var startupProbe *corev1.ProbeArgs
 		cStartupProbe := c.Container.StartupProbe
-		// Use global startup probe if container doesn't have one AND it's the ingress container,
-		// mirroring the readiness/liveness fallback above. Without this, a slow-booting service
-		// is stuck with the readiness probe's (short) window as its startup budget.
+		// Global fallback for the ingress container only, mirroring readiness/liveness above
 		if cStartupProbe == nil && args.StartupProbe != nil && isIngressContainer {
 			cStartupProbe = args.StartupProbe
 		}
 		if cStartupProbe == nil && (len(c.Container.Ports) == 1 || c.Container.MainPort != nil) {
 			startupProbe = readinessProbe
 		} else if cStartupProbe != nil {
-			// An explicit probe carries its own port resolution (httpGet.port /
-			// mainPort / first port) — mirror the readiness behavior instead of
-			// dropping it on multi-port containers.
+			// Explicit probes resolve their own port — apply even on multi-port containers
 			startupProbe = toProbeArgs(c, cStartupProbe)
 		}
 
@@ -336,8 +332,7 @@ func toProbeArgs(c *ContainerImage, probe *k8s.CloudRunProbe) *corev1.ProbeArgs 
 		probePort = c.Container.Ports[0]
 	}
 
-	// periodSeconds (k8s-native spelling) wins over the legacy duration-typed interval;
-	// duration values only survive YAML conversion when given as Go duration strings.
+	// periodSeconds (k8s-native) wins over the legacy duration-typed interval
 	periodSeconds := probe.PeriodSeconds
 	if periodSeconds == nil && probe.Interval != nil {
 		periodSeconds = lo.ToPtr(int(lo.FromPtr(probe.Interval).Seconds()))

--- a/pkg/clouds/pulumi/kubernetes/deployment_test.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	sdk "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/samber/lo"
 
 	"github.com/simple-container-com/api/pkg/clouds/k8s"
@@ -325,4 +326,65 @@ func TestToProbeArgs_HeaderPreservation(t *testing.T) {
 
 	Expect(result).ToNot(BeNil(), "ProbeArgs should not be nil")
 	Expect(result.HttpGet).ToNot(BeNil(), "Should have HTTP GET configured")
+}
+
+// TestToProbeArgs_PeriodSeconds verifies the precedence between the k8s-native
+// periodSeconds field and the legacy duration-typed interval field.
+func TestToProbeArgs_PeriodSeconds(t *testing.T) {
+	container := &ContainerImage{
+		Container: k8s.CloudRunContainer{
+			Name:     "test-container",
+			Ports:    []int{8080},
+			MainPort: lo.ToPtr(8080),
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		probe    *k8s.CloudRunProbe
+		expected sdk.IntPtrInput
+	}{
+		{
+			name: "periodSeconds used directly",
+			probe: &k8s.CloudRunProbe{
+				PeriodSeconds: lo.ToPtr(15),
+			},
+			expected: sdk.IntPtr(15),
+		},
+		{
+			name: "interval converted to seconds when periodSeconds absent",
+			probe: &k8s.CloudRunProbe{
+				Interval: lo.ToPtr(20 * time.Second),
+			},
+			expected: sdk.IntPtr(20),
+		},
+		{
+			name: "periodSeconds wins over interval",
+			probe: &k8s.CloudRunProbe{
+				PeriodSeconds: lo.ToPtr(15),
+				Interval:      lo.ToPtr(99 * time.Second),
+			},
+			expected: sdk.IntPtr(15),
+		},
+		{
+			name:     "neither set leaves kubelet default",
+			probe:    &k8s.CloudRunProbe{},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterTestingT(t)
+
+			result := toProbeArgs(container, tc.probe)
+
+			Expect(result).ToNot(BeNil())
+			if tc.expected == nil {
+				Expect(result.PeriodSeconds).To(BeNil())
+			} else {
+				Expect(result.PeriodSeconds).To(Equal(tc.expected))
+			}
+		})
+	}
 }

--- a/pkg/clouds/pulumi/kubernetes/kube_run.go
+++ b/pkg/clouds/pulumi/kubernetes/kube_run.go
@@ -145,6 +145,7 @@ func KubeRun(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params 
 		VPA:            kubeRunInput.Deployment.VPA,            // Pass VPA configuration from DeploymentConfig
 		ReadinessProbe: kubeRunInput.Deployment.ReadinessProbe, // Pass global readiness probe configuration
 		LivenessProbe:  kubeRunInput.Deployment.LivenessProbe,  // Pass global liveness probe configuration
+		StartupProbe:   kubeRunInput.Deployment.StartupProbe,   // Pass global startup probe configuration
 		EphemeralSize:  lo.FromPtr(kubeRunInput.Deployment.StackConfig).Size.Ephemeral,
 	}
 

--- a/pkg/security/signing/keybased.go
+++ b/pkg/security/signing/keybased.go
@@ -73,9 +73,8 @@ func (s *KeyBasedSigner) Sign(ctx context.Context, imageRef string) (*SignResult
 
 	// Execute cosign sign command
 	args := []string{"sign", "--key", keyPath, imageRef}
-	stdout, stderr, err := tools.ExecCommand(ctx, "cosign", args, env, s.Timeout)
-	if err != nil {
-		return nil, fmt.Errorf("cosign sign failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
+	if _, err := runCosignSign(ctx, args, env, s.Timeout); err != nil {
+		return nil, err
 	}
 
 	result := &SignResult{

--- a/pkg/security/signing/keybased.go
+++ b/pkg/security/signing/keybased.go
@@ -15,6 +15,9 @@ type KeyBasedSigner struct {
 	PrivateKey string // Path to private key file or key content
 	Password   string // Optional password for encrypted keys
 	Timeout    time.Duration
+
+	// exec overrides command execution in tests; nil means tools.ExecCommand.
+	exec execFn
 }
 
 // NewKeyBasedSigner creates a new key-based signer
@@ -73,7 +76,11 @@ func (s *KeyBasedSigner) Sign(ctx context.Context, imageRef string) (*SignResult
 
 	// Execute cosign sign command
 	args := []string{"sign", "--key", keyPath, imageRef}
-	if _, err := runCosignSign(ctx, args, env, s.Timeout); err != nil {
+	exec := s.exec
+	if exec == nil {
+		exec = tools.ExecCommand
+	}
+	if _, err := runCosignSign(ctx, exec, args, env, s.Timeout); err != nil {
 		return nil, err
 	}
 

--- a/pkg/security/signing/keybased_test.go
+++ b/pkg/security/signing/keybased_test.go
@@ -105,10 +105,8 @@ func TestKeyBasedSignerPasswordHandling(t *testing.T) {
 func TestKeyBasedSigner_Sign_GivesUpOnPersistentRekorConflict(t *testing.T) {
 	RegisterTestingT(t)
 
-	// A deterministic key (e.g. ed25519) reproduces the same signature on
-	// retry, so a persistent conflict must exhaust the bounded loop and
-	// surface the error — never be treated as success: a tlog entry existing
-	// does not prove the signature was attached to the registry.
+	// Deterministic keys reproduce the same signature: a persistent conflict
+	// must exhaust the loop and fail, never be treated as success.
 	calls := 0
 	signer := NewKeyBasedSigner("test-key-content", "", time.Second)
 	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {

--- a/pkg/security/signing/keybased_test.go
+++ b/pkg/security/signing/keybased_test.go
@@ -2,6 +2,7 @@ package signing
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,4 +100,45 @@ func TestKeyBasedSignerPasswordHandling(t *testing.T) {
 
 	withPassword := NewKeyBasedSigner("/tmp/cosign.key", "secret123", 5*time.Minute)
 	Expect(strings.Contains("COSIGN_PASSWORD="+withPassword.Password, "COSIGN_PASSWORD=secret123")).To(BeTrue())
+}
+
+func TestKeyBasedSigner_Sign_GivesUpOnPersistentRekorConflict(t *testing.T) {
+	RegisterTestingT(t)
+
+	// A deterministic key (e.g. ed25519) reproduces the same signature on
+	// retry, so a persistent conflict must exhaust the bounded loop and
+	// surface the error — never be treated as success: a tlog entry existing
+	// does not prove the signature was attached to the registry.
+	calls := 0
+	signer := NewKeyBasedSigner("test-key-content", "", time.Second)
+	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+		calls++
+		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
+	}
+
+	_, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+	Expect(calls).To(Equal(maxSignAttempts))
+}
+
+func TestKeyBasedSigner_Sign_RetriesOnceOnTransientConflict(t *testing.T) {
+	RegisterTestingT(t)
+
+	calls := 0
+	signer := NewKeyBasedSigner("test-key-content", "", time.Second)
+	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+		calls++
+		if calls == 1 {
+			return "", "createLogEntryConflict", fmt.Errorf("exit status 1")
+		}
+		return "", "", nil
+	}
+
+	result, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(result).ToNot(BeNil())
+	Expect(calls).To(Equal(2))
 }

--- a/pkg/security/signing/keyless.go
+++ b/pkg/security/signing/keyless.go
@@ -3,6 +3,7 @@ package signing
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -10,8 +11,9 @@ import (
 	"github.com/simple-container-com/api/pkg/security/tools"
 )
 
-// execCommand is a seam for tests; production code always uses tools.ExecCommand.
-var execCommand = tools.ExecCommand
+// execFn matches tools.ExecCommand; signers carry it as a field so tests can
+// inject a fake without racing on package state.
+type execFn func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error)
 
 // maxSignAttempts bounds the Rekor-conflict retry loop in runCosignSign.
 const maxSignAttempts = 3
@@ -27,13 +29,17 @@ func isRekorConflict(output string) bool {
 }
 
 // runCosignSign executes `cosign sign`, retrying the full invocation when the
-// only failure is a Rekor entry conflict. A fresh invocation mints a fresh
-// (ephemeral or randomized-ECDSA) signature, so a retry cannot conflict with
-// itself; any other error is returned immediately.
-func runCosignSign(ctx context.Context, args, env []string, timeout time.Duration) (string, error) {
+// only failure is a Rekor entry conflict. Keyless (ephemeral key) and
+// randomized-ECDSA key-based invocations mint a fresh signature each run, so
+// their retries cannot conflict with themselves. Deterministic keys (e.g.
+// ed25519) reproduce the same signature — for them the bounded loop exhausts
+// and surfaces the conflict, which is correct: the tlog entry existing does
+// NOT prove the signature was attached to the registry, so success must not
+// be assumed. Any non-conflict error is returned immediately.
+func runCosignSign(ctx context.Context, exec execFn, args, env []string, timeout time.Duration) (string, error) {
 	var lastErr error
 	for attempt := 1; attempt <= maxSignAttempts; attempt++ {
-		stdout, stderr, err := execCommand(ctx, "cosign", args, env, timeout)
+		stdout, stderr, err := exec(ctx, "cosign", args, env, timeout)
 		if err == nil {
 			return stdout, nil
 		}
@@ -41,7 +47,7 @@ func runCosignSign(ctx context.Context, args, env []string, timeout time.Duratio
 		if !isRekorConflict(stderr) && !isRekorConflict(stdout) {
 			return "", lastErr
 		}
-		fmt.Printf("Warning: Rekor transparency-log conflict on sign attempt %d/%d, retrying with a fresh signature\n", attempt, maxSignAttempts)
+		fmt.Fprintf(os.Stderr, "Warning: Rekor transparency-log conflict on sign attempt %d/%d, retrying\n", attempt, maxSignAttempts)
 	}
 	return "", lastErr
 }
@@ -50,6 +56,9 @@ func runCosignSign(ctx context.Context, args, env []string, timeout time.Duratio
 type KeylessSigner struct {
 	OIDCToken string
 	Timeout   time.Duration
+
+	// exec overrides command execution in tests; nil means tools.ExecCommand.
+	exec execFn
 }
 
 // NewKeylessSigner creates a new keyless signer
@@ -77,7 +86,11 @@ func (s *KeylessSigner) Sign(ctx context.Context, imageRef string) (*SignResult,
 
 	// Execute cosign sign command
 	args := []string{"sign", "--yes", imageRef}
-	stdout, err := runCosignSign(ctx, args, env, s.Timeout)
+	exec := s.exec
+	if exec == nil {
+		exec = tools.ExecCommand
+	}
+	stdout, err := runCosignSign(ctx, exec, args, env, s.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/signing/keyless.go
+++ b/pkg/security/signing/keyless.go
@@ -10,6 +10,42 @@ import (
 	"github.com/simple-container-com/api/pkg/security/tools"
 )
 
+// execCommand is a seam for tests; production code always uses tools.ExecCommand.
+var execCommand = tools.ExecCommand
+
+// maxSignAttempts bounds the Rekor-conflict retry loop in runCosignSign.
+const maxSignAttempts = 3
+
+// isRekorConflict reports whether a cosign failure was caused by Rekor's
+// createLogEntryConflict (HTTP 409 on POST /api/v1/log/entries). This happens
+// when an identical entry is already in the transparency log — typically
+// cosign re-uploading an entry whose first attempt timed out client-side but
+// succeeded server-side (seen under parallel CI runners signing concurrently).
+func isRekorConflict(output string) bool {
+	return strings.Contains(output, "createLogEntryConflict") ||
+		(strings.Contains(output, "409") && strings.Contains(output, "/api/v1/log/entries"))
+}
+
+// runCosignSign executes `cosign sign`, retrying the full invocation when the
+// only failure is a Rekor entry conflict. A fresh invocation mints a fresh
+// (ephemeral or randomized-ECDSA) signature, so a retry cannot conflict with
+// itself; any other error is returned immediately.
+func runCosignSign(ctx context.Context, args, env []string, timeout time.Duration) (string, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxSignAttempts; attempt++ {
+		stdout, stderr, err := execCommand(ctx, "cosign", args, env, timeout)
+		if err == nil {
+			return stdout, nil
+		}
+		lastErr = fmt.Errorf("cosign sign failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
+		if !isRekorConflict(stderr) && !isRekorConflict(stdout) {
+			return "", lastErr
+		}
+		fmt.Printf("Warning: Rekor transparency-log conflict on sign attempt %d/%d, retrying with a fresh signature\n", attempt, maxSignAttempts)
+	}
+	return "", lastErr
+}
+
 // KeylessSigner implements keyless signing using OIDC tokens
 type KeylessSigner struct {
 	OIDCToken string
@@ -41,9 +77,9 @@ func (s *KeylessSigner) Sign(ctx context.Context, imageRef string) (*SignResult,
 
 	// Execute cosign sign command
 	args := []string{"sign", "--yes", imageRef}
-	stdout, stderr, err := tools.ExecCommand(ctx, "cosign", args, env, s.Timeout)
+	stdout, err := runCosignSign(ctx, args, env, s.Timeout)
 	if err != nil {
-		return nil, fmt.Errorf("cosign sign failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
+		return nil, err
 	}
 
 	// Parse output for Rekor entry URL

--- a/pkg/security/signing/keyless.go
+++ b/pkg/security/signing/keyless.go
@@ -11,31 +11,24 @@ import (
 	"github.com/simple-container-com/api/pkg/security/tools"
 )
 
-// execFn matches tools.ExecCommand; signers carry it as a field so tests can
-// inject a fake without racing on package state.
+// execFn matches tools.ExecCommand; injectable for tests.
 type execFn func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error)
 
 // maxSignAttempts bounds the Rekor-conflict retry loop in runCosignSign.
 const maxSignAttempts = 3
 
-// isRekorConflict reports whether a cosign failure was caused by Rekor's
-// createLogEntryConflict (HTTP 409 on POST /api/v1/log/entries). This happens
-// when an identical entry is already in the transparency log — typically
-// cosign re-uploading an entry whose first attempt timed out client-side but
-// succeeded server-side (seen under parallel CI runners signing concurrently).
+// isRekorConflict reports a Rekor createLogEntryConflict (HTTP 409) — an
+// identical entry already in the tlog, typically a cosign upload retry after
+// a client-side timeout whose first attempt succeeded server-side.
 func isRekorConflict(output string) bool {
 	return strings.Contains(output, "createLogEntryConflict") ||
 		(strings.Contains(output, "409") && strings.Contains(output, "/api/v1/log/entries"))
 }
 
-// runCosignSign executes `cosign sign`, retrying the full invocation when the
-// only failure is a Rekor entry conflict. Keyless (ephemeral key) and
-// randomized-ECDSA key-based invocations mint a fresh signature each run, so
-// their retries cannot conflict with themselves. Deterministic keys (e.g.
-// ed25519) reproduce the same signature — for them the bounded loop exhausts
-// and surfaces the conflict, which is correct: the tlog entry existing does
-// NOT prove the signature was attached to the registry, so success must not
-// be assumed. Any non-conflict error is returned immediately.
+// runCosignSign retries the full `cosign sign` on Rekor entry conflicts (a
+// fresh invocation can't conflict with itself). Deterministic keys reproduce
+// the same signature and exhaust the loop — correct, since a tlog entry does
+// not prove the signature reached the registry. Other errors fail fast.
 func runCosignSign(ctx context.Context, exec execFn, args, env []string, timeout time.Duration) (string, error) {
 	var lastErr error
 	for attempt := 1; attempt <= maxSignAttempts; attempt++ {

--- a/pkg/security/signing/keyless_test.go
+++ b/pkg/security/signing/keyless_test.go
@@ -198,13 +198,11 @@ func TestIsRekorConflict(t *testing.T) {
 func TestKeylessSigner_Sign_RetriesOnRekorConflict(t *testing.T) {
 	RegisterTestingT(t)
 
-	origExec := execCommand
-	defer func() { execCommand = origExec }()
-
 	conflictStderr := `signing bundle: error signing bundle: [POST /api/v1/log/entries][409] createLogEntryConflict {"code":409,"message":"an equivalent entry already exists in the transparency log"}`
 
 	calls := 0
-	execCommand = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		Expect(name).To(Equal("cosign"))
 		Expect(args[0]).To(Equal("sign"))
@@ -213,8 +211,6 @@ func TestKeylessSigner_Sign_RetriesOnRekorConflict(t *testing.T) {
 		}
 		return "tlog entry created with index: 123456", "", nil
 	}
-
-	signer := NewKeylessSigner("a.b.c", time.Second)
 	result, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
 
 	Expect(err).ToNot(HaveOccurred())
@@ -225,16 +221,12 @@ func TestKeylessSigner_Sign_RetriesOnRekorConflict(t *testing.T) {
 func TestKeylessSigner_Sign_NoRetryOnOtherErrors(t *testing.T) {
 	RegisterTestingT(t)
 
-	origExec := execCommand
-	defer func() { execCommand = origExec }()
-
 	calls := 0
-	execCommand = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		return "", "error signing: getting signer: oidc: token expired", fmt.Errorf("exit status 1")
 	}
-
-	signer := NewKeylessSigner("a.b.c", time.Second)
 	_, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
 
 	Expect(err).To(HaveOccurred())
@@ -245,16 +237,12 @@ func TestKeylessSigner_Sign_NoRetryOnOtherErrors(t *testing.T) {
 func TestKeylessSigner_Sign_GivesUpAfterMaxConflictAttempts(t *testing.T) {
 	RegisterTestingT(t)
 
-	origExec := execCommand
-	defer func() { execCommand = origExec }()
-
 	calls := 0
-	execCommand = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
 	}
-
-	signer := NewKeylessSigner("a.b.c", time.Second)
 	_, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
 
 	Expect(err).To(HaveOccurred())

--- a/pkg/security/signing/keyless_test.go
+++ b/pkg/security/signing/keyless_test.go
@@ -2,6 +2,7 @@ package signing
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -143,4 +144,120 @@ func TestGetRekorEntryFromOutput(t *testing.T) {
 	expected := "https://rekor.sigstore.dev/api/v1/log/entries?logIndex=999"
 
 	Expect(GetRekorEntryFromOutput(output)).To(Equal(expected))
+}
+
+func TestIsRekorConflict(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name: "cosign bundle 409 createLogEntryConflict",
+			output: `signing registry.example.com/app@sha256:a7c43eb1700be291e4ea2bc146c8d5d23118f1d9: signing bundle: error signing bundle: ` +
+				`[POST /api/v1/log/entries][409] createLogEntryConflict {"code":409,"message":"an equivalent entry already exists in the transparency log with UUID 108e9186e8c5677a"}`,
+			want: true,
+		},
+		{
+			name:   "bare conflict marker",
+			output: "createLogEntryConflict",
+			want:   true,
+		},
+		{
+			name:   "409 against the rekor entries endpoint",
+			output: "[POST /api/v1/log/entries][409] something else",
+			want:   true,
+		},
+		{
+			name:   "unrelated 409 from a registry",
+			output: "GET https://registry.example.com/v2/: unexpected status 409",
+			want:   false,
+		},
+		{
+			name:   "fulcio auth failure",
+			output: "error signing: getting signer: getting key from Fulcio: retrieving cert: oidc: token expired",
+			want:   false,
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(isRekorConflict(tt.output)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestKeylessSigner_Sign_RetriesOnRekorConflict(t *testing.T) {
+	RegisterTestingT(t)
+
+	origExec := execCommand
+	defer func() { execCommand = origExec }()
+
+	conflictStderr := `signing bundle: error signing bundle: [POST /api/v1/log/entries][409] createLogEntryConflict {"code":409,"message":"an equivalent entry already exists in the transparency log"}`
+
+	calls := 0
+	execCommand = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+		calls++
+		Expect(name).To(Equal("cosign"))
+		Expect(args[0]).To(Equal("sign"))
+		if calls == 1 {
+			return "", conflictStderr, fmt.Errorf("exit status 1")
+		}
+		return "tlog entry created with index: 123456", "", nil
+	}
+
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	result, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(calls).To(Equal(2), "conflict must trigger exactly one retry")
+	Expect(result.RekorEntry).To(Equal("https://rekor.sigstore.dev/api/v1/log/entries?logIndex=123456"))
+}
+
+func TestKeylessSigner_Sign_NoRetryOnOtherErrors(t *testing.T) {
+	RegisterTestingT(t)
+
+	origExec := execCommand
+	defer func() { execCommand = origExec }()
+
+	calls := 0
+	execCommand = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+		calls++
+		return "", "error signing: getting signer: oidc: token expired", fmt.Errorf("exit status 1")
+	}
+
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	_, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("token expired"))
+	Expect(calls).To(Equal(1), "non-conflict errors must not be retried")
+}
+
+func TestKeylessSigner_Sign_GivesUpAfterMaxConflictAttempts(t *testing.T) {
+	RegisterTestingT(t)
+
+	origExec := execCommand
+	defer func() { execCommand = origExec }()
+
+	calls := 0
+	execCommand = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+		calls++
+		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
+	}
+
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	_, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+	Expect(calls).To(Equal(maxSignAttempts))
 }


### PR DESCRIPTION
Two production-surfaced fixes, bundled per repo convention.

## 1. Signing: tolerate Rekor `409 createLogEntryConflict` by retrying with a fresh signature

When several CI deploys run in parallel for stacks that share one image (one compose file, several `runs:` stacks), `sc image sign` can abort with:

```
signing bundle: error signing bundle: [POST /api/v1/log/entries][409] createLogEntryConflict
{"code":409,"message":"an equivalent entry already exists in the transparency log with UUID …"}
```

An *identical* entry already being in the tlog means the signature upload effectively succeeded — keyless ephemeral keys (and randomized-ECDSA key-based signatures) can't produce identical entries across independent invocations, so the typical cause is cosign re-uploading an entry whose first attempt timed out client-side but landed server-side. The image ends up signed, yet the deploy fails. Observed breaking every push-fanout deploy in a multi-stack repo; single-stack dispatches passed.

**Fix:** `runCosignSign` retries the full `cosign sign` invocation (up to 3 attempts) when — and only when — the failure is a Rekor entry conflict. A fresh invocation mints a fresh signature, so a retry cannot conflict with itself. Any other error still fails fast. Shared by the keyless and key-based signers.

## 2. Probes: `cloudExtras.startupProbe` was silently dropped; `periodSeconds` unsupported

`k8s.CloudExtras`/`DeploymentConfig` had `readinessProbe` + `livenessProbe` but **no `startupProbe` field**, so a user-supplied startup budget never reached the cluster — the container fell back to the readiness probe (or its 60s default TCP window) as its cold-start budget. On a freshly-provisioned Autopilot node (image pull + migrations + worker boot) that gets the pod SIGTERM-killed mid-boot, which converts an ordinary node move into an outage for single-replica services.

Additionally `CloudRunProbe` only understood the duration-typed `interval` key; configs written with the k8s-native `periodSeconds` spelling silently lost their probe period (plain integers don't survive the YAML→`time.Duration` conversion).

**Fix:**
- `CloudRunProbe.PeriodSeconds` added; takes precedence over `interval` in `toProbeArgs`.
- `StartupProbe` added to `CloudExtras` + `DeploymentConfig` + `DeploymentArgs`, threaded `gke_autopilot → kube_run → deployment` with the same ingress-container fallback semantics as readiness/liveness. Existing behavior (startup := readiness when nothing is specified) is unchanged.

## Tests

- `TestIsRekorConflict` (real cosign stderr shapes, incl. non-conflict 409s that must NOT match), `TestKeylessSigner_Sign_RetriesOnRekorConflict`, `…_NoRetryOnOtherErrors`, `…_GivesUpAfterMaxConflictAttempts` — via an `execCommand` seam, asserting exact call counts.
- `TestStartupProbeExtraction` / `TestProbePeriodSecondsExtraction` / `TestStartupProbeAbsent` — `ConvertDescriptor` regression tests proving the yaml keys now survive the mapping (the original bug class).
- `TestToProbeArgs_PeriodSeconds` — precedence table (`periodSeconds` > `interval` > unset).

`go test ./pkg/security/signing/ ./pkg/clouds/k8s/ ./pkg/clouds/pulumi/kubernetes/ ./pkg/clouds/gcloud/` — all pass.