### PR TITLE
feat(aws): optional permissions boundary for workload IAM roles

### DIFF
--- a/docs/docs/examples/parent-stacks/aws-multi-region/server.yaml
+++ b/docs/docs/examples/parent-stacks/aws-multi-region/server.yaml
@@ -24,6 +24,10 @@ templates:
     config: &aws-eu-cfg
       credentials: "${auth:aws-eu}"        # Required: AWS authentication
       account: "${auth:aws-eu.projectId}"  # Required: AWS account/project ID
+      # Optional: cap every workload IAM role SC mints under this template with a
+      # permissions boundary (ECS task/exec, Lambda, DB-init roles). Uncomment and
+      # point at a real policy ARN; the boundary must exist or CreateRole fails.
+      # permissionsBoundary: "arn:aws:iam::123456789012:policy/sc-workload-boundary"
   stack-per-app-us:
     type: ecs-fargate
     config: &aws-us-cfg

--- a/docs/docs/guides/parent-ecs-fargate.md
+++ b/docs/docs/guides/parent-ecs-fargate.md
@@ -146,6 +146,34 @@ resources:
 
 ---
 
+## **Optional: Cap Workload Roles with a Permissions Boundary**
+
+Set `permissionsBoundary` on a template's `config` to an IAM policy ARN. Simple Container then attaches it as the **permissions boundary** on every IAM role it creates for workloads under that template:
+
+- ECS task and execution roles
+- Lambda execution roles (including alert / CloudTrail-security-alert Lambdas)
+- DB-init (`pg-init` / `mysql-init`) task roles
+
+```yaml
+templates:
+  stack-per-app:
+    type: ecs-fargate
+    config:
+      credentials: "${auth:aws}"
+      account: "${auth:aws.projectId}"
+      permissionsBoundary: "arn:aws:iam::123456789012:policy/sc-workload-boundary"
+```
+
+A permissions boundary is a **ceiling**: a role's effective permissions become the intersection of its own policy and the boundary. This lets an operator provision SC workloads under a least-privilege deploy identity while guaranteeing a hard limit on what any minted role can ever do.
+
+**Defaults and compatibility.** The field is optional and empty by default — leave it unset and nothing changes. Adding or changing it later is an in-place role update (`PutRolePermissionsBoundary`), not a role replacement, so existing deployments are not recreated.
+
+**Precedence.** Declare it either at the template level (as above) or inside the `${auth:...}` credentials block. A non-empty template-level value wins.
+
+> **Warning:** one ARN caps **all** workload roles for the template at once. A boundary that is too tight silently strips permissions (ECR pull, CloudWatch Logs, Secrets Manager, …) from every service on the next deploy. Validate the boundary in staging before rolling it to production.
+
+---
+
 # **Provisioning the AWS & MongoDB Atlas Parent Stack**
 Once `server.yaml` is configured, **provision** the infrastructure:
 

--- a/docs/schemas/aws/accountconfig.json
+++ b/docs/schemas/aws/accountconfig.json
@@ -27,6 +27,9 @@
       "account": {
         "type": "string"
       },
+      "permissionsBoundary": {
+        "type": "string"
+      },
       "region": {
         "type": "string"
       },

--- a/docs/schemas/aws/cloudtrailsecurityalertsconfig.json
+++ b/docs/schemas/aws/cloudtrailsecurityalertsconfig.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/docs/schemas/aws/ecrrepository.json
+++ b/docs/schemas/aws/ecrrepository.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/docs/schemas/aws/mysqlconfig.json
+++ b/docs/schemas/aws/mysqlconfig.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/docs/schemas/aws/postgresconfig.json
+++ b/docs/schemas/aws/postgresconfig.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/docs/schemas/aws/secretsconfig.json
+++ b/docs/schemas/aws/secretsconfig.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/docs/schemas/aws/secretsproviderconfig.json
+++ b/docs/schemas/aws/secretsproviderconfig.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/docs/schemas/aws/statestorageconfig.json
+++ b/docs/schemas/aws/statestorageconfig.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/docs/schemas/aws/templateconfig.json
+++ b/docs/schemas/aws/templateconfig.json
@@ -30,6 +30,9 @@
           "account": {
             "type": "string"
           },
+          "permissionsBoundary": {
+            "type": "string"
+          },
           "region": {
             "type": "string"
           },

