### PR TITLE
fix(gcp): bound state history so KMS key versions can be reclaimed

### DIFF
--- a/docs/schemas/gcp/statestorageconfig.json
+++ b/docs/schemas/gcp/statestorageconfig.json
@@ -40,6 +40,9 @@
       "name": {
         "type": "string"
       },
+      "noncurrentVersionRetentionDays": {
+        "type": "integer"
+      },
       "provision": {
         "type": "boolean"
       }

--- a/pkg/clouds/gcloud/auth.go
+++ b/pkg/clouds/gcloud/auth.go
@@ -71,6 +71,34 @@ type StateStorageConfig struct {
 	Name        string  `json:"name,omitempty" yaml:"name,omitempty"`
 	Location    *string `json:"location" yaml:"location"`
 	Provision   bool    `json:"provision" yaml:"provision"`
+
+	// NoncurrentVersionRetentionDays bounds how long overwritten state
+	// generations are kept when the bucket has object versioning enabled.
+	//
+	// It matters beyond storage cost. Pulumi's cloud secrets manager re-wraps
+	// each stack's data key on every state write, and a KMS symmetric encrypt
+	// always uses the key's current primary version, so each retained
+	// generation depends on whichever key version was primary when it was
+	// written. With versioning on and no lifecycle rule, that set of
+	// load-bearing key versions grows without limit and no key version can
+	// ever be proven unreferenced.
+	//
+	// Zero disables the rule. Nil means DefaultNoncurrentVersionRetentionDays.
+	NoncurrentVersionRetentionDays *int `json:"noncurrentVersionRetentionDays,omitempty" yaml:"noncurrentVersionRetentionDays,omitempty"`
+}
+
+// DefaultNoncurrentVersionRetentionDays is the rollback horizon applied when
+// noncurrentVersionRetentionDays is unset. Long enough to recover from a bad
+// deployment, short enough that the dependency set stays bounded.
+const DefaultNoncurrentVersionRetentionDays = 30
+
+// EffectiveNoncurrentVersionRetentionDays resolves the configured retention,
+// falling back to the default when unset. A configured zero disables the rule.
+func (s *StateStorageConfig) EffectiveNoncurrentVersionRetentionDays() int {
+	if s.NoncurrentVersionRetentionDays == nil {
+		return DefaultNoncurrentVersionRetentionDays
+	}
+	return *s.NoncurrentVersionRetentionDays
 }
 
 // GetBucketName returns the bucket name, supporting both "name" and "bucketName" fields

--- a/pkg/clouds/pulumi/gcp/provider.go
+++ b/pkg/clouds/pulumi/gcp/provider.go
@@ -76,15 +76,72 @@ func InitStateStore(ctx context.Context, stateStoreCfg api.StateStorageConfig, l
 		_ = client.Close()
 	}(client)
 	bucketRef := client.Bucket(gcpStateCfg.GetBucketName())
+	retentionDays := gcpStateCfg.EffectiveNoncurrentVersionRetentionDays()
 
-	_, err = bucketRef.Attrs(ctx)
+	attrs, err := bucketRef.Attrs(ctx)
 	if err != nil {
 		// does not exist
 		return bucketRef.Create(ctx, gcpStateCfg.ProjectId, &gcpStorage.BucketAttrs{
-			Location: lo.FromPtr(gcpStateCfg.Location),
+			Location:  lo.FromPtr(gcpStateCfg.Location),
+			Lifecycle: NoncurrentVersionLifecycle(retentionDays),
 		})
 	}
+
+	if ShouldApplyNoncurrentVersionLifecycle(attrs, retentionDays) {
+		log.Info(ctx, "state bucket %q has object versioning enabled and no lifecycle rule; "+
+			"bounding retained state generations to %d days",
+			gcpStateCfg.GetBucketName(), retentionDays)
+		if _, err := bucketRef.Update(ctx, gcpStorage.BucketAttrsToUpdate{
+			Lifecycle: lo.ToPtr(NoncurrentVersionLifecycle(retentionDays)),
+		}); err != nil {
+			return errors.Wrapf(err, "failed to bound state history on bucket %q", gcpStateCfg.GetBucketName())
+		}
+	}
 	return nil
