### PR TITLE
fix(gcp): bound the state bucket backups prefix, not just noncurrent versions

### DIFF
--- a/pkg/clouds/pulumi/gcp/provider.go
+++ b/pkg/clouds/pulumi/gcp/provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	gcpStorage "cloud.google.com/go/storage"
 	gcpOptions "google.golang.org/api/option"
@@ -83,22 +84,27 @@ func InitStateStore(ctx context.Context, stateStoreCfg api.StateStorageConfig, l
 		// does not exist
 		return bucketRef.Create(ctx, gcpStateCfg.ProjectId, &gcpStorage.BucketAttrs{
 			Location:  lo.FromPtr(gcpStateCfg.Location),
-			Lifecycle: NoncurrentVersionLifecycle(retentionDays),
+			Lifecycle: StateHistoryLifecycle(retentionDays),
 		})
 	}
 
-	if ShouldApplyNoncurrentVersionLifecycle(attrs, retentionDays) {
-		log.Info(ctx, "state bucket %q has object versioning enabled and no lifecycle rule; "+
-			"bounding retained state generations to %d days",
-			gcpStateCfg.GetBucketName(), retentionDays)
+	if ShouldApplyStateHistoryLifecycle(attrs, retentionDays) {
+		log.Info(ctx, "state bucket %q has object versioning enabled and no lifecycle policy of its own; "+
+			"bounding superseded state generations and %s to %d days",
+			gcpStateCfg.GetBucketName(), PulumiBackupsPrefix, retentionDays)
 		if _, err := bucketRef.Update(ctx, gcpStorage.BucketAttrsToUpdate{
-			Lifecycle: lo.ToPtr(NoncurrentVersionLifecycle(retentionDays)),
+			Lifecycle: lo.ToPtr(StateHistoryLifecycle(retentionDays)),
 		}); err != nil {
 			return errors.Wrapf(err, "failed to bound state history on bucket %q", gcpStateCfg.GetBucketName())
 		}
 	}
 	return nil
 }
+
+// PulumiBackupsPrefix is where the Pulumi gs backend writes a per-update copy of
+// each stack's state. Every rule that can delete a LIVE object must be scoped to
+// this prefix; a prefix-less age rule would delete the current state file.
+const PulumiBackupsPrefix = ".pulumi/backups/"
 
 // NoncurrentVersionLifecycle deletes state generations once they have been
 // superseded for retentionDays. It targets Archived objects only, so the live
@@ -120,8 +126,131 @@ func NoncurrentVersionLifecycle(retentionDays int) gcpStorage.Lifecycle {
 	}
 }
 