--- a/pkg/clouds/aws/auth.go
+++ b/pkg/clouds/aws/auth.go
@@ -25,13 +25,30 @@ type AccountConfig struct {
 	SecretAccessKey string `json:"secretAccessKey" yaml:"secretAccessKey"`
 	Region          string `json:"region" yaml:"region"`
 	// PermissionsBoundary, when set to an IAM policy ARN, is applied as the
-	// permissions boundary on every IAM role SC creates for workloads under
-	// this account (ECS task/execution roles, Lambda execution roles). Optional
-	// and empty by default, so it changes nothing unless a parent stack opts in
-	// per template. Lets an operator cap what a deployed workload role can ever
-	// do, independent of the role's own policy.
+	// permissions boundary on every IAM role SC creates for workloads under this
+	// account: ECS task/execution roles, Lambda and alert-Lambda execution roles,
+	// and DB-init (pg-init/mysql-init) exec-task roles. Optional and empty by
+	// default, so it changes nothing unless a parent stack opts in per template.
+	// Lets an operator cap what a deployed workload role can ever do, independent
+	// of the role's own policy (effective perms become policy AND boundary).
+	// WARNING: one ARN caps ALL workload roles in the stack at once — a boundary
+	// too tight silently strips e.g. ECR pull / logs / SecretsManager from every
+	// service on the next deploy, so validate it in staging first.
 	PermissionsBoundary string `json:"permissionsBoundary,omitempty" yaml:"permissionsBoundary,omitempty"`
 	api.Credentials     `json:",inline" yaml:",inline"`
+}
+
+// KeepBoundary preserves a non-credential permissions-boundary value across an
+// api.ConvertAuth call, which rehydrates an AccountConfig from the resolved
+// ${auth:...} credentials blob and so carries only credential fields. Callers
+// pass the boundary declared at template level; a non-empty template value wins
+// (the documented precedence), while an empty one leaves whatever ConvertAuth
+// loaded (an auth-level boundary). Centralizes the precedence so every
+// ConvertAuth site that feeds a workload role behaves identically.
+func (r *AccountConfig) KeepBoundary(templateBoundary string) {
+	if templateBoundary != "" {
+		r.PermissionsBoundary = templateBoundary
+	}
 }
 
 type SecretsConfig struct {

--- a/pkg/clouds/aws/auth.go
+++ b/pkg/clouds/aws/auth.go
@@ -24,7 +24,14 @@ type AccountConfig struct {
 	AccessKey       string `json:"accessKey" yaml:"accessKey"`
 	SecretAccessKey string `json:"secretAccessKey" yaml:"secretAccessKey"`
 	Region          string `json:"region" yaml:"region"`
-	api.Credentials `json:",inline" yaml:",inline"`
+	// PermissionsBoundary, when set to an IAM policy ARN, is applied as the
+	// permissions boundary on every IAM role SC creates for workloads under
+	// this account (ECS task/execution roles, Lambda execution roles). Optional
+	// and empty by default, so it changes nothing unless a parent stack opts in
+	// per template. Lets an operator cap what a deployed workload role can ever
+	// do, independent of the role's own policy.
+	PermissionsBoundary string `json:"permissionsBoundary,omitempty" yaml:"permissionsBoundary,omitempty"`
+	api.Credentials     `json:",inline" yaml:",inline"`
 }
 
 type SecretsConfig struct {

--- a/pkg/clouds/aws/auth_test.go
+++ b/pkg/clouds/aws/auth_test.go
@@ -8,9 +8,30 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	"github.com/simple-container-com/api/pkg/api"
 )
+
+// TestAccountConfig_PermissionsBoundaryYAML verifies the permissionsBoundary
+// field parses from stack YAML (the load-bearing tag: parents set it per
+// template) and round-trips, and that it defaults to empty when absent.
+func TestAccountConfig_PermissionsBoundaryYAML(t *testing.T) {
+	RegisterTestingT(t)
+
+	const arn = "arn:aws:iam::123456789012:policy/my-workload-boundary"
+	var ac AccountConfig
+	Expect(yaml.Unmarshal([]byte("account: \"123456789012\"\npermissionsBoundary: \""+arn+"\"\n"), &ac)).To(Succeed())
+	Expect(ac.PermissionsBoundary).To(Equal(arn))
+
+	out, err := yaml.Marshal(&ac)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(out)).To(ContainSubstring("permissionsBoundary: " + arn))
+
+	var absent AccountConfig
+	Expect(yaml.Unmarshal([]byte("account: \"123456789012\"\n"), &absent)).To(Succeed())
+	Expect(absent.PermissionsBoundary).To(BeEmpty())
+}
 
 // ---- AccountConfig getters ----------------------------------------------
 