+}
+
+// NoncurrentVersionLifecycle deletes state generations once they have been
+// superseded for retentionDays. It targets Archived objects only, so the live
+// state file is never a candidate. A non-positive retention yields no rules.
+func NoncurrentVersionLifecycle(retentionDays int) gcpStorage.Lifecycle {
+	if retentionDays <= 0 {
+		return gcpStorage.Lifecycle{}
+	}
+	return gcpStorage.Lifecycle{
+		Rules: []gcpStorage.LifecycleRule{
+			{
+				Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+				Condition: gcpStorage.LifecycleCondition{
+					Liveness:                gcpStorage.Archived,
+					DaysSinceNoncurrentTime: int64(retentionDays),
+				},
+			},
+		},
+	}
+}
+
+// ShouldApplyNoncurrentVersionLifecycle decides whether to modify a state
+// bucket that already exists. Adding a rule to somebody's existing bucket is
+// the kind of thing that should be narrow and predictable, so all three
+// conditions must hold:
+//
+//   - retention is enabled;
+//   - object versioning is on, so noncurrent generations actually accumulate
+//     and the rule is not merely inert;
+//   - the bucket has no lifecycle rules at all, so an operator's own policy is
+//     never edited, replaced or merged with.
+//
+// A bucket that already carries any rule is left alone even if that rule does
+// not bound noncurrent versions. Guessing at intent there would be worse than
+// leaving it to the operator.
+func ShouldApplyNoncurrentVersionLifecycle(attrs *gcpStorage.BucketAttrs, retentionDays int) bool {
+	if attrs == nil || retentionDays <= 0 {
+		return false
+	}
+	if !attrs.VersioningEnabled {
+		return false
+	}
+	return len(attrs.Lifecycle.Rules) == 0
 }
 
 func Provider(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params pApi.ProvisionParams) (*api.ResourceOutput, error) {

--- a/pkg/clouds/pulumi/gcp/state_bucket_lifecycle_test.go
+++ b/pkg/clouds/pulumi/gcp/state_bucket_lifecycle_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Simple Container
+
+package gcp
+
+import (
+	"testing"
+
+	gcpStorage "cloud.google.com/go/storage"
+	. "github.com/onsi/gomega"
+
+	"github.com/simple-container-com/api/pkg/clouds/gcloud"
+)
+
+// InitStateStore now touches buckets it did not create. These tests pin the
+// guards on that, because the failure mode is editing an operator's lifecycle
+// policy on a bucket holding all of their Pulumi state.
+func TestShouldApplyNoncurrentVersionLifecycle(t *testing.T) {
+	RegisterTestingT(t)
+
+	versioned := func(rules ...gcpStorage.LifecycleRule) *gcpStorage.BucketAttrs {
+		return &gcpStorage.BucketAttrs{
+			VersioningEnabled: true,
+			Lifecycle:         gcpStorage.Lifecycle{Rules: rules},
+		}
+	}
+	someRule := gcpStorage.LifecycleRule{
+		Action:    gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+		Condition: gcpStorage.LifecycleCondition{AgeInDays: 365},
+	}
+
+	for _, tc := range []struct {
+		name  string
+		attrs *gcpStorage.BucketAttrs
+		days  int
+		want  bool
+		why   string
+	}{
+		{
+			name:  "versioned bucket with no rules is the case this exists for",
+			attrs: versioned(),
+			days:  30,
+			want:  true,
+			why:   "unbounded history keeps every KMS key version load-bearing",
+		},
+		{
+			name:  "an existing rule is left alone even if it does not bound noncurrent versions",
+			attrs: versioned(someRule),
+			days:  30,
+			want:  false,
+			why:   "the operator owns their lifecycle policy; guessing at intent is worse than doing nothing",
+		},
+		{
+			name:  "versioning off means noncurrent generations never accumulate",
+			attrs: &gcpStorage.BucketAttrs{VersioningEnabled: false},
+			days:  30,
+			want:  false,
+			why:   "the rule would be inert, so do not touch the bucket at all",
+		},
+		{
+			name:  "retention explicitly disabled",
+			attrs: versioned(),
+			days:  0,
+			want:  false,
+			why:   "zero is a deliberate opt-out",
+		},
+		{
+			name:  "negative retention is not treated as enabled",
+			attrs: versioned(),
+			days:  -1,
+			want:  false,
+		},
+		{
+			name:  "nil attrs never provokes a write",
+			attrs: nil,
+			days:  30,
+			want:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			Expect(ShouldApplyNoncurrentVersionLifecycle(tc.attrs, tc.days)).To(Equal(tc.want), tc.why)
+		})
+	}
+}
+
+// The rule must target archived objects only. A rule that matched live objects
+// would delete the current state file, which is the worst outcome available
+// here, so assert the shape rather than trusting the constant.
+func TestNoncurrentVersionLifecycleTargetsArchivedOnly(t *testing.T) {
+	RegisterTestingT(t)
+
+	lc := NoncurrentVersionLifecycle(30)
+	Expect(lc.Rules).To(HaveLen(1))
+
+	rule := lc.Rules[0]
+	Expect(rule.Action.Type).To(Equal(gcpStorage.DeleteAction))
+	Expect(rule.Condition.Liveness).To(Equal(gcpStorage.Archived),
+		"a Live or LiveAndArchived rule would delete the current state file")
+	Expect(rule.Condition.DaysSinceNoncurrentTime).To(Equal(int64(30)))
+	Expect(rule.Condition.AgeInDays).To(BeZero(),
+		"AgeInDays counts from creation, not from being superseded, and would expire live state")
+}
+
+func TestNoncurrentVersionLifecycleDisabled(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(NoncurrentVersionLifecycle(0).Rules).To(BeEmpty())
+	Expect(NoncurrentVersionLifecycle(-5).Rules).To(BeEmpty())
+}
+
+func TestEffectiveNoncurrentVersionRetentionDays(t *testing.T) {
+	RegisterTestingT(t)
+
+	cfg := &gcloud.StateStorageConfig{}
+	Expect(cfg.EffectiveNoncurrentVersionRetentionDays()).To(Equal(gcloud.DefaultNoncurrentVersionRetentionDays),
+		"unset must not mean unbounded, which is the state that caused this")
+
+	zero := 0
+	cfg.NoncurrentVersionRetentionDays = &zero
+	Expect(cfg.EffectiveNoncurrentVersionRetentionDays()).To(BeZero(),
+		"an explicit zero is an opt-out and must be distinguishable from unset")
+
+	seven := 7
+	cfg.NoncurrentVersionRetentionDays = &seven
+	Expect(cfg.EffectiveNoncurrentVersionRetentionDays()).To(Equal(7))
+}


