### PR TITLE
fix(git): open absolute-path files via osfs root "/" (fixes "public key is not configured")

### DIFF
--- a/pkg/api/git/repo.go
+++ b/pkg/api/git/repo.go
@@ -75,7 +75,12 @@ func (r *repo) OpenFile(filePath string, flag int, perm os.FileMode) (billy.File
 		return nil, errors.Wrapf(err, "failed to replace path %q with home", filePath)
 	}
 	if path.IsAbs(rPath) {
-		return osfs.New("").OpenFile(rPath, flag, perm)
+		// Root the OS filesystem at "/" (not "") for absolute paths. go-billy's
+		// chroot helper (osfs default) resolves symlinks relative to its root via
+		// filepath.Rel; with an empty root that cleans to ".", and Rel(".", "/abs/path")
+		// fails, so every absolute open returns "chroot boundary crossed". Rooting at
+		// "/" makes Rel("/", "/abs/path") well-defined. Regressed with go-billy v5.9.0.
+		return osfs.New("/").OpenFile(rPath, flag, perm)
 	}
 	return r.wdFs.OpenFile(rPath, flag, perm)
 }

--- a/pkg/api/git/repo_lifecycle_test.go
+++ b/pkg/api/git/repo_lifecycle_test.go
@@ -353,13 +353,6 @@ func TestFileOperations(t *testing.T) {
 		Expect(string(b)).To(Equal("relative"))
 	})
 
-	// QUIRK (repo.go:74-75): for an absolute path OpenFile delegates to
-	// osfs.New("").OpenFile(...). Under go-billy v5.9.0 the default ChrootOS has
-	// root "" (a *relative* path), and its symlink-follow boundary check runs
-	// filepath.Rel(".", <absolute path>) which always errors, so it returns
-	// "chroot boundary crossed". The absolute-path branch therefore cannot
-	// actually open any absolute file with this billy version; we assert that
-	// observed behaviour (the branch is still exercised for coverage).
 	t.Run("OpenFile wraps a tilde-expansion error for an unknown user", func(t *testing.T) {
 		RegisterTestingT(t)
 		wd := t.TempDir()
@@ -372,7 +365,11 @@ func TestFileOperations(t *testing.T) {
 		Expect(err.Error()).To(ContainSubstring("failed to replace path"))
 	})
 
-	t.Run("OpenFile with an absolute path hits the chroot boundary error", func(t *testing.T) {
+	// For an absolute path OpenFile delegates to osfs.New("/").OpenFile(...).
+	// Rooting the OS filesystem at "/" (rather than "") keeps go-billy's ChrootOS
+	// symlink-follow boundary check well-defined for absolute paths — see repo.go.
+	// This is the path that loads keys referenced by ~/.ssh-style profile config.
+	t.Run("OpenFile opens a file by absolute path", func(t *testing.T) {
 		RegisterTestingT(t)
 		wd := t.TempDir()
 		r := newRepoIn(wd)
@@ -380,9 +377,12 @@ func TestFileOperations(t *testing.T) {
 		absPath := filepath.Join(t.TempDir(), "abs.txt")
 		Expect(os.WriteFile(absPath, []byte("absolute"), 0o644)).To(Succeed())
 
-		_, err := r.OpenFile(absPath, os.O_RDONLY, 0)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("boundary"))
+		f, err := r.OpenFile(absPath, os.O_RDONLY, 0)
+		Expect(err).ToNot(HaveOccurred())
+		defer func() { _ = f.Close() }()
+		b, err := io.ReadAll(f)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(b)).To(Equal("absolute"))
 	})
 }
 


### PR DESCRIPTION
## Problem

  sc secrets reveal (and secrets add / secrets allow) fails with:

  Error: public key is not configured

  even when the profile is correctly configured and the key files exist. It reproduces with any profile that references keys by path, e.g. .sc/cfg.default.yaml:

  projectName: my-project
  privateKeyPath: ~/.ssh/id_rsa
  publicKeyPath: ~/.ssh/id_rsa.pub

##  Root cause

  git.repo.OpenFile delegates absolute paths to osfs.New("").OpenFile(...). Under go-billy v5.9.0, the default ChrootOS resolves symlinks relative to its root via filepath.Rel. With an empty
  root (which cleans to "."), filepath.Rel(".", "/abs/path") always errors, so every absolute open returns chroot boundary crossed.

  The failure cascades into the misleading error:

  1. WithKeysFromScConfig loads the private key first (~/.ssh/id_rsa → absolute after tilde expansion), so the failed open aborts the entire profile load.
  2. That error is swallowed at command bootstrap by IgnoreConfigDirError: true (root.go).
  3. The public key is therefore never set, and DecryptAll later reports public key is not configured.

  This was a latent regression introduced with the go-billy v5.9.0 upgrade — there was even a unit test that had codified the broken chroot boundary behavior as a "QUIRK."

 ## Fix

  Root the OS filesystem at "/" (not "") for absolute paths, so filepath.Rel("/", "/abs/path") is well-defined:

  if path.IsAbs(rPath) {
      return osfs.New("/").OpenFile(rPath, flag, perm)
  }

  The relative-path fallback (wdFs = osfs.New("") in initRepo) is intentionally left rooted at "" so it keeps resolving against the process cwd.

  Updated the unit test that asserted the broken behavior to instead assert that absolute-path opens succeed and read content back.

  Verification

  - Reproduced the failure, then confirmed sc secrets reveal reveals all secret files after the fix.
  - Verified empirically: osfs.New("") → "chroot boundary crossed"; osfs.New("/") → opens correctly.
  - go test ./pkg/api/git/... and ./pkg/api/secrets/... pass.

  Impact

  Restores key-by-path / ~/.ssh-style profile configs for all secrets operations. No behavior change for inline-key profiles or relative-path resolution.