--- a/pkg/clouds/aws/aws_lambda.go
+++ b/pkg/clouds/aws/aws_lambda.go
@@ -51,9 +51,12 @@ func ToAwsLambdaConfig(tpl any, stackCfg *api.StackConfigSingleImage) (any, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields; preserve the non-credential
-	// permissions boundary from the template so it reaches the execution role.
-	accountConfig.PermissionsBoundary = templateCfg.AccountConfig.PermissionsBoundary
+	// ConvertAuth carries only credential fields. Preserve the non-credential
+	// permissions boundary so it reaches the execution role: a template-level
+	// value wins; if unset, keep whatever ConvertAuth loaded (an auth-level one).
+	if templateCfg.AccountConfig.PermissionsBoundary != "" {
+		accountConfig.PermissionsBoundary = templateCfg.AccountConfig.PermissionsBoundary
+	}
 	if stackCfg == nil {
 		return nil, errors.Errorf("stack config cannot be nil")
 	}

--- a/pkg/clouds/aws/aws_lambda.go
+++ b/pkg/clouds/aws/aws_lambda.go
@@ -51,12 +51,9 @@ func ToAwsLambdaConfig(tpl any, stackCfg *api.StackConfigSingleImage) (any, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields. Preserve the non-credential
-	// permissions boundary so it reaches the execution role: a template-level
-	// value wins; if unset, keep whatever ConvertAuth loaded (an auth-level one).
-	if templateCfg.AccountConfig.PermissionsBoundary != "" {
-		accountConfig.PermissionsBoundary = templateCfg.AccountConfig.PermissionsBoundary
-	}
+	// Preserve the template-level boundary across ConvertAuth's credential-only
+	// rehydrate so it reaches the execution role (see AccountConfig.KeepBoundary).
+	accountConfig.KeepBoundary(templateCfg.AccountConfig.PermissionsBoundary)
 	if stackCfg == nil {
 		return nil, errors.Errorf("stack config cannot be nil")
 	}

--- a/pkg/clouds/aws/aws_lambda.go
+++ b/pkg/clouds/aws/aws_lambda.go
@@ -51,6 +51,9 @@ func ToAwsLambdaConfig(tpl any, stackCfg *api.StackConfigSingleImage) (any, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
+	// ConvertAuth carries only credential fields; preserve the non-credential
+	// permissions boundary from the template so it reaches the execution role.
+	accountConfig.PermissionsBoundary = templateCfg.AccountConfig.PermissionsBoundary
 	if stackCfg == nil {
 		return nil, errors.Errorf("stack config cannot be nil")
 	}

--- a/pkg/clouds/aws/boundary_survival_test.go
+++ b/pkg/clouds/aws/boundary_survival_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Simple Container
+
+package aws
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/simple-container-com/api/pkg/api"
+)
+
+const testBoundaryARN = "arn:aws:iam::123456789012:policy/my-workload-boundary"
+
+// authBlob is a resolved ${auth:...} credentials blob WITHOUT permissionsBoundary.
+// Using it (rather than an empty Credentials.Credentials) is what makes these
+// tests load-bearing: with empty creds, CredentialsValue marshals the whole
+// struct so the boundary rides along even if the preserve logic is deleted.
+const authBlob = `{"account":"123456789012","region":"us-east-1"}`
+
+// KeepBoundary centralizes the "template wins, else keep what ConvertAuth
+// loaded" precedence. Pin both directions.
+func TestAccountConfig_KeepBoundary(t *testing.T) {
+	RegisterTestingT(t)
+
+	// A non-empty template value overrides whatever is already set.
+	ac := AccountConfig{PermissionsBoundary: "auth-level-arn"}
+	ac.KeepBoundary("template-level-arn")
+	Expect(ac.PermissionsBoundary).To(Equal("template-level-arn"))
+
+	// An empty template value leaves the existing (auth-level) value intact.
+	ac2 := AccountConfig{PermissionsBoundary: "auth-level-arn"}
+	ac2.KeepBoundary("")
+	Expect(ac2.PermissionsBoundary).To(Equal("auth-level-arn"))
+}
+
+// The in-place ConvertAuth path used by the ECS/Lambda pulumi constructors:
+// a template-level boundary must survive the credential rehydrate.
+func TestConvertAuth_InPlacePreservesTemplateBoundary(t *testing.T) {
+	RegisterTestingT(t)
+	ac := AccountConfig{
+		PermissionsBoundary: testBoundaryARN,
+		Credentials:         api.Credentials{Credentials: authBlob},
+	}
+	tpl := ac.PermissionsBoundary
+	Expect(api.ConvertAuth(&ac, &ac)).To(Succeed())
+	ac.KeepBoundary(tpl)
+	Expect(ac.PermissionsBoundary).To(Equal(testBoundaryARN)) // survived
+	Expect(ac.Account).To(Equal("123456789012"))              // creds still loaded
+}
+
+// The fresh-struct converter path (ToAwsLambdaConfig): boundary must reach the
+// resulting *LambdaInput for both template-level and auth-level declaration,
+// and stay empty when unset.
+func TestToAwsLambdaConfig_PermissionsBoundary(t *testing.T) {
+	t.Run("template-level survives ConvertAuth", func(t *testing.T) {
+		RegisterTestingT(t)
+		tpl := &TemplateConfig{AccountConfig: AccountConfig{
+			PermissionsBoundary: testBoundaryARN,
+			Credentials:         api.Credentials{Credentials: authBlob},
+		}}
+		out, err := ToAwsLambdaConfig(tpl, &api.StackConfigSingleImage{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.(*LambdaInput).PermissionsBoundary).To(Equal(testBoundaryARN))
+	})
+
+	t.Run("auth-level survives ConvertAuth", func(t *testing.T) {
+		RegisterTestingT(t)
+		tpl := &TemplateConfig{AccountConfig: AccountConfig{
+			Credentials: api.Credentials{Credentials: `{"account":"123456789012","region":"us-east-1","permissionsBoundary":"` + testBoundaryARN + `"}`},
+		}}
+		out, err := ToAwsLambdaConfig(tpl, &api.StackConfigSingleImage{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.(*LambdaInput).PermissionsBoundary).To(Equal(testBoundaryARN))
+	})
+
+	t.Run("unset stays empty (no-op contract)", func(t *testing.T) {
+		RegisterTestingT(t)
+		out, err := ToAwsLambdaConfig(validTemplateConfig(), &api.StackConfigSingleImage{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.(*LambdaInput).PermissionsBoundary).To(BeEmpty())
+	})
+}

--- a/pkg/clouds/pulumi/aws/alerts.go
+++ b/pkg/clouds/pulumi/aws/alerts.go
@@ -39,6 +39,9 @@ type alertCfg struct {
 	metricAlarmArgs cloudwatch.MetricAlarmArgs
 	helpersImage    *docker.Image
 	snsTopic        *sns.Topic
+	// permissionsBoundary, when set (AccountConfig.PermissionsBoundary), is
+	// applied to the alert Lambda's execution role. Empty = none.
+	permissionsBoundary string
 	// Optional — when all three are set, the Lambda will look up matching
 	// CloudTrail events in the alarm's time window and include a summary
 	// (event name, actor, source IP, timestamp) in the Slack/Discord/Telegram
@@ -153,7 +156,8 @@ func pushHelpersImageToECR(ctx *sdk.Context, cfg helperCfg) (*docker.Image, erro
 func createAlert(ctx *sdk.Context, cfg alertCfg) error {
 	// Create IAM Role for Lambda Function
 	lambdaExecutionRole, err := iam.NewRole(ctx, fmt.Sprintf("%s-execution-role", cfg.name), &iam.RoleArgs{
-		Tags: cfg.tags,
+		Tags:                cfg.tags,
+		PermissionsBoundary: permissionsBoundaryPtr(cfg.permissionsBoundary),
 		AssumeRolePolicy: pulumi.String(`{
 			"Version": "2012-10-17",
 			"Statement": [{

--- a/pkg/clouds/pulumi/aws/aws_lambda.go
+++ b/pkg/clouds/pulumi/aws/aws_lambda.go
@@ -45,9 +45,17 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 	if !ok {
 		return output, errors.Errorf("failed to convert aws-lambda config for %q in stack %q in %q", input.Descriptor.Type, stack.Name, deployParams.Environment)
 	}
+	// This in-place ConvertAuth re-reads the credentials blob over
+	// crInput.AccountConfig; capture the (template-level) boundary first and
+	// re-assert it after so "template wins" holds consistently with the other
+	// constructors, and so a future switch to the fresh-struct idiom can't
+	// silently drop it. json.Unmarshal already leaves absent fields untouched;
+	// this makes the intent explicit and survives a dual (template+auth) decl.
+	tplBoundary := crInput.AccountConfig.PermissionsBoundary
 	if err := api.ConvertAuth(crInput, &crInput.AccountConfig); err != nil {
 		return nil, errors.Wrapf(err, "failed to convert auth config to aws.AccountConfig")
 	}
+	crInput.AccountConfig.KeepBoundary(tplBoundary)
 	stackConfig := crInput.StackConfig
 
 	awsCloudExtras := &aws.CloudExtras{}

--- a/pkg/clouds/pulumi/aws/aws_lambda.go
+++ b/pkg/clouds/pulumi/aws/aws_lambda.go
@@ -96,7 +96,8 @@ func Lambda(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, params p
 	lambdaExecutionRoleName := fmt.Sprintf("%s-execution-role", stack.Name)
 	params.Log.Info(ctx.Context(), "configure lambda execution role %q for %q in %q...", lambdaExecutionRoleName, stack.Name, deployParams.Environment)
 	lambdaExecutionRole, err := iam.NewRole(ctx, lambdaExecutionRoleName, &iam.RoleArgs{
-		Tags: tags,
+		Tags:                tags,
+		PermissionsBoundary: permissionsBoundaryPtr(crInput.AccountConfig.PermissionsBoundary),
 		AssumeRolePolicy: sdk.String(`{
 			"Version": "2012-10-17",
 			"Statement": [{

--- a/pkg/clouds/pulumi/aws/cloudtrail_security_alerts.go
+++ b/pkg/clouds/pulumi/aws/cloudtrail_security_alerts.go
@@ -556,12 +556,9 @@ func CloudTrailSecurityAlerts(ctx *sdk.Context, stack api.Stack, input api.Resou
 	if err := api.ConvertAuth(&cfg.AccountConfig, accountConfig); err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields. Preserve the non-credential
-	// permissions boundary so it reaches the alert Lambda's execution role: a
-	// template-level value wins; if unset, keep the auth-level one ConvertAuth loaded.
-	if cfg.AccountConfig.PermissionsBoundary != "" {
-		accountConfig.PermissionsBoundary = cfg.AccountConfig.PermissionsBoundary
-	}
+	// Preserve the template-level boundary across ConvertAuth so it reaches the
+	// alert Lambda's execution role (see awsApi.AccountConfig.KeepBoundary).
+	accountConfig.KeepBoundary(cfg.AccountConfig.PermissionsBoundary)
 	cfg.AccountConfig = *accountConfig
 
 	if cfg.LogGroupName == "" {

--- a/pkg/clouds/pulumi/aws/cloudtrail_security_alerts.go
+++ b/pkg/clouds/pulumi/aws/cloudtrail_security_alerts.go
@@ -556,9 +556,12 @@ func CloudTrailSecurityAlerts(ctx *sdk.Context, stack api.Stack, input api.Resou
 	if err := api.ConvertAuth(&cfg.AccountConfig, accountConfig); err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields; preserve the non-credential
-	// permissions boundary so it reaches the alert Lambda's execution role.
-	accountConfig.PermissionsBoundary = cfg.AccountConfig.PermissionsBoundary
+	// ConvertAuth carries only credential fields. Preserve the non-credential
+	// permissions boundary so it reaches the alert Lambda's execution role: a
+	// template-level value wins; if unset, keep the auth-level one ConvertAuth loaded.
+	if cfg.AccountConfig.PermissionsBoundary != "" {
+		accountConfig.PermissionsBoundary = cfg.AccountConfig.PermissionsBoundary
+	}
 	cfg.AccountConfig = *accountConfig
 
 	if cfg.LogGroupName == "" {

--- a/pkg/clouds/pulumi/aws/cloudtrail_security_alerts.go
+++ b/pkg/clouds/pulumi/aws/cloudtrail_security_alerts.go
@@ -556,6 +556,9 @@ func CloudTrailSecurityAlerts(ctx *sdk.Context, stack api.Stack, input api.Resou
 	if err := api.ConvertAuth(&cfg.AccountConfig, accountConfig); err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
+	// ConvertAuth carries only credential fields; preserve the non-credential
+	// permissions boundary so it reaches the alert Lambda's execution role.
+	accountConfig.PermissionsBoundary = cfg.AccountConfig.PermissionsBoundary
 	cfg.AccountConfig = *accountConfig
 
 	if cfg.LogGroupName == "" {
@@ -739,22 +742,23 @@ func CloudTrailSecurityAlerts(ctx *sdk.Context, stack api.Stack, input api.Resou
 			alertRegion := cfg.LogGroupRegion
 			ctLogGroupArn := cloudTrailLogGroupArn(cfg, alertRegion)
 			if err := createAlert(ctx, alertCfg{
-				name:             alertBaseName,
-				description:      alertDef.description,
-				slackConfig:      cfg.Slack,
-				discordConfig:    cfg.Discord,
-				telegramConfig:   cfg.Telegram,
-				deployParams:     *input.StackParams,
-				secretSuffix:     resPrefix,
-				helpersImage:     helpersImage,
-				snsTopic:         snsTopic,
-				opts:             opts,
-				tags:             tags,
-				metricAlarmArgs:  alarmArgs,
-				ctLogGroupName:   cfg.LogGroupName,
-				ctLogGroupRegion: alertRegion,
-				ctFilterPattern:  alertDef.filterPattern,
-				ctLogGroupArn:    ctLogGroupArn,
+				permissionsBoundary: cfg.AccountConfig.PermissionsBoundary,
+				name:                alertBaseName,
+				description:         alertDef.description,
+				slackConfig:         cfg.Slack,
+				discordConfig:       cfg.Discord,
+				telegramConfig:      cfg.Telegram,
+				deployParams:        *input.StackParams,
+				secretSuffix:        resPrefix,
+				helpersImage:        helpersImage,
+				snsTopic:            snsTopic,
+				opts:                opts,
+				tags:                tags,
+				metricAlarmArgs:     alarmArgs,
+				ctLogGroupName:      cfg.LogGroupName,
+				ctLogGroupRegion:    alertRegion,
+				ctFilterPattern:     alertDef.filterPattern,
+				ctLogGroupArn:       ctLogGroupArn,
 			}); err != nil {
 				return nil, errors.Wrapf(err, "failed to create alert %q", alertDef.name)
 			}

--- a/pkg/clouds/pulumi/aws/compute_proc.go
+++ b/pkg/clouds/pulumi/aws/compute_proc.go
@@ -48,12 +48,9 @@ func RdsPostgresComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Re
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields. Preserve the non-credential
-	// permissions boundary so it reaches the pg-init exec task's role: a
-	// template-level value wins; if unset, keep the auth-level one ConvertAuth loaded.
-	if postgresCfg.AccountConfig.PermissionsBoundary != "" {
-		accountConfig.PermissionsBoundary = postgresCfg.AccountConfig.PermissionsBoundary
-	}
+	// Preserve the template-level boundary across ConvertAuth so it reaches the
+	// pg-init exec task's role (see aws.AccountConfig.KeepBoundary).
+	accountConfig.KeepBoundary(postgresCfg.AccountConfig.PermissionsBoundary)
 
 	postgresCfg.AccountConfig = *accountConfig
 	postgresResName := lo.If(postgresCfg.Name == "", input.Descriptor.Name).Else(postgresCfg.Name)
@@ -200,12 +197,9 @@ func RdsMysqlComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Resou
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields. Preserve the non-credential
-	// permissions boundary so it reaches the mysql-init exec task's role: a
-	// template-level value wins; if unset, keep the auth-level one ConvertAuth loaded.
-	if mysqlCfg.AccountConfig.PermissionsBoundary != "" {
-		accountConfig.PermissionsBoundary = mysqlCfg.AccountConfig.PermissionsBoundary
-	}
+	// Preserve the template-level boundary across ConvertAuth so it reaches the
+	// mysql-init exec task's role (see aws.AccountConfig.KeepBoundary).
+	accountConfig.KeepBoundary(mysqlCfg.AccountConfig.PermissionsBoundary)
 
 	mysqlCfg.AccountConfig = *accountConfig
 	dbCfg := mysqlCfg

--- a/pkg/clouds/pulumi/aws/compute_proc.go
+++ b/pkg/clouds/pulumi/aws/compute_proc.go
@@ -48,9 +48,12 @@ func RdsPostgresComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Re
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields; preserve the non-credential
-	// permissions boundary so it reaches the pg-init exec task's role.
-	accountConfig.PermissionsBoundary = postgresCfg.AccountConfig.PermissionsBoundary
+	// ConvertAuth carries only credential fields. Preserve the non-credential
+	// permissions boundary so it reaches the pg-init exec task's role: a
+	// template-level value wins; if unset, keep the auth-level one ConvertAuth loaded.
+	if postgresCfg.AccountConfig.PermissionsBoundary != "" {
+		accountConfig.PermissionsBoundary = postgresCfg.AccountConfig.PermissionsBoundary
+	}
 
 	postgresCfg.AccountConfig = *accountConfig
 	postgresResName := lo.If(postgresCfg.Name == "", input.Descriptor.Name).Else(postgresCfg.Name)
@@ -197,9 +200,12 @@ func RdsMysqlComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Resou
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
-	// ConvertAuth carries only credential fields; preserve the non-credential
-	// permissions boundary so it reaches the mysql-init exec task's role.
-	accountConfig.PermissionsBoundary = mysqlCfg.AccountConfig.PermissionsBoundary
+	// ConvertAuth carries only credential fields. Preserve the non-credential
+	// permissions boundary so it reaches the mysql-init exec task's role: a
+	// template-level value wins; if unset, keep the auth-level one ConvertAuth loaded.
+	if mysqlCfg.AccountConfig.PermissionsBoundary != "" {
+		accountConfig.PermissionsBoundary = mysqlCfg.AccountConfig.PermissionsBoundary
+	}
 
 	mysqlCfg.AccountConfig = *accountConfig
 	dbCfg := mysqlCfg

--- a/pkg/clouds/pulumi/aws/compute_proc.go
+++ b/pkg/clouds/pulumi/aws/compute_proc.go
@@ -48,6 +48,9 @@ func RdsPostgresComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Re
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
+	// ConvertAuth carries only credential fields; preserve the non-credential
+	// permissions boundary so it reaches the pg-init exec task's role.
+	accountConfig.PermissionsBoundary = postgresCfg.AccountConfig.PermissionsBoundary
 
 	postgresCfg.AccountConfig = *accountConfig
 	postgresResName := lo.If(postgresCfg.Name == "", input.Descriptor.Name).Else(postgresCfg.Name)
@@ -194,6 +197,9 @@ func RdsMysqlComputeProcessor(ctx *sdk.Context, stack api.Stack, input api.Resou
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to convert aws account config")
 	}
+	// ConvertAuth carries only credential fields; preserve the non-credential
+	// permissions boundary so it reaches the mysql-init exec task's role.
+	accountConfig.PermissionsBoundary = mysqlCfg.AccountConfig.PermissionsBoundary
 
 	mysqlCfg.AccountConfig = *accountConfig
 	dbCfg := mysqlCfg

--- a/pkg/clouds/pulumi/aws/ecs_fargate.go
+++ b/pkg/clouds/pulumi/aws/ecs_fargate.go
@@ -89,9 +89,15 @@ func EcsFargate(ctx *sdk.Context, stack api.Stack, input api.ResourceInput, para
 	if !ok {
 		return output, errors.Errorf("failed to convert ecs_fargate config for %q in stack %q in %q", input.Descriptor.Type, stack.Name, deployParams.Environment)
 	}
+	// This in-place ConvertAuth re-reads the credentials blob over
+	// crInput.AccountConfig (which createEcsFargateCluster reads for the role's
+	// boundary). Capture the template-level boundary first and re-assert it so
+	// "template wins" holds and a future refactor can't silently drop it.
+	tplBoundary := crInput.AccountConfig.PermissionsBoundary
 	if err := api.ConvertAuth(crInput, &crInput.AccountConfig); err != nil {
 		return nil, errors.Wrapf(err, "failed to convert auth config to aws.AccountConfig")
 	}
+	crInput.AccountConfig.KeepBoundary(tplBoundary)
 
 	params.Log.Debug(ctx.Context(), "configure ECS Fargate for stack %q in %q: %+v...", stack.Name, deployParams.Environment, crInput)
 

--- a/pkg/clouds/pulumi/aws/ecs_fargate.go
+++ b/pkg/clouds/pulumi/aws/ecs_fargate.go
@@ -253,8 +253,9 @@ func createEcsFargateCluster(ctx *sdk.Context, stack api.Stack, params pApi.Prov
 	// Create an ECS task execution IAM role
 	roleName := fmt.Sprintf("%s-exec-role", ecsSimpleClusterName)
 	taskExecRole, err := iam.NewRole(ctx, roleName, &iam.RoleArgs{
-		Name: sdk.String(ecsSimpleClusterName),
-		Tags: tags,
+		Name:                sdk.String(ecsSimpleClusterName),
+		Tags:                tags,
+		PermissionsBoundary: permissionsBoundaryPtr(crInput.AccountConfig.PermissionsBoundary),
 		AssumeRolePolicy: sdk.String(`{
                 "Version": "2012-10-17",
                 "Statement": [{
@@ -753,16 +754,17 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 
 	if alerts.MaxCPU != nil {
 		if err := createAlert(ctx, alertCfg{
-			name:           fmt.Sprintf("%s--%s", alerts.MaxCPU.AlertName, deployParams.Environment),
-			description:    alerts.MaxCPU.Description,
-			telegramConfig: alerts.Telegram,
-			discordConfig:  alerts.Discord,
-			slackConfig:    alerts.Slack,
-			deployParams:   deployParams,
-			helpersImage:   helpersImage,
-			secretSuffix:   crInput.Config.Version,
-			opts:           opts,
-			tags:           tags,
+			permissionsBoundary: crInput.AccountConfig.PermissionsBoundary,
+			name:                fmt.Sprintf("%s--%s", alerts.MaxCPU.AlertName, deployParams.Environment),
+			description:         alerts.MaxCPU.Description,
+			telegramConfig:      alerts.Telegram,
+			discordConfig:       alerts.Discord,
+			slackConfig:         alerts.Slack,
+			deployParams:        deployParams,
+			helpersImage:        helpersImage,
+			secretSuffix:        crInput.Config.Version,
+			opts:                opts,
+			tags:                tags,
 			metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 				ComparisonOperator: sdk.String("GreaterThanThreshold"),
 				EvaluationPeriods:  sdk.Int(1),
@@ -784,16 +786,17 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 	}
 	if alerts.MaxMemory != nil {
 		if err := createAlert(ctx, alertCfg{
-			name:           fmt.Sprintf("%s--%s", alerts.MaxMemory.AlertName, deployParams.Environment),
-			description:    alerts.MaxMemory.Description,
-			telegramConfig: alerts.Telegram,
-			discordConfig:  alerts.Discord,
-			slackConfig:    alerts.Slack,
-			deployParams:   deployParams,
-			secretSuffix:   crInput.Config.Version,
-			helpersImage:   helpersImage,
-			opts:           opts,
-			tags:           tags,
+			permissionsBoundary: crInput.AccountConfig.PermissionsBoundary,
+			name:                fmt.Sprintf("%s--%s", alerts.MaxMemory.AlertName, deployParams.Environment),
+			description:         alerts.MaxMemory.Description,
+			telegramConfig:      alerts.Telegram,
+			discordConfig:       alerts.Discord,
+			slackConfig:         alerts.Slack,
+			deployParams:        deployParams,
+			secretSuffix:        crInput.Config.Version,
+			helpersImage:        helpersImage,
+			opts:                opts,
+			tags:                tags,
 			metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 				ComparisonOperator: sdk.String("GreaterThanThreshold"),
 				EvaluationPeriods:  sdk.Int(1),
@@ -860,17 +863,18 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 		// Server Errors (5XX) Alert
 		if alerts.ServerErrors != nil {
 			if err := createAlert(ctx, alertCfg{
-				name:           fmt.Sprintf("%s--%s", alerts.ServerErrors.AlertName, deployParams.Environment),
-				description:    alerts.ServerErrors.Description,
-				telegramConfig: alerts.Telegram,
-				discordConfig:  alerts.Discord,
-				slackConfig:    alerts.Slack,
-				deployParams:   deployParams,
-				secretSuffix:   crInput.Config.Version,
-				helpersImage:   helpersImage,
-				snsTopic:       snsTopic,
-				opts:           opts,
-				tags:           tags,
+				permissionsBoundary: crInput.AccountConfig.PermissionsBoundary,
+				name:                fmt.Sprintf("%s--%s", alerts.ServerErrors.AlertName, deployParams.Environment),
+				description:         alerts.ServerErrors.Description,
+				telegramConfig:      alerts.Telegram,
+				discordConfig:       alerts.Discord,
+				slackConfig:         alerts.Slack,
+				deployParams:        deployParams,
+				secretSuffix:        crInput.Config.Version,
+				helpersImage:        helpersImage,
+				snsTopic:            snsTopic,
+				opts:                opts,
+				tags:                tags,
 				metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 					ComparisonOperator: sdk.String("GreaterThanThreshold"),
 					EvaluationPeriods:  sdk.Int(2),
@@ -893,17 +897,18 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 		// Unhealthy Hosts Alert
 		if alerts.UnhealthyHosts != nil {
 			if err := createAlert(ctx, alertCfg{
-				name:           fmt.Sprintf("%s--%s", alerts.UnhealthyHosts.AlertName, deployParams.Environment),
-				description:    alerts.UnhealthyHosts.Description,
-				telegramConfig: alerts.Telegram,
-				discordConfig:  alerts.Discord,
-				slackConfig:    alerts.Slack,
-				deployParams:   deployParams,
-				secretSuffix:   crInput.Config.Version,
-				helpersImage:   helpersImage,
-				snsTopic:       snsTopic,
-				opts:           opts,
-				tags:           tags,
+				permissionsBoundary: crInput.AccountConfig.PermissionsBoundary,
+				name:                fmt.Sprintf("%s--%s", alerts.UnhealthyHosts.AlertName, deployParams.Environment),
+				description:         alerts.UnhealthyHosts.Description,
+				telegramConfig:      alerts.Telegram,
+				discordConfig:       alerts.Discord,
+				slackConfig:         alerts.Slack,
+				deployParams:        deployParams,
+				secretSuffix:        crInput.Config.Version,
+				helpersImage:        helpersImage,
+				snsTopic:            snsTopic,
+				opts:                opts,
+				tags:                tags,
 				metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 					ComparisonOperator: sdk.String("GreaterThanOrEqualToThreshold"),
 					EvaluationPeriods:  sdk.Int(2),
@@ -927,17 +932,18 @@ func createEcsAlerts(ctx *sdk.Context, clusterName, serviceName string, stack ap
 		// Target Response Time Alert
 		if alerts.ResponseTime != nil {
 			if err := createAlert(ctx, alertCfg{
-				name:           fmt.Sprintf("%s--%s", alerts.ResponseTime.AlertName, deployParams.Environment),
-				description:    alerts.ResponseTime.Description,
-				telegramConfig: alerts.Telegram,
-				discordConfig:  alerts.Discord,
-				slackConfig:    alerts.Slack,
-				deployParams:   deployParams,
-				secretSuffix:   crInput.Config.Version,
-				helpersImage:   helpersImage,
-				snsTopic:       snsTopic,
-				opts:           opts,
-				tags:           tags,
+				permissionsBoundary: crInput.AccountConfig.PermissionsBoundary,
+				name:                fmt.Sprintf("%s--%s", alerts.ResponseTime.AlertName, deployParams.Environment),
+				description:         alerts.ResponseTime.Description,
+				telegramConfig:      alerts.Telegram,
+				discordConfig:       alerts.Discord,
+				slackConfig:         alerts.Slack,
+				deployParams:        deployParams,
+				secretSuffix:        crInput.Config.Version,
+				helpersImage:        helpersImage,
+				snsTopic:            snsTopic,
+				opts:                opts,
+				tags:                tags,
 				metricAlarmArgs: cloudwatch.MetricAlarmArgs{
 					ComparisonOperator: sdk.String("GreaterThanThreshold"),
 					EvaluationPeriods:  sdk.Int(3),

--- a/pkg/clouds/pulumi/aws/exec_ecs_task.go
+++ b/pkg/clouds/pulumi/aws/exec_ecs_task.go
@@ -49,8 +49,9 @@ func execEcsTask(ctx *sdk.Context, config ecsTaskConfig) error {
 	params.Log.Info(ctx.Context(), "configure exec role for %q", name)
 	execRoleName := fmt.Sprintf("%s-exec-role", name)
 	taskExecRole, err := iam.NewRole(ctx, execRoleName, &iam.RoleArgs{
-		Name: sdk.String(execRoleName),
-		Tags: config.tags,
+		Name:                sdk.String(execRoleName),
+		Tags:                config.tags,
+		PermissionsBoundary: permissionsBoundaryPtr(config.account.PermissionsBoundary),
 		AssumeRolePolicy: sdk.String(`{
                 "Version": "2012-10-17",
                 "Statement": [{

--- a/pkg/clouds/pulumi/aws/permissions_boundary.go
+++ b/pkg/clouds/pulumi/aws/permissions_boundary.go
@@ -1,0 +1,19 @@
+package aws
+
+import (
+	"strings"
+
+	sdk "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// permissionsBoundaryPtr renders an AccountConfig.PermissionsBoundary ARN as
+// the PermissionsBoundary input for an iam.RoleArgs. An empty ARN yields nil,
+// i.e. no boundary is set on the role — the default for every stack that does
+// not opt in, so existing deployments are unaffected. Setting/adding a
+// boundary is an in-place role update (never a replacement).
+func permissionsBoundaryPtr(arn string) sdk.StringPtrInput {
+	if strings.TrimSpace(arn) == "" {
+		return nil
+	}
+	return sdk.String(arn)
+}

--- a/pkg/clouds/pulumi/aws/permissions_boundary.go
+++ b/pkg/clouds/pulumi/aws/permissions_boundary.go
@@ -12,7 +12,8 @@ import (
 // not opt in, so existing deployments are unaffected. Setting/adding a
 // boundary is an in-place role update (never a replacement).
 func permissionsBoundaryPtr(arn string) sdk.StringPtrInput {
-	if strings.TrimSpace(arn) == "" {
+	arn = strings.TrimSpace(arn)
+	if arn == "" {
 		return nil
 	}
 	return sdk.String(arn)

--- a/pkg/clouds/pulumi/aws/permissions_boundary_test.go
+++ b/pkg/clouds/pulumi/aws/permissions_boundary_test.go
@@ -3,29 +3,48 @@
 
 package aws
 
-import "testing"
+import (
+	"testing"
 
-// permissionsBoundaryPtr's contract is the backward-compat guarantee: an empty
-// or whitespace-only ARN must yield nil (no boundary set on the role), so every
-// stack that does not opt in is unchanged. A real ARN must yield non-nil.
+	sdk "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// permissionsBoundaryPtr's contract: an empty/whitespace-only ARN yields nil
+// (no boundary set — the backward-compat guarantee for stacks that don't opt
+// in), and a real ARN yields the trimmed value (a downstream enforcement flip
+// matches the boundary EXACTLY, so a wrong/padded value must not slip through).
 func TestPermissionsBoundaryPtr(t *testing.T) {
 	tests := []struct {
 		name    string
 		arn     string
 		wantNil bool
+		wantVal string // expected sdk.String value when !wantNil
 	}{
 		{name: "empty means no boundary", arn: "", wantNil: true},
 		{name: "whitespace means no boundary", arn: "   ", wantNil: true},
-		{name: "arn sets a boundary", arn: "arn:aws:iam::123456789012:policy/my-workload-boundary", wantNil: false},
+		{name: "arn sets a boundary", arn: "arn:aws:iam::123456789012:policy/my-workload-boundary", wantNil: false, wantVal: "arn:aws:iam::123456789012:policy/my-workload-boundary"},
+		{name: "surrounding whitespace is trimmed", arn: "  arn:aws:iam::123456789012:policy/my-workload-boundary  ", wantNil: false, wantVal: "arn:aws:iam::123456789012:policy/my-workload-boundary"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := permissionsBoundaryPtr(tc.arn)
-			if tc.wantNil && got != nil {
-				t.Fatalf("permissionsBoundaryPtr(%q) = non-nil, want nil (would attach an unintended boundary)", tc.arn)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("permissionsBoundaryPtr(%q) = non-nil, want nil (would attach an unintended boundary)", tc.arn)
+				}
+				return
 			}
-			if !tc.wantNil && got == nil {
+			if got == nil {
 				t.Fatalf("permissionsBoundaryPtr(%q) = nil, want the boundary to be set", tc.arn)
+			}
+			// Assert the exact value, not just non-nil: a bug returning a wrong or
+			// untrimmed ARN would break the exact-match enforcement flip.
+			s, ok := got.(sdk.String)
+			if !ok {
+				t.Fatalf("permissionsBoundaryPtr(%q) is %T, want sdk.String", tc.arn, got)
+			}
+			if string(s) != tc.wantVal {
+				t.Fatalf("permissionsBoundaryPtr(%q) = %q, want %q", tc.arn, string(s), tc.wantVal)
 			}
 		})
 	}

--- a/pkg/clouds/pulumi/aws/permissions_boundary_test.go
+++ b/pkg/clouds/pulumi/aws/permissions_boundary_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Simple Container
+
+package aws
+
+import "testing"
+
+// permissionsBoundaryPtr's contract is the backward-compat guarantee: an empty
+// or whitespace-only ARN must yield nil (no boundary set on the role), so every
+// stack that does not opt in is unchanged. A real ARN must yield non-nil.
+func TestPermissionsBoundaryPtr(t *testing.T) {
+	tests := []struct {
+		name    string
+		arn     string
+		wantNil bool
+	}{
+		{name: "empty means no boundary", arn: "", wantNil: true},
+		{name: "whitespace means no boundary", arn: "   ", wantNil: true},
+		{name: "arn sets a boundary", arn: "arn:aws:iam::123456789012:policy/my-workload-boundary", wantNil: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := permissionsBoundaryPtr(tc.arn)
+			if tc.wantNil && got != nil {
+				t.Fatalf("permissionsBoundaryPtr(%q) = non-nil, want nil (would attach an unintended boundary)", tc.arn)
+			}
+			if !tc.wantNil && got == nil {
+				t.Fatalf("permissionsBoundaryPtr(%q) = nil, want the boundary to be set", tc.arn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What
Adds an optional `permissionsBoundary` field to the AWS `AccountConfig`. When set to an IAM policy ARN, SC applies it as the **PermissionsBoundary** on every IAM role it creates for workloads:
- ECS task/execution roles (`ecs_fargate`, `exec_ecs_task`)
- Lambda execution roles (`aws_lambda`)
- Alert Lambda execution roles (`alerts` / cloudtrail security alerts)
- ECS init-task execution roles (pg-init / mysql-init)

## Why
A permissions boundary caps what a deployed workload role can *ever* do, independent of the role's own policy — useful for operators who provision SC workloads under a least-privilege deploy identity and want a hard ceiling on the roles it can mint.

## Backward compatibility
Empty by default. `permissionsBoundaryPtr` returns `nil` for an empty/whitespace ARN, so no boundary is set and existing stacks are byte-for-byte unaffected. The field is `omitempty`, so it is **not** added to any schema's `required` list.

## Notes for reviewers
- `ConvertAuth` only carries credential fields when it rebuilds an `AccountConfig` from a resolved `${auth:...}` blob, which would drop this non-credential field. It is therefore explicitly preserved at each converter that rebuilds the config (lambda, cloudtrail alerts, pg-init/mysql-init). The `ecs-fargate` path reads the template's `AccountConfig` directly (embedded via `TemplateConfig`), so it needs no preserve.
- Setting/adding `permissionsBoundary` on `aws.iam.Role` is an **in-place** update (`PutRolePermissionsBoundary`), not a replacement — no role churn for existing deployments when a boundary is later added.
- Regenerated `docs/schemas` (only the AWS configs that embed `AccountConfig`).

## Tests
- `pkg/clouds/aws`: YAML round-trip of `permissionsBoundary` (+ empty-when-absent).
- `pkg/clouds/pulumi/aws`: `permissionsBoundaryPtr` returns nil for empty/whitespace, non-nil for an ARN (the backward-compat contract).

`go vet` + package tests pass (the `cmd/sc` binary link is unrelated).