### PR TITLE
docs: load mermaid from jsdelivr so the CSP allows it

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -116,6 +116,12 @@ plugins:
   - search
   - mermaid2:
       version: 10.6.1
+      # Load Mermaid from jsdelivr, not the plugin's default unpkg.com. The
+      # docs site's Content-Security-Policy allows script-src from
+      # cdn.jsdelivr.net but NOT unpkg.com, so the default URL was blocked and
+      # no diagram rendered. The .esm bundle lazy-loads its chunks relatively,
+      # so they resolve on jsdelivr too (also CSP-allowed).
+      javascript: https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.esm.min.mjs
       arguments:
         # startOnLoad MUST be set: supplying a custom `arguments` block
         # overrides the plugin's defaults (which include it), and Mermaid v10's


### PR DESCRIPTION
## Problem
After #338 (restoring `startOnLoad`), mermaid diagrams **still** didn't render on the live docs (e.g. [concepts/main-concepts](https://docs.simple-container.com/concepts/main-concepts/)) — the page showed the raw `graph TB ...` source as text.

## Root cause
The docs site enforces a Content-Security-Policy whose `script-src` allows `'self'`, googletagmanager, and **`cdn.jsdelivr.net`** — but **not `unpkg.com`**. The `mermaid2` plugin defaults to loading Mermaid from `unpkg.com`, so the browser blocked the import:

```
Loading the script 'https://unpkg.com/mermaid@10.6.1/dist/mermaid.esm.min.mjs'
violates the following Content Security Policy directive: "script-src 'self' ... https://cdn.jsdelivr.net". The action has been blocked.
```

(My earlier local test missed this because `http.server` sends no CSP.)

## Fix
Set the plugin's `javascript:` option to the jsdelivr URL, which the CSP already allows. The `.esm` bundle lazy-loads its chunks via **relative** imports, so those resolve on jsdelivr too (also allowed) — whereas from unpkg they'd have been blocked as well.

## Verification
Built the site and served it **with the production CSP header**, then rendered headless: no CSP violations in the console, and the `<div class="mermaid">` now contains a rendered `<svg>` (confirmed against `concepts/main-concepts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)