+// StateHistoryLifecycle bounds BOTH halves of a state bucket's history.
+//
+// The noncurrent rule alone does not do that, and the gap is not academic.
+// Pulumi writes each per-update backup under .pulumi/backups as its own LIVE
+// object, so it never becomes noncurrent and a DaysSinceNoncurrentTime rule
+// never reaches it. Measured on one real bucket 2026-08-20: 11,947 such objects
+// going back to the day the bucket was created, none of them ever eligible for
+// deletion.
+//
+// That matters beyond storage, which is trivial for state files. Each backup
+// carries the stack's data key wrapped under whichever KMS key version was
+// primary when it was written, so an unbounded backups prefix keeps nearly every
+// key version alive and billable. On the bucket above that was ~7,000 versions,
+// around $420/mo, none of it reclaimable while the prefix grows without limit.
+//
+// The second rule is therefore age-based and LIVE-matching, which is only safe
+// because it is scoped to the backups prefix. It is emitted only when that
+// prefix is non-empty, so a refactor that loses the scope produces no rule
+// rather than a rule that deletes live state.
+func StateHistoryLifecycle(retentionDays int) gcpStorage.Lifecycle {
+	lc := NoncurrentVersionLifecycle(retentionDays)
+	if retentionDays <= 0 || PulumiBackupsPrefix == "" {
+		return lc
+	}
+	lc.Rules = append(lc.Rules, gcpStorage.LifecycleRule{
+		Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+		Condition: gcpStorage.LifecycleCondition{
+			AgeInDays:     int64(retentionDays),
+			MatchesPrefix: []string{PulumiBackupsPrefix},
+		},
+	})
+	return lc
+}
+
+// isManagedStateHistoryRule reports whether a rule is one this package writes.
+//
+// Used to tell "a policy Simple Container put here" apart from "a policy the
+// operator wrote", so the former can be upgraded when this package learns a new
+// rule while the latter is still never touched. The match is on exact shape, not
+// on the day count, because the day count comes from the operator's config and
+// may legitimately have changed since it was written.
+func isManagedStateHistoryRule(rule gcpStorage.LifecycleRule) bool {
+	if rule.Action.Type != gcpStorage.DeleteAction {
+		return false
+	}
+	c := rule.Condition
+	noExtras := c.CreatedBefore.IsZero() && c.CustomTimeBefore.IsZero() &&
+		c.DaysSinceCustomTime == 0 && c.NumNewerVersions == 0 &&
+		len(c.MatchesStorageClasses) == 0 && len(c.MatchesSuffix) == 0
+	if !noExtras {
+		return false
+	}
+	// The noncurrent rule.
+	if c.Liveness == gcpStorage.Archived && c.DaysSinceNoncurrentTime > 0 &&
+		c.AgeInDays == 0 && len(c.MatchesPrefix) == 0 {
+		return true
+	}
+	// The backups rule.
+	if c.AgeInDays > 0 && c.DaysSinceNoncurrentTime == 0 &&
+		len(c.MatchesPrefix) == 1 && c.MatchesPrefix[0] == PulumiBackupsPrefix {
+		return true
+	}
+	return false
+}
+
+// hasBackupsPruningRule reports whether anything already bounds the backups
+// prefix, however it was written. An operator who bounds it their own way must
+// not be overridden.
+func hasBackupsPruningRule(attrs *gcpStorage.BucketAttrs) bool {
+	if attrs == nil {
+		return false
+	}
+	for _, rule := range attrs.Lifecycle.Rules {
+		for _, prefix := range rule.Condition.MatchesPrefix {
+			if strings.HasPrefix(PulumiBackupsPrefix, prefix) || strings.HasPrefix(prefix, PulumiBackupsPrefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ShouldApplyStateHistoryLifecycle decides whether to write the full two-rule
+// policy onto a bucket that already exists.
+//
+// It extends ShouldApplyNoncurrentVersionLifecycle with one case: a bucket whose
+// rules were all written by this package. Without that, the guard below excludes
+// every bucket Simple Container has already touched, so the backups rule would
+// only ever reach newly created buckets and the buckets that actually have the
+// problem would never be fixed.
+//
+// The property the original guard exists for is kept intact: a bucket carrying
+// any rule this package did not write is left completely alone, and so is a
+// bucket where the backups prefix is already bounded by some other means.
+func ShouldApplyStateHistoryLifecycle(attrs *gcpStorage.BucketAttrs, retentionDays int) bool {
+	if attrs == nil || retentionDays <= 0 {
+		return false
+	}
+	if !attrs.VersioningEnabled {
+		return false
+	}
+	if len(attrs.Lifecycle.Rules) == 0 {
+		return true
+	}
+	if hasBackupsPruningRule(attrs) {
+		return false
+	}
+	for _, rule := range attrs.Lifecycle.Rules {
+		if !isManagedStateHistoryRule(rule) {
+			return false
+		}
+	}
+	return true
+}
+
 // ShouldApplyNoncurrentVersionLifecycle decides whether to modify a state
-// bucket that already exists. Adding a rule to somebody's existing bucket is
+// bucket that already exists.
+//
+// Deprecated: use ShouldApplyStateHistoryLifecycle. This one is retained for
+// compatibility but is too narrow to be useful on its own: it excludes every
+// bucket that already carries a rule, including the buckets whose only rule was
+// written by this package, which are exactly the ones still needing the backups
+// prefix bounded.
+//
+// Adding a rule to somebody's existing bucket is
 // the kind of thing that should be narrow and predictable, so all three
 // conditions must hold:
 //

--- a/pkg/clouds/pulumi/gcp/state_bucket_backups_test.go
+++ b/pkg/clouds/pulumi/gcp/state_bucket_backups_test.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Simple Container
+
+package gcp
+
+import (
+	"testing"
+
+	gcpStorage "cloud.google.com/go/storage"
+	. "github.com/onsi/gomega"
+)
+
+func managedNoncurrentRule(days int64) gcpStorage.LifecycleRule {
+	return gcpStorage.LifecycleRule{
+		Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+		Condition: gcpStorage.LifecycleCondition{
+			Liveness:                gcpStorage.Archived,
+			DaysSinceNoncurrentTime: days,
+		},
+	}
+}
+
+func managedBackupsRule(days int64) gcpStorage.LifecycleRule {
+	return gcpStorage.LifecycleRule{
+		Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+		Condition: gcpStorage.LifecycleCondition{
+			AgeInDays:     days,
+			MatchesPrefix: []string{PulumiBackupsPrefix},
+		},
+	}
+}
+
+// The single most dangerous thing in this file. The backups rule matches LIVE
+// objects by age, so it is only safe while it is scoped to the backups prefix.
+// Unscoped, it deletes the current state file of every stack in the bucket.
+func TestBackupsRuleIsAlwaysScopedToThePrefix(t *testing.T) {
+	RegisterTestingT(t)
+
+	lc := StateHistoryLifecycle(30)
+	Expect(lc.Rules).To(HaveLen(2))
+
+	for i, rule := range lc.Rules {
+		if rule.Condition.AgeInDays == 0 {
+			continue
+		}
+		Expect(rule.Condition.MatchesPrefix).To(Equal([]string{PulumiBackupsPrefix}),
+			"rule %d matches live objects by age and MUST be scoped to the backups prefix; "+
+				"unscoped it deletes the live state file", i)
+	}
+}
+
+// Restating the invariant independently of rule ordering or count, so a future
+// rule cannot slip in unscoped.
+func TestNoAgeBasedRuleIsUnscoped(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, days := range []int{1, 7, 30, 365} {
+		for _, rule := range StateHistoryLifecycle(days).Rules {
+			if rule.Condition.AgeInDays > 0 {
+				Expect(rule.Condition.MatchesPrefix).ToNot(BeEmpty(),
+					"an AgeInDays rule with no prefix expires live state")
+			}
+		}
+	}
+}
+
+func TestStateHistoryLifecycleKeepsTheNoncurrentRule(t *testing.T) {
+	RegisterTestingT(t)
+
+	lc := StateHistoryLifecycle(30)
+	Expect(lc.Rules).To(ContainElement(managedNoncurrentRule(30)),
+		"the backups rule is additional to the noncurrent rule, not a replacement")
+	Expect(lc.Rules).To(ContainElement(managedBackupsRule(30)))
+}
+
+func TestStateHistoryLifecycleDisabled(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(StateHistoryLifecycle(0).Rules).To(BeEmpty(), "zero is a deliberate opt-out")
+	Expect(StateHistoryLifecycle(-1).Rules).To(BeEmpty())
+}
+
+func TestShouldApplyStateHistoryLifecycle(t *testing.T) {
+	RegisterTestingT(t)
+
+	versioned := func(rules ...gcpStorage.LifecycleRule) *gcpStorage.BucketAttrs {
+		return &gcpStorage.BucketAttrs{
+			VersioningEnabled: true,
+			Lifecycle:         gcpStorage.Lifecycle{Rules: rules},
+		}
+	}
+	operatorRule := gcpStorage.LifecycleRule{
+		Action:    gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+		Condition: gcpStorage.LifecycleCondition{AgeInDays: 365},
+	}
+	operatorBackupsRule := gcpStorage.LifecycleRule{
+		Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+		Condition: gcpStorage.LifecycleCondition{
+			AgeInDays:     90,
+			MatchesPrefix: []string{".pulumi/backups/"},
+		},
+	}
+	broaderOperatorPrefix := gcpStorage.LifecycleRule{
+		Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+		Condition: gcpStorage.LifecycleCondition{
+			AgeInDays:     90,
+			MatchesPrefix: []string{".pulumi/"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name  string
+		attrs *gcpStorage.BucketAttrs
+		days  int
+		want  bool
+		why   string
+	}{
+		{
+			name:  "empty policy is the original case",
+			attrs: versioned(),
+			days:  30,
+			want:  true,
+		},
+		{
+			name:  "a policy this package wrote is upgradable",
+			attrs: versioned(managedNoncurrentRule(30)),
+			days:  30,
+			want:  true,
+			why: "without this the guard excludes every bucket SC already touched, " +
+				"so the buckets that have the problem could never be fixed",
+		},
+		{
+			name:  "recognised even when the day count has since changed in config",
+			attrs: versioned(managedNoncurrentRule(7)),
+			days:  30,
+			want:  true,
+			why:   "the count comes from operator config and may legitimately differ",
+		},
+		{
+			name:  "already fully managed, so nothing to add",
+			attrs: versioned(managedNoncurrentRule(30), managedBackupsRule(30)),
+			days:  30,
+			want:  false,
+			why:   "the backups prefix is already bounded; rewriting it is a pointless write",
+		},
+		{
+			name:  "an operator's own rule is still never touched",
+			attrs: versioned(operatorRule),
+			days:  30,
+			want:  false,
+			why:   "this is the property the original guard exists for",
+		},
+		{
+			name:  "a managed rule alongside an operator rule is left alone",
+			attrs: versioned(managedNoncurrentRule(30), operatorRule),
+			days:  30,
+			want:  false,
+			why:   "any unrecognised rule means the policy is not ours to rewrite",
+		},
+		{
+			name:  "an operator bounding backups their own way wins",
+			attrs: versioned(operatorBackupsRule),
+			days:  30,
+			want:  false,
+			why:   "their retention choice for the prefix must not be overridden",
+		},
+		{
+			name:  "an operator rule covering a parent of the prefix also wins",
+			attrs: versioned(broaderOperatorPrefix),
+			days:  30,
+			want:  false,
+			why:   ".pulumi/ already covers .pulumi/backups/",
+		},
+		{
+			name:  "versioning off means the noncurrent half would be inert",
+			attrs: &gcpStorage.BucketAttrs{VersioningEnabled: false},
+			days:  30,
+			want:  false,
+		},
+		{
+			name:  "retention explicitly disabled",
+			attrs: versioned(),
+			days:  0,
+			want:  false,
+		},
+		{
+			name:  "nil attrs never provokes a write",
+			attrs: nil,
+			days:  30,
+			want:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			Expect(ShouldApplyStateHistoryLifecycle(tc.attrs, tc.days)).To(Equal(tc.want), tc.why)
+		})
+	}
+}
+
+// The shape match is what separates "ours" from "theirs". If it were loose
+// enough to accept an operator's rule, the guard above would start rewriting
+// policies it must never touch.
+func TestIsManagedStateHistoryRuleRejectsLookalikes(t *testing.T) {
+	RegisterTestingT(t)
+
+	for _, tc := range []struct {
+		name string
+		rule gcpStorage.LifecycleRule
+		want bool
+	}{
+		{"our noncurrent rule", managedNoncurrentRule(30), true},
+		{"our backups rule", managedBackupsRule(30), true},
+		{
+			name: "not a delete action",
+			rule: gcpStorage.LifecycleRule{
+				Action:    gcpStorage.LifecycleAction{Type: gcpStorage.SetStorageClassAction, StorageClass: "NEARLINE"},
+				Condition: gcpStorage.LifecycleCondition{Liveness: gcpStorage.Archived, DaysSinceNoncurrentTime: 30},
+			},
+		},
+		{
+			name: "age rule with a different prefix",
+			rule: gcpStorage.LifecycleRule{
+				Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+				Condition: gcpStorage.LifecycleCondition{
+					AgeInDays:     30,
+					MatchesPrefix: []string{"other/"},
+				},
+			},
+		},
+		{
+			name: "unscoped age rule is emphatically not ours",
+			rule: gcpStorage.LifecycleRule{
+				Action:    gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+				Condition: gcpStorage.LifecycleCondition{AgeInDays: 30},
+			},
+		},
+		{
+			name: "carries an extra condition we never set",
+			rule: gcpStorage.LifecycleRule{
+				Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+				Condition: gcpStorage.LifecycleCondition{
+					Liveness:                gcpStorage.Archived,
+					DaysSinceNoncurrentTime: 30,
+					NumNewerVersions:        3,
+				},
+			},
+		},
+		{
+			name: "matches a storage class we never filter on",
+			rule: gcpStorage.LifecycleRule{
+				Action: gcpStorage.LifecycleAction{Type: gcpStorage.DeleteAction},
+				Condition: gcpStorage.LifecycleCondition{
+					Liveness:                gcpStorage.Archived,
+					DaysSinceNoncurrentTime: 30,
+					MatchesStorageClasses:   []string{"STANDARD"},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			Expect(isManagedStateHistoryRule(tc.rule)).To(Equal(tc.want))
+		})
+	}
+}
+
+// A freshly created bucket must get both rules, not just the noncurrent one.
+// Getting this wrong is how the original fix ended up only half-applied.
+func TestNewBucketGetsBothRules(t *testing.T) {
+	RegisterTestingT(t)
+
+	lc := StateHistoryLifecycle(30)
+	var archived, backups int
+	for _, r := range lc.Rules {
+		if r.Condition.Liveness == gcpStorage.Archived && r.Condition.DaysSinceNoncurrentTime > 0 {
+			archived++
+		}
+		if r.Condition.AgeInDays > 0 && len(r.Condition.MatchesPrefix) == 1 {
+			backups++
+		}
+	}
+	Expect(archived).To(Equal(1), "superseded generations must be bounded")
+	Expect(backups).To(Equal(1), "the backups prefix must be bounded too, or KMS versions stay pinned")
+}


### PR DESCRIPTION
## Why

The noncurrent-generation lifecycle rule bounds half of a state bucket's history. The half it leaves unbounded is the expensive one.

Pulumi writes each per-update backup under `.pulumi/backups` as its own **live** object. It never becomes noncurrent, so a `DaysSinceNoncurrentTime` rule never reaches it. Measured on a real state bucket: **11,947** such objects reaching back to the day the bucket was created, none ever eligible for deletion.

Storage is not the issue — state files are small, that prefix was 7.5 GB. The issue is that each of those objects carries the stack's data key **wrapped under whichever KMS key version was primary when it was written**. An unbounded backups prefix therefore keeps nearly every key version alive and billable. On that bucket it pinned roughly **7,000 versions, about $420/mo**, none of it reclaimable while the prefix grows without limit.

That re-wrap was confirmed rather than assumed: sampling one stack's backups across five dates and hashing `secrets_providers.state.encryptedkey` gave five distinct ciphertexts.

## The rule

`StateHistoryLifecycle` now emits two rules — the existing archived-only rule, plus an age-based rule scoped to the backups prefix.

The second one matches **live** objects, which is only safe while it is scoped. Unscoped it would delete the current state file of every stack in the bucket. So it is emitted only when the prefix constant is non-empty: a refactor that loses the scope produces no rule rather than a catastrophic one. Two tests assert that invariant — one per-rule, one across all rules independent of ordering or count, so a future third rule cannot slip in unscoped.

## Why the guard had to change too

`ShouldApplyNoncurrentVersionLifecycle` applies a policy only to buckets with **no** lifecycle rules at all. That is deliberate and correct as a way of never editing an operator's policy — but it means this fix could never reach the buckets that have the problem, because any bucket this package has already touched now carries exactly one rule: the one it wrote.

`ShouldApplyStateHistoryLifecycle` adds a single case: a bucket whose rules were **all** written by this package is upgradable. Recognition is by exact rule shape, not by day count, since the count comes from operator config and may legitimately have changed since it was written.

The original property is intact, and tested:

- a bucket carrying any rule this package did not write is left completely alone;
- so is a bucket where the backups prefix is already bounded by other means, including by a broader prefix such as `.pulumi/`;
- versioning off, retention `0`, negative retention and `nil` attrs all still refuse to write.

`ShouldApplyNoncurrentVersionLifecycle` is kept for compatibility and marked deprecated with the reason it is too narrow to use alone.

## Verification

- Full package suite green, including the pre-existing lifecycle tests unchanged.
- Every new guard mutation-checked — removed one at a time, confirmed a test fails:
  - dropping the prefix scoping → fails
  - guard accepting any existing policy → fails on "an operator's own rule is never touched"
  - ignoring an operator's own backups rule → fails
  - backups rule never emitted (the original half-fix) → fails
- `go build ./...`, `go vet`, `gofmt` all clean.

## Compatibility and blast radius

Additive. No exported symbol removed or changed in signature. New buckets get both rules at create time; existing buckets get the second rule only if this package wrote everything already there.

The one behaviour change worth calling out explicitly: a bucket whose only rule was written by an older version of this package will now be **updated** rather than skipped. That is the entire point of the change, but it does mean the write is no longer restricted to empty policies, so it is worth a reviewer's attention.

Anyone who wants the old behaviour can bound the prefix themselves or set retention to `0`, both of which this now respects.
