### PR TITLE
fix(actions): pin github-actions runtime image to the release version

### DIFF
--- a/.github/actions/cancel-stack/action.yml
+++ b/.github/actions/cancel-stack/action.yml
@@ -71,7 +71,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://simplecontainer/github-actions:latest'
+  image: 'docker://simplecontainer/github-actions:staging'
   env:
     GITHUB_ACTION_TYPE: 'cancel-stack'
     STACK_NAME: ${{ inputs.stack-name }}

--- a/.github/actions/deploy-client-stack/action.yml
+++ b/.github/actions/deploy-client-stack/action.yml
@@ -69,7 +69,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://simplecontainer/github-actions:latest'
+  image: 'docker://simplecontainer/github-actions:staging'
   env:
     GITHUB_ACTION_TYPE: 'deploy-client-stack'
     STACK_NAME: ${{ inputs.stack-name }}

--- a/.github/actions/destroy/action.yml
+++ b/.github/actions/destroy/action.yml
@@ -72,7 +72,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://simplecontainer/github-actions:latest'
+  image: 'docker://simplecontainer/github-actions:staging'
   env:
     GITHUB_ACTION_TYPE: 'destroy'
     STACK_NAME: ${{ inputs.stack-name }}

--- a/.github/actions/provision-parent-stack/action.yml
+++ b/.github/actions/provision-parent-stack/action.yml
@@ -62,7 +62,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://simplecontainer/github-actions:latest'
+  image: 'docker://simplecontainer/github-actions:staging'
   env:
     GITHUB_ACTION_TYPE: 'provision-parent-stack'
     STACK_NAME: ${{ inputs.stack-name }}

--- a/welder.yaml
+++ b/welder.yaml
@@ -272,6 +272,12 @@ tasks:
   tag-release:
     runOn: host
     script:
+      # Pin the github-actions runtime image to this exact release version in
+      # every composite action, so consumers pinning the action git ref get a
+      # reproducible image instead of floating :staging. Mirrors branch-preview.yaml.
+      - find .github/actions -name action.yml -exec sed -i "s|docker://simplecontainer/github-actions:staging|docker://simplecontainer/github-actions:${project:version}|g" {} +
+      - git add .github/actions/*/action.yml
+      - git commit -m "chore(release): pin github-actions image to ${project:version}" || echo "github-actions image tags already pinned"
       - git tag ${project:version} || echo "Already set tag ${project:version}"
       - git push -f origin ${project:version} || echo "Tag ${project:version} already exists in origin"
   build-docs:


### PR DESCRIPTION
## Problem

The four composite actions — `deploy-client-stack`, `provision-parent-stack`, `cancel-stack`, `destroy` — hardcode their runtime image as `docker://simplecontainer/github-actions:latest`.

A Docker-based action's `image:` field is a **parse-time literal** (GitHub Actions does not allow `${{ }}` interpolation there). So when a consumer carefully pins the action git ref — e.g. `uses: simple-container-com/api/.github/actions/deploy-client-stack@2026.6.14` — the pin only fixes the thin `action.yml` wrapper. The code that actually runs is whatever `simplecontainer/github-actions:latest` points to at job time.

Result: **any release that re-tags `:latest` silently changes the runtime for every downstream consumer that believes it is pinned**, defeating the entire purpose of version pinning.

This already bit production on **2026-06-30**: `2026.6.17` was published and moved `:latest` at 07:48 UTC, and a downstream deploy that was pinned to an older action tag immediately started running the new image with no change on its side.

There's a second, latent bug: `branch-preview.yaml` already substitutes `:staging` → `:${VERSION}`, but `main` never contained `:staging` (it was `:latest`), so that substitution was a **no-op** — preview builds shipped `:latest` too.

## Fix

Unify on the `:staging` placeholder that `branch-preview.yaml` already expects:

- **`action.yml` ×4: `:latest` → `:staging`.** `@main` / dev now resolves to the maintained staging image (built and pushed by `build-staging.yml`), and `branch-preview.yaml`'s existing `:staging` → version substitution finally applies.
- **`welder.yaml` `tag-release`:** substitute `:staging` → `:${project:version}` and commit before tagging, mirroring `branch-preview.yaml`. Prod release tags now ship `action.yml` pinned to their own version's image — the same image `push.yaml` already builds, signs, and attests.

After this, `@2026.6.X` ⇒ `simplecontainer/github-actions:2026.6.X` (reproducible), `@main` ⇒ `:staging`, preview tags ⇒ their preview version.

## Compatibility

The `:latest` and `:staging` Docker tags are **still published** by `welder.yaml` / `push.yaml` / `build-staging.yml`, so anyone referencing them directly is unaffected. Only future release tags change behaviour; already-published tags (`2026.6.17` and earlier) keep their `:latest` reference and are not rewritten.

## Test plan

- [x] All five YAML files parse.
- [x] Simulated the `tag-release` sed with `VERSION=2026.6.18` → `image: 'docker://simplecontainer/github-actions:2026.6.18'`.
- [ ] First release after merge: confirm the `2026.6.x` tag's `action.yml` references `:2026.6.x` (not `:latest`), and that the tagged commit's image is signed/attested.

## Follow-up (not in this PR)

Add a release-gate check that fails if a pushed release tag's `action.yml` still references `:staging`/`:latest`, so this can't silently regress.
