### PR TITLE
chore(deps): bump go directive 1.26.4 → 1.26.5 (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/simple-container-com/api
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/storage v1.62.3


### PR DESCRIPTION
## What
Bumps the `go` directive in `go.mod` from `1.26.4` to `1.26.5`.

## Why
`govulncheck` reads the stdlib version it scans from the `go` directive. Go **1.26.4** is affected by **GO-2026-5856** (`crypto/tls`), fixed in **go1.26.5**. The finding is *reachable* through several pre-existing paths, so the reachability gate now fails on **every Go-touching PR** until the toolchain is bumped:

```
Vulnerability #1: GO-2026-5856  (crypto/tls@go1.26.4 → fixed in go1.26.5)
  #1 pkg/util/exec.go … tls.Conn.Handshake
  #2 pkg/assistant/mcp/server.go … tls.Conn.HandshakeContext
  #3 pkg/assistant/llm/ollama.go … tls.Conn.Read
  #4 pkg/api/git/repo.go … tls.Conn.Write
  #5 pkg/clouds/pulumi/mongodb/drop_db.go … tls.Dial
  #6 pkg/assistant/llm/openai.go … tls.Dialer.DialContext
```

Bumping the directive clears the advisory fleet-wide (unblocks #363 and any other open Go PR). `go1.26.5` is released; `GOTOOLCHAIN=auto` already resolves the toolchain, and the other workflows read the version from `go.mod` / auto-upgrade — so **no source change** is needed.

## Scope
One line in `go.mod`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)