### PR DESCRIPTION
The GCP state bucket is created with nothing but a `Location` (`bucketRef.Create`, `pkg/clouds/pulumi/gcp/provider.go`) and never looked at again. If object versioning is enabled on it, overwritten state generations are retained **forever**.

## Why this is a correctness problem, not a storage-cost one

Pulumi's cloud secrets manager re-wraps each stack's data key on **every state write**, and a KMS symmetric encrypt always uses the key's **current primary version**. So each retained generation depends on whichever key version was primary the day it was written.

Measured on a live deployment (`gs://payspace-infrastructure-state`, `versioning: true`, `lifecycle: null`, created 2025-10-17):

- **318 retained generations** of one stack object
- sampling 12 of them across three months and hashing `secrets_providers.state.encryptedkey` gives **9 distinct wrapped data keys** — the only repeats being consecutive writes inside a single `up`

With key rotation on any short period, the set of load-bearing key versions therefore grows without limit. Nothing can ever be shown to be unreferenced, so nothing can safely be destroyed, and the KMS bill grows with it — that deployment reached **8,952 billed key versions and $537/mo**, since every ACTIVE version bills whether `ENABLED`, `DISABLED` or `DESTROY_SCHEDULED`.

Bounding history makes the dependency set provable by construction: after the rule has been in place for its retention window, every version older than the window is referenced by nothing.

