### PR TITLE
feat(actions): add skip-refresh input to provision-parent-stack

### DIFF
--- a/.github/actions/provision-parent-stack/action.yml
+++ b/.github/actions/provision-parent-stack/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: 'Commit message'
     required: false
     default: ''
+  skip-refresh:
+    description: 'Skip Pulumi refresh operation before provisioning'
+    required: false
+    default: 'false'
 
 outputs:
   stack-name:
@@ -78,3 +82,4 @@ runs:
     GITHUB_REF: ${{ inputs.ref }}
     COMMIT_AUTHOR: ${{ inputs.commit-author }}
     COMMIT_MESSAGE: ${{ inputs.commit-message }}
+    SKIP_REFRESH: ${{ inputs.skip-refresh }}

--- a/pkg/githubactions/actions/operation_executor.go
+++ b/pkg/githubactions/actions/operation_executor.go
@@ -319,8 +319,8 @@ func (e *Executor) executeProvision(ctx context.Context, config OperationConfig,
 		StacksDir:    ".sc/stacks",
 		Profile:      profile,
 		Stacks:       []string{config.StackName},
-		SkipRefresh:  previewMode,
-		DetailedDiff: true, // Enable detailed diff for better visibility in GitHub Actions
+		SkipRefresh:  config.SkipRefresh || previewMode, // Use configured skip-refresh or preview mode
+		DetailedDiff: true,                              // Enable detailed diff for better visibility in GitHub Actions
 	}
 
 	if previewMode {

--- a/pkg/githubactions/actions/operations.go
+++ b/pkg/githubactions/actions/operations.go
@@ -78,9 +78,10 @@ func (e *Executor) ProvisionParentStack(ctx context.Context) error {
 	// Wrap the provision with signal handling and panic recovery
 	return e.signalHandler.WithSignalHandling(ctx, opTypeProvision, provisionParams, func(opCtx context.Context) error {
 		return e.executeOperation(opCtx, OperationConfig{
-			Type:      OperationProvision,
-			Scope:     ScopeParent,
-			StackName: stackName,
+			Type:        OperationProvision,
+			Scope:       ScopeParent,
+			StackName:   stackName,
+			SkipRefresh: os.Getenv("SKIP_REFRESH") == "true", // Skip Pulumi refresh if requested
 		})
 	})
 }


### PR DESCRIPTION
The provision-parent-stack action always ran a Pulumi refresh on real (non-dry-run) provisions: executeProvision hard-coded SkipRefresh to previewMode, and neither the action nor ProvisionParentStack read a SKIP_REFRESH signal. The sibling deploy-client-stack action already supported skip-refresh; this brings provision to parity.

- action.yml: add `skip-refresh` input (default false) mapped to SKIP_REFRESH env.
- ProvisionParentStack: read SKIP_REFRESH into OperationConfig.SkipRefresh.
- executeProvision: honor config.SkipRefresh (SkipRefresh = config.SkipRefresh || previewMode), mirroring executeDeploy.

Refresh stays on by default; opting out is explicit. Note skipping refresh on a parent/infra stack means Pulumi won't reconcile state against the cloud first, so out-of-band drift can cause stale-state surprises — use deliberately.