### PR TITLE
ci(semgrep): disable flaky p/ci gha-curl-pipe-shell rule

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -52,4 +52,16 @@ jobs:
       #   secure_file_reader.go). The SC team explicitly dropped its
       #   own equivalent rule in round-6 triage for the same reason
       #   (see go-canon.yml comment in actions repo).
-      disabled-rules: 'go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5,go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface'
+      #
+      #   `gha-curl-pipe-shell` — this p/ci rule re-parses each workflow
+      #   `run:` block as Bash via a metavariable-pattern. GHA `${{ }}`
+      #   expressions are not valid Bash, so the sub-parser emits
+      #   nondeterministic PartialParsing / "Internal matching error"
+      #   engine errors (24 on our workflows), which scan.sh counts as
+      #   `.errors` and fails the build — flaky red CI, not real findings
+      #   (the same commit passed and then failed on consecutive runs).
+      #   Replacement coverage: the SC `shell-curl-pipe-to-shell` rule
+      #   (shell.yml) flags curl/wget output piped into a shell across
+      #   `**/*.yml`/`**/*.yaml` by regex, with no Bash sub-parse — so no
+      #   coverage is lost by suppressing the registry rule.
+      disabled-rules: 'go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5,go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface,yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell'


### PR DESCRIPTION
## Problem

The Semgrep check is **flaky-red** on PRs and went red on `main` after #355 merged. Root cause is the `p/ci` registry rule `yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell`.

That rule re-parses every workflow `run:` block as Bash via a `metavariable-pattern`. GitHub Actions `${{ }}` expressions are **not valid Bash**, so the sub-parser throws — emitting `PartialParsing` + `Internal matching error` entries into the results JSON (24 on our workflows). The scan action treats a non-empty `.errors` array as a hard failure, so the build fails even though **zero real findings** were produced.

It's nondeterministic: the same commit on `feat/provision-skip-refresh` **passed** in [run 28464481418](https://github.com/simple-container-com/api/actions/runs/28464481418) and then **failed** in [run 28464579912](https://github.com/simple-container-com/api/actions/runs/28464579912). After #355 squash-merged, the post-merge `main` run [28469227229](https://github.com/simple-container-com/api/actions/runs/28469227229) failed for the same reason.

## Fix

Add the rule to the existing `disabled-rules` input (the documented knob for over-broad registry-pack rules).

## Why no coverage is lost

The SC custom ruleset already ships `shell-curl-pipe-to-shell` (`semgrep-scan/rules/shell.yml`), an ERROR-severity **regex** rule that flags `curl|wget … | sh` supply-chain piping across `**/*.sh`, `**/*.bash`, `**/*.yml`, `**/*.yaml` — with no Bash sub-parse, so it can't hit this engine bug. The registry rule is redundant with it.

## Empirical verification

Pinned image `semgrep/semgrep:1.161.0` against `.github/workflows`:

| Config | `.errors` |
|---|---|
| `p/ci` (rule active) | 22–24 (engine parse errors, **not findings**) |
| `p/ci` + `--exclude-rule …gha-curl-pipe-shell` | **0** |

All 24 CI errors traced to this single rule (`23× PartialParsing + Internal matching error`, no other rule implicated).