Worth noting audit logs cannot substitute here. For a symmetric key the caller names the `CryptoKey` and never a version (passing one is an error), and KMS resolves the version internally from the ciphertext, so Data Access logs record which key was used but not which version.

## What this adds

`noncurrentVersionRetentionDays` on the GCP `StateStorageConfig`, defaulting to **30**.

- **New buckets** get the lifecycle rule at creation.
- The rule deletes **`Archived` objects only**, keyed on `DaysSinceNoncurrentTime`, so the live state file is never a candidate. `AgeInDays` would have been wrong — it counts from creation, not from being superseded, and would expire live state.
- `0` opts out. The field is a pointer, so an explicit zero is distinguishable from unset.

## Existing buckets: new behaviour, deliberately narrow

`InitStateStore` now reconciles a bucket it did not create. That is a real behaviour change, so all three conditions must hold before it writes:

1. retention is enabled,
2. object versioning is **on**, so noncurrent generations actually accumulate and the rule is not merely inert,
3. the bucket has **no lifecycle rules at all**.

A bucket carrying any existing rule is left alone even if that rule does not bound noncurrent versions. Guessing at an operator's intent on the bucket that holds all of their Pulumi state is worse than doing nothing.

## Tests

`ShouldApplyNoncurrentVersionLifecycle` and the rule shape are pure functions, table-tested over the six guard cases. Both safety properties are mutation-verified:

- dropping the existing-rules check → `an existing rule is left alone…` fails
- widening `Liveness` to `LiveAndArchived` → `a Live or LiveAndArchived rule would delete the current state file` fails

## Verified against the real GCS API

Unit tests assert the struct we build; they cannot tell us whether GCS accepts it. That gap is exactly what let an alert-policy filter ship twice with a missing `resource.type` — the API validates at write time, and nothing before that catches it.

So this was exercised end to end against a throwaway versioned bucket (created and deleted by the probe, nothing existing touched):

```
creating throwaway bucket sc-lifecycle-probe-delete-me-1786358662
generations of state.json: 2
versioning=true existing lifecycle rules=0
ShouldApply -> true (as designed)
GCS accepted and read back: action=Delete liveness=2 daysSinceNoncurrentTime=30 ageInDays=0
ShouldApply -> false on re-read (idempotent)

PASS: GCS accepts the rule, it round-trips as Archived-only, and reconcile is idempotent.
deleted throwaway bucket sc-lifecycle-probe-delete-me-1786358662
```

Three things that only an integration run can establish:

- **GCS accepts the rule.** `Update` succeeded rather than 400-ing on the condition shape.
- **`Liveness` round-trips as `Archived`** (`2`; `LiveAndArchived` is `0`, `Live` is `1`) and `AgeInDays` stays `0`. A regression on either would make the live state file a deletion candidate.
- **Reconcile is idempotent.** Re-reading the bucket returns `ShouldApply -> false`, so a second `provision` does not rewrite the rule on every run. Without the existing-rules guard this would have been an unconditional write on every invocation.

## Notes

Schema regenerated; the field is optional, not `required`, so existing `server.yaml` files are unaffected.

`schema-gen` also surfaced **pre-existing drift** in `docs/schemas/kubernetes/kubernetescloudextras.json` — `externalTrafficPolicy` and `serviceType` exist on the Go struct but not in the committed schema. Left out of this PR to keep the diff reviewable; worth a separate regen.

SC does not enable bucket versioning itself, so a bucket only reaches the unbounded state if versioning was turned on out of band. This change makes that safe rather than assuming it never happens.

