### PR TITLE
docs: fix broken mermaid diagrams (restore startOnLoad)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -117,6 +117,11 @@ plugins:
   - mermaid2:
       version: 10.6.1
       arguments:
+        # startOnLoad MUST be set: supplying a custom `arguments` block
+        # overrides the plugin's defaults (which include it), and Mermaid v10's
+        # ESM build only auto-renders <div class="mermaid"> when startOnLoad is
+        # true. Without it the library loads but no diagram is drawn.
+        startOnLoad: true
         theme: base
         themeVariables:
           # Aligned with simple-container.com palette (dark scheme).


### PR DESCRIPTION
## Problem
The Architecture overview diagram on [concepts/main-concepts](https://docs.simple-container.com/concepts/main-concepts/) (and every other mermaid diagram in the docs) stopped rendering. The page emits `<div class="mermaid">…</div>` and loads Mermaid v10.6.1, but `mermaid.initialize({...})` ran **without `startOnLoad`**, so the ESM build never drew the diagrams.

## Root cause
Supplying a custom `arguments:` block to the `mermaid2` plugin (the brand `theme` + `themeVariables`) **replaces** the plugin's default arguments — which include `startOnLoad: true`. Mermaid v10's ESM build only auto-renders on load when `startOnLoad` is set.

## Fix
Re-add `startOnLoad: true` to the `mermaid2.arguments` block.

## Verification
- `mkdocs build` now emits `mermaid.initialize({ startOnLoad: true, theme: "base", … })`.
- Headless-browser render of the built `concepts/main-concepts` page draws the full diagram (all three subgraphs, brand colors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)