### PR TITLE
test(signing): fix CheckInstalled signature drift in e2e skip guard

### DIFF
--- a/pkg/security/signing/e2e_test.go
+++ b/pkg/security/signing/e2e_test.go
@@ -33,12 +33,12 @@ func skipIfToolsNotInstalled(t *testing.T) {
 	installer := tools.NewToolInstaller()
 
 	// Check cosign
-	if installed, err := installer.CheckInstalled("cosign"); err != nil || !installed {
+	if err := installer.CheckInstalled(context.Background(), "cosign"); err != nil {
 		t.Skip("Skipping E2E test: cosign not installed. Install from https://docs.sigstore.dev/cosign/installation/")
 	}
 
 	// Check docker
-	if installed, err := installer.CheckInstalled("docker"); err != nil || !installed {
+	if err := installer.CheckInstalled(context.Background(), "docker"); err != nil {
 		t.Skip("Skipping E2E test: docker not installed")
 	}
 }


### PR DESCRIPTION
## Summary

`pkg/security/signing/e2e_test.go` no longer compiled under `-tags e2e`. Its
`skipIfToolsNotInstalled` helper called `ToolInstaller.CheckInstalled` with the
pre-drift signature:

```
pkg/security/signing/e2e_test.go:36:56: not enough arguments in call to installer.CheckInstalled
    have (string)
    want (context.Context, string)
```

The call now passes a context and checks only the returned error, matching what
`signing/integration_test.go:26` and `security/executor_integration_test.go:25`
already do.

Closes #336.

## Rationale

`CheckInstalled` (`pkg/security/tools/installer.go:36`) returns a bare `error`:
a failed `exec.LookPath` comes back as a non-nil error, so the `installed` bool
the test also inspected has no counterpart in the current API. Dropping it is not
a loosening of the guard: the "tool missing" case is exactly the error case.

Worth flagging separately: nothing in CI ever builds this file. `branch.yaml`,
`branch-preview.yaml` and `push.yaml` all run a bare `go test ./...`, and no
workflow passes `-tags e2e` or `-tags integration`. That is why the drift sat
undetected. A cheap compile-only guard (`go test -tags e2e -run='^$' ./...`)
would catch the next one without needing cosign, docker, or a registry. Left out
of this PR to keep it to one concern; happy to open a follow-up issue.

## Test plan

```
# before
$ go vet -tags e2e ./pkg/security/signing/
vet: pkg/security/signing/e2e_test.go:36:56: not enough arguments in call to installer.CheckInstalled

# after
$ go vet -tags e2e ./pkg/security/signing/
$ go test -tags e2e -run='^$' ./pkg/security/signing/
ok      github.com/simple-container-com/api/pkg/security/signing        0.005s [no tests to run]
$ gofmt -l pkg/security/signing/e2e_test.go   # clean
```

Not verified: that the e2e tests **pass** when actually run. That needs cosign
plus docker plus pushes to the public `ttl.sh` registry, which I do not have set
up. The acceptance criteria on #336 asks for a clean compile only.

## Projected impact

None on the default test path: `go test ./...` does not build this file before
or after. Under `-tags e2e` the package now compiles, so the e2e suite becomes
runnable again for anyone with the tools installed.

## Threat-model note

Required by CONTRIBUTING.md because the diff is under `pkg/security/`. No
production reachability: the file is test-only and behind the `e2e` build tag, so
it ships in no binary and is excluded from every CI invocation. No entry in
SECURITY.md's STRIDE table or vectors V1-V5 is addressed or affected, and no
verification step is weakened. The skip guard still refuses to run when cosign is
absent; it just reads that absence off the error instead of a bool the API no
longer returns.
