### PR TITLE
fix(security): confirm a Rekor 409 by verifying it, sign before the rollout, publish release artifacts only after the attestation gate

### DIFF
--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -168,9 +168,10 @@ jobs:
           go build -ldflags "-s -w -X=github.com/simple-container-com/api/internal/build.Version=${VERSION}" -o dist/${GOOS}-${GOARCH}/sc${EXT} ./cmd/sc
           tar -czf .sc/stacks/dist/bundle/sc-${GOOS}-${GOARCH}.tar.gz -C dist/${GOOS}-${GOARCH} sc${EXT}
           cp .sc/stacks/dist/bundle/sc-${GOOS}-${GOARCH}.tar.gz .sc/stacks/dist/bundle/sc-${GOOS}-${GOARCH}-v${VERSION}.tar.gz
-      # Phase 2 attestation (mirrors push.yaml). Soft-fail per step — the
-      # tarball itself is the publish artifact. Preview builds only publish
-      # versioned tarballs (no unversioned twin), so sidecars are per-version.
+      # Attestation for preview tarballs. Soft-fail per step, and unlike
+      # push.yaml there is no gate afterwards: a preview publishes whatever it
+      # managed to attest. Preview builds only publish versioned tarballs (no
+      # unversioned twin), so sidecars are per-version.
       - name: SHA-256 sidecar for ${{ matrix.os }}/${{ matrix.arch }}
         env:
           GOOS: ${{ matrix.os }}
@@ -375,10 +376,13 @@ jobs:
           # cache. Measured cost of re-running `runtime` alone: ~34 s.
           no-cache-filters: runtime
           provenance: false
-      # Phase 2 attestation (mirrors push.yaml). Preview builds get the SAME
-      # security guarantees as production releases so consumers pin-testing a
+      # Attestation for preview images. Preview builds run the same sign + SBOM
+      # + SLSA steps as production releases, so consumers pin-testing a
       # preview version (per project_sc_preview memory: PAY-SPACE pins workflows
       # to versioned preview builds) can verify the same way they verify prod.
+      # Same steps, weaker promise: a preview does NOT get the release gate, and
+      # its tags go live before anything is signed. The warn-only aggregator
+      # below is the accurate statement of what a preview guarantees.
       - name: Sign + attest ${{ matrix.target }} (SBOM + cosign + SLSA)
         id: signattest
         if: steps.build_and_push.outcome == 'success'
@@ -388,7 +392,8 @@ jobs:
           image-name: ${{ matrix.target }}
           subject-name: index.docker.io/${{ matrix.image_repo }}
           subject-digest: ${{ steps.build_and_push.outputs.digest }}
-          # Phase 2 bake-in soft-fail. Mirrors push.yaml.
+          # Soft-fail. push.yaml sets this too, but follows it with a gate
+          # that fails the release; a preview has no such gate.
           soft-fail: 'true'
       - name: Record image digest for verify-attestations
         if: steps.build_and_push.outcome == 'success'

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -406,6 +406,10 @@ jobs:
           name: image-digest-${{ matrix.target }}
           path: digests/${{ matrix.target }}.txt
           retention-days: 1
+      # Warn-only on purpose. Previews and staging builds are not releases:
+      # nothing in SECURITY.md promises a consumer they carry a complete
+      # attestation chain, and blocking them would stall iteration on a
+      # Sigstore hiccup. push.yaml gates releases instead.
       - name: Soft-fail aggregator for ${{ matrix.target }} attestation
         if: always() && steps.build_and_push.outcome == 'success'
         env:

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -160,7 +160,8 @@ jobs:
       - name: Install attestation tools
         id: install_attest_tools
         if: steps.build_gha_staging.outcome == 'success' || steps.build_caddy_staging.outcome == 'success'
-        continue-on-error: true   # Best-effort during Phase 2 bake-in (matches push.yaml).
+        continue-on-error: true   # Best-effort: staging is not a release, so a
+                                  # missing tool must not fail the build.
         uses: simple-container-com/actions/install-attest-tools@0af5a697f24ea484991660619d0ae42d50343b9d # main
 
       - name: Sign + attest github-actions staging (SBOM + cosign + SLSA)
@@ -174,7 +175,9 @@ jobs:
           subject-digest: ${{ steps.build_gha_staging.outputs.digest }}
           # cosign + syft already installed by the step above; skip re-install.
           install-tools: 'false'
-          # Phase 2 bake-in soft-fail. Mirrors push.yaml.
+          # Soft-fail with no gate behind it. push.yaml sets soft-fail too,
+          # but gates on the outcomes and fails the release; staging does not,
+          # because SECURITY.md promises a complete chain for releases only.
           soft-fail: 'true'
 
       - name: Sign + attest caddy staging (SBOM + cosign + SLSA)

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -189,6 +189,10 @@ jobs:
           install-tools: 'false'
           soft-fail: 'true'
 
+      # Warn-only on purpose. Previews and staging builds are not releases:
+      # nothing in SECURITY.md promises a consumer they carry a complete
+      # attestation chain, and blocking them would stall iteration on a
+      # Sigstore hiccup. push.yaml gates releases instead.
       - name: Soft-fail aggregator for staging attestation
         if: always()
         env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -263,9 +263,10 @@ jobs:
       # and no provenance is indistinguishable from a good one at the consumer
       # end. Branch previews and staging builds keep the warn-only aggregator.
       #
-      # Break glass: set the repository variable ATTESTATION_SOFT_FAIL to
-      # 'true' to degrade this back to a warning for the duration of a Sigstore
-      # or Rekor outage. Unset it once the release ships.
+      # Break glass: set the variable ATTESTATION_SOFT_FAIL to an ISO-8601 UTC
+      # expiry date (YYYY-MM-DD) to degrade this to a warning for the duration
+      # of a Sigstore or Rekor outage. It stops applying on that date whether
+      # or not anyone remembers to unset it, and every run prints its value.
       - name: Attestation gate for sc-${{ matrix.os }}-${{ matrix.arch }}
         if: always()
         env:
@@ -275,6 +276,11 @@ jobs:
           SOFT_FAIL: ${{ vars.ATTESTATION_SOFT_FAIL }}
           PLATFORM: ${{ matrix.os }}-${{ matrix.arch }}
         run: |
+          # See the image gate for why this is printed unconditionally and why
+          # the value must be a date: `vars.*` also resolves ORGANIZATION
+          # variables, so this can be switched off from outside the repository.
+          echo "ATTESTATION_SOFT_FAIL=${SOFT_FAIL:-<unset>}"
+          today="$(date -u +%F)"
           fail=0
           for v in "$SBOM_OUTCOME" "$SIGN_OUTCOME" "$SLSA_OUTCOME"; do
             if [ "$v" != "success" ]; then fail=1; fi
@@ -284,11 +290,24 @@ jobs:
             exit 0
           fi
           detail="sc-${PLATFORM} (sbom=$SBOM_OUTCOME sign=$SIGN_OUTCOME slsa=$SLSA_OUTCOME)"
-          if [ "${SOFT_FAIL:-}" = "true" ]; then
-            echo "::warning title=Attestation incomplete::${detail}. Blocking is disabled by the repository variable ATTESTATION_SOFT_FAIL."
+          if [ -n "${SOFT_FAIL:-}" ]; then
+            case "$SOFT_FAIL" in
+              [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+              *)
+                echo "::error title=Break-glass malformed::ATTESTATION_SOFT_FAIL must be an ISO-8601 UTC expiry date (YYYY-MM-DD); got '${SOFT_FAIL}'. Not bypassing the gate."
+                SOFT_FAIL=""
+                ;;
+            esac
+          fi
+          if [ -n "${SOFT_FAIL:-}" ] && [[ "$today" < "$SOFT_FAIL" ]]; then
+            echo "::warning title=Attestation incomplete::${detail}. Break-glass active until ${SOFT_FAIL}."
+            echo "attestation-breakglass=${SOFT_FAIL}" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          echo "::error title=Attestation incomplete::${detail}. A release must not publish a tarball without an SBOM, a signature and provenance. Re-run the job; if the transparency log is down, set the repository variable ATTESTATION_SOFT_FAIL=true to ship without them."
+          if [ -n "${SOFT_FAIL:-}" ]; then
+            echo "::warning title=Break-glass expired::ATTESTATION_SOFT_FAIL=${SOFT_FAIL} is not after ${today}; the gate is blocking. Remove the variable."
+          fi
+          echo "::error title=Attestation incomplete::${detail}. A release must not publish a tarball without an SBOM, a signature and provenance. Re-run the job; if the transparency log is down, set ATTESTATION_SOFT_FAIL to an ISO-8601 UTC expiry date to ship without them."
           exit 1
       - name: upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -486,7 +505,16 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
-          tags: ${{ matrix.tags }}
+          # Build to a throwaway CI tag, never straight to the release tags.
+          # cosign signs by digest, so the image has to exist in the registry
+          # before `Sign + attest` can run; but pushing `:latest` and
+          # `:<version>` here put them in front of consumers before the
+          # attestation gate below could block them. A failing gate then left a
+          # mutable `:latest` pointing at an unsigned, un-SBOM'd image while
+          # dist.simple-container.com still served the previous version. The
+          # release tags are applied by `Promote release tags` after the gate
+          # passes, which is the order the tarball path has always used.
+          tags: ${{ matrix.image_repo }}:ci-${{ github.run_id }}-${{ github.run_attempt }}
           push: true
           # Cache scopes are prefixed by TRUST TIER, not just by image.
           # A lower-trust build must never write a scope a release build
@@ -551,7 +579,8 @@ jobs:
           name: image-digest-${{ matrix.image }}
           path: digests/${{ matrix.image }}.txt
           retention-days: 1
-      # Release gate for images. Same policy as the tarball gate above.
+      # Release gate for images. Same policy as the tarball gate above, and it
+      # runs BEFORE the release tags exist: see `Promote release tags` below.
       - name: Attestation gate for ${{ matrix.image }}
         if: always() && steps.build_and_push.outcome == 'success'
         env:
@@ -562,6 +591,12 @@ jobs:
           SOFT_FAIL: ${{ vars.ATTESTATION_SOFT_FAIL }}
           IMAGE: ${{ matrix.image }}
         run: |
+          # Printed on every run, pass or fail. `vars.*` resolves ORGANIZATION
+          # variables as well as repository ones, so a variable of this name
+          # set at the org level silently applies to this repo, and to every
+          # other repo that reads it. This line is what makes that visible.
+          echo "ATTESTATION_SOFT_FAIL=${SOFT_FAIL:-<unset>}"
+          today="$(date -u +%F)"
           fail=0
           for v in "$SIGN_OUTCOME" "$SBOM_OUTCOME" "$ATTEST_SBOM_OUTCOME" "$SLSA_OUTCOME"; do
             if [ "$v" != "success" ]; then fail=1; fi
@@ -571,12 +606,110 @@ jobs:
             exit 0
           fi
           detail="${IMAGE} (sign=$SIGN_OUTCOME sbom=$SBOM_OUTCOME attest-sbom=$ATTEST_SBOM_OUTCOME slsa=$SLSA_OUTCOME)"
-          if [ "${SOFT_FAIL:-}" = "true" ]; then
-            echo "::warning title=Attestation incomplete::${detail}. Blocking is disabled by the repository variable ATTESTATION_SOFT_FAIL."
+          # Break glass carries its own expiry so a forgotten value stops
+          # bypassing on its own. Anything that is not an ISO-8601 UTC date is
+          # rejected rather than trusted, including the historical 'true'.
+          if [ -n "${SOFT_FAIL:-}" ]; then
+            case "$SOFT_FAIL" in
+              [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+              *)
+                echo "::error title=Break-glass malformed::ATTESTATION_SOFT_FAIL must be an ISO-8601 UTC expiry date (YYYY-MM-DD); got '${SOFT_FAIL}'. Not bypassing the gate."
+                SOFT_FAIL=""
+                ;;
+            esac
+          fi
+          if [ -n "${SOFT_FAIL:-}" ] && [[ "$today" < "$SOFT_FAIL" ]]; then
+            echo "::warning title=Attestation incomplete::${detail}. Break-glass active until ${SOFT_FAIL}."
+            echo "attestation-breakglass=${SOFT_FAIL}" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          echo "::error title=Attestation incomplete::${detail}. A release must not publish an image without a signature, an SBOM attestation and provenance. See the verify-attestations workflow for the post-publish check."
+          if [ -n "${SOFT_FAIL:-}" ]; then
+            echo "::warning title=Break-glass expired::ATTESTATION_SOFT_FAIL=${SOFT_FAIL} is not after ${today}; the gate is blocking. Remove the variable."
+          fi
+          echo "::error title=Attestation incomplete::${detail}. A release must not publish an image without a signature, an SBOM attestation and provenance. No release tag was applied, so nothing shipped. See the verify-attestations workflow for the post-publish check."
           exit 1
+      # The only step that makes this image reachable under a consumer-facing
+      # tag. No `if:`, so the default success() applies and a failed gate skips
+      # it.
+      #
+      # Promotion re-PUTs the signed manifest byte for byte under each release
+      # tag, which is what `crane tag` does and what keeps the tag resolving to
+      # the digest cosign signed. `docker buildx imagetools create` is NOT
+      # usable here: given a single platform-specific manifest it wraps it in a
+      # NEW index, so the tag resolves to an index digest that was never signed
+      # and `cosign verify <repo>:latest` fails. Measured against a local
+      # registry: source sha256:dd54c6… came back as sha256:45b9e3… .
+      #
+      # The Docker-Content-Digest check below makes the step self-verifying: if
+      # promotion ever stops preserving the digest, the release fails instead of
+      # shipping a tag no consumer can verify.
+      - name: Promote release tags for ${{ matrix.image }}
+        env:
+          TAGS: ${{ matrix.tags }}
+          IMAGE_REPO: ${{ matrix.image_repo }}
+          DIGEST: ${{ steps.build_and_push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          token="$(sc stack secret-get -s dist dockerhub-cicd-token)"
+          echo "::add-mask::${token}"
+          bearer="$(curl -sS -u "simplecontainer:${token}" \
+            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${IMAGE_REPO}:pull,push" \
+            | jq -r '.token // empty')"
+          if [ -z "$bearer" ]; then
+            echo "::error title=Promotion failed::could not obtain a registry token for ${IMAGE_REPO}"
+            exit 1
+          fi
+          echo "::add-mask::${bearer}"
+          accept='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json'
+          manifest="$(mktemp)"
+          ctype="$(curl -sS -D - -o "$manifest" \
+            -H "Authorization: Bearer ${bearer}" -H "Accept: ${accept}" \
+            "https://registry-1.docker.io/v2/${IMAGE_REPO}/manifests/${DIGEST}" \
+            | tr -d '\r' | awk 'tolower($1)=="content-type:"{print $2}')"
+          if [ -z "$ctype" ]; then
+            echo "::error title=Promotion failed::could not read the manifest for ${IMAGE_REPO}@${DIGEST}"
+            exit 1
+          fi
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Promoting ${IMAGE_REPO}@${DIGEST} to ${tag}"
+            pushed="$(curl -sS -X PUT -D - -o /dev/null \
+              -H "Authorization: Bearer ${bearer}" -H "Content-Type: ${ctype}" \
+              --data-binary "@${manifest}" \
+              "https://registry-1.docker.io/v2/${IMAGE_REPO}/manifests/${tag##*:}" \
+              | tr -d '\r' | awk 'tolower($1)=="docker-content-digest:"{print $2}')"
+            if [ "$pushed" != "$DIGEST" ]; then
+              echo "::error title=Promotion changed the digest::${tag} resolved to ${pushed:-<none>}, not the signed ${DIGEST}. Consumers verifying by tag would fail."
+              exit 1
+            fi
+          done <<< "$TAGS"
+      # Best effort: drop the throwaway build tag once the release tags carry
+      # the digest. Runs even when the gate blocked, because that is exactly
+      # the case where an unsigned image would otherwise stay reachable under a
+      # predictable name. Never fails the job: the tag is undocumented and
+      # untouched by any consumer either way.
+      - name: Remove throwaway CI tag for ${{ matrix.image }}
+        if: always() && steps.build_and_push.outcome == 'success'
+        continue-on-error: true
+        env:
+          IMAGE_REPO: ${{ matrix.image_repo }}
+          CI_TAG: ci-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          token="$(sc stack secret-get -s dist dockerhub-cicd-token)"
+          echo "::add-mask::${token}"
+          jwt="$(curl -sS -X POST https://hub.docker.com/v2/users/login/ \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"simplecontainer\",\"password\":\"${token}\"}" \
+            | jq -r '.token // empty')"
+          if [ -z "$jwt" ]; then
+            echo "Could not obtain a Docker Hub session; leaving ${IMAGE_REPO}:${CI_TAG} in place."
+            exit 0
+          fi
+          echo "::add-mask::${jwt}"
+          curl -sS -o /dev/null -w 'delete %{http_code}\n' -X DELETE \
+            -H "Authorization: JWT ${jwt}" \
+            "https://hub.docker.com/v2/repositories/${IMAGE_REPO}/tags/${CI_TAG}/"
 
   docker-finalize:
     name: Docker finalize (tag-release, deploy)
@@ -648,46 +781,55 @@ jobs:
           done
       # Second line of defence: build-platforms gates per matrix leg, this one
       # gates the bundle that actually reaches the CDN. Honours the same
-      # ATTESTATION_SOFT_FAIL break-glass variable.
-      - name: Sidecar count assertion
+      # ATTESTATION_SOFT_FAIL break-glass variable, expiry date and all.
+      - name: Sidecar assertion
         env:
           SOFT_FAIL: ${{ vars.ATTESTATION_SOFT_FAIL }}
         run: |
           set -euo pipefail
           cd .sc/stacks/dist/bundle
           shopt -s nullglob
-          arr_tarballs=( sc-*.tar.gz ); tarballs=${#arr_tarballs[@]}
-          arr_shas=( sc-*.tar.gz.sha256 ); shas=${#arr_shas[@]}
-          arr_bundles=( sc-*.tar.gz.cosign-bundle ); bundles=${#arr_bundles[@]}
-          arr_provs=( sc-*.tar.gz.sigstore.json ); provs=${#arr_provs[@]}
-          arr_sboms=( sc-*.tar.gz.sbom.cdx.json ); sboms=${#arr_sboms[@]}
-          echo "tarballs=$tarballs sha256=$shas cosign-bundle=$bundles slsa=$provs sbom=$sboms"
-          if [ "$tarballs" -eq 0 ]; then
+          echo "ATTESTATION_SOFT_FAIL=${SOFT_FAIL:-<unset>}"
+          today="$(date -u +%F)"
+          tarballs=( sc-*.tar.gz )
+          echo "tarballs=${#tarballs[@]}"
+          if [ "${#tarballs[@]}" -eq 0 ]; then
             echo "::error title=No tarballs to publish::dist bundle has zero tarballs"
             exit 1
           fi
+          # Paired per tarball, not counted in aggregate. Comparing totals let a
+          # bundle pass in which one tarball carried two sidecars of a kind and
+          # another carried none, which is the exact shape a half-failed matrix
+          # leg produces. An empty sidecar counts as missing.
           missing=0
-          # Every tarball has matching .sha256 / .cosign-bundle / .sigstore.json
-          # / .sbom.cdx.json sidecars; build-platforms duplicates the per-build
-          # outputs across the versioned and unversioned tarball names.
-          for kind_count in "sha256=$shas" \
-                            "cosign-bundle=$bundles" \
-                            "slsa=$provs" \
-                            "sbom=$sboms"; do
-            label="${kind_count%%=*}"
-            count="${kind_count#*=}"
-            if [ "$count" -lt "$tarballs" ]; then
-              echo "::warning title=Sidecar count mismatch::${label} has $count of $tarballs expected sidecars"
-              missing=1
-            fi
+          for tarball in "${tarballs[@]}"; do
+            for suffix in sha256 cosign-bundle sigstore.json sbom.cdx.json; do
+              if [ ! -s "${tarball}.${suffix}" ]; then
+                echo "::warning title=Sidecar missing::${tarball} has no .${suffix}"
+                missing=1
+              fi
+            done
           done
           if [ "$missing" -eq 0 ]; then
             echo "All sidecars present for every published tarball."
             exit 0
           fi
-          if [ "${SOFT_FAIL:-}" = "true" ]; then
-            echo "::warning title=Sidecars incomplete::Publishing anyway; blocking is disabled by the repository variable ATTESTATION_SOFT_FAIL."
+          if [ -n "${SOFT_FAIL:-}" ]; then
+            case "$SOFT_FAIL" in
+              [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+              *)
+                echo "::error title=Break-glass malformed::ATTESTATION_SOFT_FAIL must be an ISO-8601 UTC expiry date (YYYY-MM-DD); got '${SOFT_FAIL}'. Not bypassing the gate."
+                SOFT_FAIL=""
+                ;;
+            esac
+          fi
+          if [ -n "${SOFT_FAIL:-}" ] && [[ "$today" < "$SOFT_FAIL" ]]; then
+            echo "::warning title=Sidecars incomplete::Publishing anyway. Break-glass active until ${SOFT_FAIL}."
+            echo "attestation-breakglass=${SOFT_FAIL}" >> "$GITHUB_STEP_SUMMARY"
             exit 0
+          fi
+          if [ -n "${SOFT_FAIL:-}" ]; then
+            echo "::warning title=Break-glass expired::ATTESTATION_SOFT_FAIL=${SOFT_FAIL} is not after ${today}; the gate is blocking. Remove the variable."
           fi
           echo "::error title=Sidecars incomplete::Refusing to publish a release bundle with missing sidecars. Every tarball on dist must ship with .sha256, .cosign-bundle, .sigstore.json and .sbom.cdx.json."
           exit 1

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -173,10 +173,14 @@ jobs:
           # (no embedded timestamp) so a rebuild reproduces it bit-for-bit.
           tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner --mode='u=rwx,go=rx' -cf - -C dist/${GOOS}-${GOARCH} sc${EXT} | gzip -9 -n > .sc/stacks/dist/bundle/sc-${GOOS}-${GOARCH}.tar.gz
           cp .sc/stacks/dist/bundle/sc-${GOOS}-${GOARCH}.tar.gz .sc/stacks/dist/bundle/sc-${GOOS}-${GOARCH}-v${VERSION}.tar.gz
-      # Phase 2: per-tarball SHA-256, CycloneDX SBOM, cosign keyless signature
-      # (self-contained bundle), SLSA provenance. Soft-fail per step — the tarball
-      # itself is the publish artifact; sidecars are best-effort during the 14-day
-      # bake-in. See HARDENING.md Phase 2 plan + verify-attestations.yml gate.
+      # Per-tarball SHA-256, CycloneDX SBOM, cosign keyless signature
+      # (self-contained bundle), SLSA provenance.
+      #
+      # continue-on-error stays on every step so one failure does not abort the
+      # rest: the run still produces a complete picture of which sidecars are
+      # missing. The trailing gate then decides whether that is publishable.
+      # On this workflow it is not — see the gate step for the release policy
+      # and the break-glass variable.
       - name: SHA-256 sidecars for ${{ matrix.os }}/${{ matrix.arch }}
         id: sha256
         env:
@@ -190,10 +194,10 @@ jobs:
           sha256sum "sc-${GOOS}-${GOARCH}-v${VERSION}.tar.gz" > "sc-${GOOS}-${GOARCH}-v${VERSION}.tar.gz.sha256"
       - name: Install attestation tools
         id: install_attest_tools
-        continue-on-error: true   # Best-effort during Phase 2 bake-in. If the
-                                  # installer flakes, downstream sign/SBOM/SLSA
-                                  # steps soft-skip via their own outcome
-                                  # guards; the tarball + .sha256 still publish.
+        continue-on-error: true   # If the installer flakes, downstream
+                                  # sign/SBOM/SLSA steps soft-skip via their own
+                                  # outcome guards and the gate below reports
+                                  # every one of them at once.
         uses: simple-container-com/actions/install-attest-tools@0af5a697f24ea484991660619d0ae42d50343b9d # main
       - name: Generate CycloneDX SBOM for sc-${{ matrix.os }}-${{ matrix.arch }}
         id: sbom_tarball
@@ -253,22 +257,39 @@ jobs:
           for tarball in "sc-${GOOS}-${GOARCH}-v${VERSION}.tar.gz" "sc-${GOOS}-${GOARCH}.tar.gz"; do
             cp "$BUNDLE_PATH" "${dest_dir}/${tarball}.sigstore.json"
           done
-      - name: Soft-fail aggregator for sc-${{ matrix.os }}-${{ matrix.arch }} attestation
+      # Release gate. SECURITY.md tells consumers that every release produces
+      # signed, attested artifacts, so an incomplete attestation chain is a
+      # failed release, not a warning: a green run with no SBOM, no signature
+      # and no provenance is indistinguishable from a good one at the consumer
+      # end. Branch previews and staging builds keep the warn-only aggregator.
+      #
+      # Break glass: set the repository variable ATTESTATION_SOFT_FAIL to
+      # 'true' to degrade this back to a warning for the duration of a Sigstore
+      # or Rekor outage. Unset it once the release ships.
+      - name: Attestation gate for sc-${{ matrix.os }}-${{ matrix.arch }}
         if: always()
         env:
           SBOM_OUTCOME: ${{ steps.sbom_tarball.outcome }}
           SIGN_OUTCOME: ${{ steps.cosign_sign_tarball.outcome }}
           SLSA_OUTCOME: ${{ steps.slsa_tarball.outcome }}
+          SOFT_FAIL: ${{ vars.ATTESTATION_SOFT_FAIL }}
+          PLATFORM: ${{ matrix.os }}-${{ matrix.arch }}
         run: |
           fail=0
           for v in "$SBOM_OUTCOME" "$SIGN_OUTCOME" "$SLSA_OUTCOME"; do
             if [ "$v" != "success" ]; then fail=1; fi
           done
-          if [ "$fail" -eq 1 ]; then
-            echo "::warning title=Attestation incomplete::sc-${{ matrix.os }}-${{ matrix.arch }} tarball published but one or more attestation steps failed (sbom=$SBOM_OUTCOME sign=$SIGN_OUTCOME slsa=$SLSA_OUTCOME)."
-          else
-            echo "All tarball attestation steps succeeded for ${{ matrix.os }}/${{ matrix.arch }}."
+          if [ "$fail" -eq 0 ]; then
+            echo "All tarball attestation steps succeeded for ${PLATFORM}."
+            exit 0
           fi
+          detail="sc-${PLATFORM} (sbom=$SBOM_OUTCOME sign=$SIGN_OUTCOME slsa=$SLSA_OUTCOME)"
+          if [ "${SOFT_FAIL:-}" = "true" ]; then
+            echo "::warning title=Attestation incomplete::${detail}. Blocking is disabled by the repository variable ATTESTATION_SOFT_FAIL."
+            exit 0
+          fi
+          echo "::error title=Attestation incomplete::${detail}. A release must not publish a tarball without an SBOM, a signature and provenance. Re-run the job; if the transparency log is down, set the repository variable ATTESTATION_SOFT_FAIL=true to ship without them."
+          exit 1
       - name: upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -487,12 +508,9 @@ jobs:
           # cache. Measured cost of re-running `runtime` alone: ~34 s.
           no-cache-filters: runtime
           provenance: false
-      # Phase 2 attestation: keyless cosign sign + CycloneDX SBOM + SLSA L3
-      # provenance. The publish step above is the gating job. Sign/attest steps
-      # below are continue-on-error so a sigstore-public outage does not block
-      # releases. A trailing aggregator emits ::warning:: on any failure. After
-      # 14 days of clean post-publish verification (see verify-attestations),
-      # flip continue-on-error to false (tracked in HARDENING.md Phase 2 plan).
+      # Attestation: keyless cosign sign + CycloneDX SBOM + SLSA L3 provenance.
+      # The sub-steps stay soft so that one failure does not hide the others;
+      # the trailing gate turns an incomplete chain into a failed release.
       #
       # `github-actions-staging` is intentionally skipped from attestation here.
       # The `:staging` tag is the canonical output of build-staging.yml under
@@ -511,9 +529,8 @@ jobs:
           image-name: ${{ matrix.image }}
           subject-name: index.docker.io/${{ matrix.image_repo }}
           subject-digest: ${{ steps.build_and_push.outputs.digest }}
-          # Phase 2 bake-in: keep soft-fail until 14 days of clean
-          # verify-attestations on `main`. Flip to 'false' tracked in
-          # HARDENING.md Phase 2.
+          # Kept soft so every sub-step reports its own outcome. The gate
+          # step below is what fails the release on an incomplete chain.
           soft-fail: 'true'
       # Record the immutable digest so verify-attestations can verify by
       # @sha256:... instead of by mutable tag (closes the verify-by-tag TOCTOU
@@ -534,23 +551,32 @@ jobs:
           name: image-digest-${{ matrix.image }}
           path: digests/${{ matrix.image }}.txt
           retention-days: 1
-      - name: Soft-fail aggregator for ${{ matrix.image }} attestation
+      # Release gate for images. Same policy as the tarball gate above.
+      - name: Attestation gate for ${{ matrix.image }}
         if: always() && steps.build_and_push.outcome == 'success'
         env:
           SIGN_OUTCOME: ${{ steps.signattest.outputs.sign-outcome }}
           SBOM_OUTCOME: ${{ steps.signattest.outputs.sbom-outcome }}
           ATTEST_SBOM_OUTCOME: ${{ steps.signattest.outputs.attest-outcome }}
           SLSA_OUTCOME: ${{ steps.signattest.outputs.slsa-outcome }}
+          SOFT_FAIL: ${{ vars.ATTESTATION_SOFT_FAIL }}
+          IMAGE: ${{ matrix.image }}
         run: |
           fail=0
           for v in "$SIGN_OUTCOME" "$SBOM_OUTCOME" "$ATTEST_SBOM_OUTCOME" "$SLSA_OUTCOME"; do
             if [ "$v" != "success" ]; then fail=1; fi
           done
-          if [ "$fail" -eq 1 ]; then
-            echo "::warning title=Attestation incomplete::${{ matrix.image }} published but one or more attestation steps failed (sign=$SIGN_OUTCOME sbom=$SBOM_OUTCOME attest-sbom=$ATTEST_SBOM_OUTCOME slsa=$SLSA_OUTCOME). See verify-attestations workflow."
-          else
-            echo "All attestation steps succeeded for ${{ matrix.image }}."
+          if [ "$fail" -eq 0 ]; then
+            echo "All attestation steps succeeded for ${IMAGE}."
+            exit 0
           fi
+          detail="${IMAGE} (sign=$SIGN_OUTCOME sbom=$SBOM_OUTCOME attest-sbom=$ATTEST_SBOM_OUTCOME slsa=$SLSA_OUTCOME)"
+          if [ "${SOFT_FAIL:-}" = "true" ]; then
+            echo "::warning title=Attestation incomplete::${detail}. Blocking is disabled by the repository variable ATTESTATION_SOFT_FAIL."
+            exit 0
+          fi
+          echo "::error title=Attestation incomplete::${detail}. A release must not publish an image without a signature, an SBOM attestation and provenance. See the verify-attestations workflow for the post-publish check."
+          exit 1
 
   docker-finalize:
     name: Docker finalize (tag-release, deploy)
@@ -608,10 +634,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .sc/stacks/dist/bundle
-          # Phase 2: copy tarballs + every sidecar (sha256, sbom, cosign-bundle,
-          # sigstore.json). Sidecars may be absent if sign/SBOM steps soft-failed
-          # in build-platforms — that is by design during the 14-day bake-in; the
-          # count-assertion step below records the gap rather than blocks the run.
+          # Copy tarballs + every sidecar (sha256, sbom, cosign-bundle,
+          # sigstore.json). A missing sidecar means build-platforms could not
+          # attest that tarball; the assertion step below decides whether the
+          # release may still publish.
           shopt -s nullglob
           for f in artifacts/sc-*/*.tar.gz \
                    artifacts/sc-*/*.tar.gz.sha256 \
@@ -620,7 +646,12 @@ jobs:
                    artifacts/sc-*/*.tar.gz.sbom.cdx.json; do
             cp "$f" .sc/stacks/dist/bundle/
           done
-      - name: Sidecar count assertion (Phase 2 bake-in — warn-only)
+      # Second line of defence: build-platforms gates per matrix leg, this one
+      # gates the bundle that actually reaches the CDN. Honours the same
+      # ATTESTATION_SOFT_FAIL break-glass variable.
+      - name: Sidecar count assertion
+        env:
+          SOFT_FAIL: ${{ vars.ATTESTATION_SOFT_FAIL }}
         run: |
           set -euo pipefail
           cd .sc/stacks/dist/bundle
@@ -646,13 +677,20 @@ jobs:
             label="${kind_count%%=*}"
             count="${kind_count#*=}"
             if [ "$count" -lt "$tarballs" ]; then
-              echo "::warning title=Sidecar count mismatch::${label} has $count of $tarballs expected sidecars (Phase 2 soft-fail)"
+              echo "::warning title=Sidecar count mismatch::${label} has $count of $tarballs expected sidecars"
               missing=1
             fi
           done
           if [ "$missing" -eq 0 ]; then
             echo "All sidecars present for every published tarball."
+            exit 0
           fi
+          if [ "${SOFT_FAIL:-}" = "true" ]; then
+            echo "::warning title=Sidecars incomplete::Publishing anyway; blocking is disabled by the repository variable ATTESTATION_SOFT_FAIL."
+            exit 0
+          fi
+          echo "::error title=Sidecars incomplete::Refusing to publish a release bundle with missing sidecars. Every tarball on dist must ship with .sha256, .cosign-bundle, .sigstore.json and .sbom.cdx.json."
+          exit 1
       - name: finalize dist bundle setup
         env:
           VERSION: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/verify-attestations.yml
+++ b/.github/workflows/verify-attestations.yml
@@ -1,10 +1,15 @@
 name: Verify published attestations
 
-# Post-publish quality gate for Phase 2 supply-chain attestations.
-# Off the release critical path: fires AFTER push.yaml or branch-preview.yaml
-# succeed, runs weekly as a drift check, and is manually dispatchable for
-# ad-hoc re-verification. A failure here surfaces in the repo's Actions tab
-# without blocking the release that already shipped — bake-in policy.
+# Post-publish verification of supply-chain attestations. Deliberately off the
+# release critical path, and not the control that stops a bad release: push.yaml
+# gates each job on its own attestation outcomes and promotes image tags only
+# after that gate passes, so an incomplete chain never reaches a release tag in
+# the first place. This workflow answers a different question, from outside the
+# build: does what is actually published still verify? It fires after push.yaml
+# or branch-preview.yaml succeed, runs weekly to catch drift (a deleted
+# signature, a rotated identity, an overwritten tag), and is manually
+# dispatchable. Previews and staging builds have no gate, so here a failure is
+# the first signal rather than the second.
 
 on:
   workflow_run:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ pkg/clouds/pulumi/testdata/secrets/mongodb-e2e-config.yaml
 pkg/clouds/pulumi/testdata/secrets/docker-creds.yaml
 .windsurf
 .claude
+
+# cosign key pairs. Tests generate throwaway pairs; before GenerateKeyPair
+# passed --output-key-prefix, cosign wrote them into the process working
+# directory, which meant an encrypted private key landed in the source tree.
+cosign.key
+cosign.pub

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -125,10 +125,32 @@ if an SBOM, a signature or a provenance attestation is missing for any
 image or tarball, the release build fails and nothing is published.
 The individual attestation steps stay soft so that one failure does not
 mask the others, and a gate step at the end of each job reports every
-missing piece at once and then exits non-zero. The repository variable
-`ATTESTATION_SOFT_FAIL=true` degrades those gates back to warnings; it
-exists for a Sigstore or Rekor outage and should be unset again as soon
-as the release ships. Branch previews and staging builds are not
+missing piece at once and then exits non-zero.
+
+"Nothing is published" is literal on both paths. A tarball is uploaded
+only after its gate passes. An image is built and pushed to a
+throwaway `:ci-<run>-<attempt>` tag, because cosign signs by digest and
+needs the manifest in the registry first; the release tags (`:latest`,
+`:<version>`) are applied by a separate promote step that runs only
+after the gate passes, and the throwaway tag is removed afterwards.
+Promotion republishes the signed manifest unchanged, so a release tag
+resolves to exactly the digest that was signed and verifying by tag
+gives the same answer as verifying by digest. A blocked release
+therefore leaves no consumer-facing tag pointing at an unattested
+image.
+
+Break glass: the variable `ATTESTATION_SOFT_FAIL` degrades those gates
+to warnings for the duration of a Sigstore or Rekor outage. Its value
+must be an ISO-8601 UTC expiry date (`YYYY-MM-DD`); it stops applying
+on that date whether or not anyone remembers to remove it, and any
+other value, including the historical `true`, is rejected and does not
+bypass. Every gate prints the variable's value on every run, pass or
+fail, and a bypassed run writes `attestation-breakglass=<date>` to its
+job summary. Note that `vars.*` resolves ORGANIZATION-level variables
+as well as repository ones, so a variable of this name set on the
+organization disables the gate in every repository that reads it;
+setting it at either scope is restricted to repository and
+organization admins. Branch previews and staging builds are not
 releases and stay warn-only.
 
 ### Identity-regex contract

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -120,6 +120,17 @@ our own crypto. The local security-scan cache uses HMAC-SHA256 with a
 Every release produces signed, attested artifacts published to Docker
 Hub and `dist.simple-container.com`. Consumers can verify before use.
 
+That promise is enforced in the release workflow, not merely intended:
+if an SBOM, a signature or a provenance attestation is missing for any
+image or tarball, the release build fails and nothing is published.
+The individual attestation steps stay soft so that one failure does not
+mask the others, and a gate step at the end of each job reports every
+missing piece at once and then exits non-zero. The repository variable
+`ATTESTATION_SOFT_FAIL=true` degrades those gates back to warnings; it
+exists for a Sigstore or Rekor outage and should be unset again as soon
+as the release ships. Branch previews and staging builds are not
+releases and stay warn-only.
+
 ### Identity-regex contract
 
 Cosign keyless signatures bind the signing identity to a GitHub

--- a/pkg/clouds/pulumi/aws/ecs_fargate.go
+++ b/pkg/clouds/pulumi/aws/ecs_fargate.go
@@ -143,7 +143,14 @@ func createEcsFargateCluster(ctx *sdk.Context, stack api.Stack, params pApi.Prov
 	// Build unified tags using the tagging utility
 	tags := taggingUtil.BuildTagsFromStackParams(deployParams).ToAWSTags()
 
+	// Gate every resource in this cluster on the image security operations.
+	// The nil guard matches the export loop further down and the Kubernetes
+	// path's imageSecurityOpts: MapErr can leave a nil entry in ref.Images, and
+	// the two loops disagreeing about that is how one of them panics.
 	for _, img := range ref.Images {
+		if img == nil {
+			continue
+		}
 		opts = append(opts, img.AddOpts...)
 	}
 

--- a/pkg/clouds/pulumi/kubernetes/deployment.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment.go
@@ -57,6 +57,20 @@ type Args struct {
 	PreStopSleepSeconds *int
 }
 
+// imageSecurityOpts collects the security-gate resource options every built
+// image contributes. Images that were not built by SC (pre-built references)
+// and stacks with security disabled contribute none.
+func imageSecurityOpts(images []*ContainerImage) []sdk.ResourceOption {
+	var opts []sdk.ResourceOption
+	for _, img := range images {
+		if img == nil {
+			continue
+		}
+		opts = append(opts, img.AddOpts...)
+	}
+	return opts
+}
+
 func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOption) (*SimpleContainer, error) {
 	stackName := args.Input.StackParams.StackName
 	stackEnv := args.Input.StackParams.Environment
@@ -83,6 +97,20 @@ func DeploySimpleContainer(ctx *sdk.Context, args Args, opts ...sdk.ResourceOpti
 		namespace, deploymentName, stackEnv, parentEnv, isCustomStack(stackEnv, parentEnv))
 
 	opts = append(opts, sdk.Provider(args.KubeProvider), sdk.DependsOn(args.Params.ComputeContext.Dependencies()))
+
+	// Gate the rollout on the image security operations.
+	//
+	// BuildAndPushImages hands back the fan-in of sign / verify / SBOM
+	// attestation / provenance attestation on ContainerImage.AddOpts. Nothing
+	// was consuming it here, so the workload had no dependency edge to any of
+	// them and Pulumi was free to update the Deployment first. A signing
+	// failure then arrived after the rollout had already completed, which
+	// leaves an unsigned, unattested image serving traffic while the run
+	// reports failure. Folding the options in makes signing a precondition of
+	// the rollout, matching the dependency graph documented in
+	// pkg/clouds/pulumi/docker/build_and_push.go and the wiring the ECS path
+	// already had.
+	opts = append(opts, imageSecurityOpts(args.Images)...)
 
 	replicas := 1
 	if args.Deployment.Scale != nil {

--- a/pkg/clouds/pulumi/kubernetes/deployment_security_gate_test.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment_security_gate_test.go
@@ -5,7 +5,7 @@ package kubernetes
 
 import (
 	"context"
-	"strings"
+	"slices"
 	"testing"
 
 	"github.com/samber/lo"
@@ -132,11 +132,8 @@ func TestImageSecurityOpts(t *testing.T) {
 	}), 2, "every image contributes its own gate")
 }
 
+// want is always a full URN, so equality is the check. The old suffix arm made
+// the assertion weaker than it reads: any URN ending in the wanted one passed.
 func containsURN(urns []string, want string) bool {
-	for _, u := range urns {
-		if u == want || strings.HasSuffix(u, want) {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(urns, want)
 }

--- a/pkg/clouds/pulumi/kubernetes/deployment_security_gate_test.go
+++ b/pkg/clouds/pulumi/kubernetes/deployment_security_gate_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Simple Container
+
+package kubernetes
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	k8sprovider "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	sdk "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/simple-container-com/api/pkg/api"
+	"github.com/simple-container-com/api/pkg/api/logger"
+	"github.com/simple-container-com/api/pkg/clouds/k8s"
+	pApi "github.com/simple-container-com/api/pkg/clouds/pulumi/api"
+)
+
+// securityGate stands in for the sign / verify / SBOM / provenance commands that
+// BuildAndPushImage hangs off the image push and returns on ImageOut.AddOpts.
+type securityGate struct {
+	sdk.CustomResourceState
+}
+
+func deployArgsWithImage(img *ContainerImage, provider sdk.ProviderResource) Args {
+	return Args{
+		KubeProvider:   provider,
+		Namespace:      "shop",
+		DeploymentName: "shop",
+		Input: api.ResourceInput{
+			StackParams: &api.StackParams{StackName: "shop", Environment: "staging"},
+		},
+		Deployment: k8s.DeploymentConfig{
+			StackConfig:      &api.StackConfigCompose{},
+			IngressContainer: &img.Container,
+			Containers:       []k8s.CloudRunContainer{img.Container},
+		},
+		Images: []*ContainerImage{img},
+		Params: pApi.ProvisionParams{
+			Log: logger.New(),
+			ComputeContext: pApi.NewComputeContextCollector(
+				context.Background(), logger.New(), "shop", "staging"),
+		},
+	}
+}
+
+func testContainerImage(addOpts ...sdk.ResourceOption) *ContainerImage {
+	return &ContainerImage{
+		Container: k8s.CloudRunContainer{
+			Name:     "shop",
+			MainPort: lo.ToPtr(8080),
+			Ports:    k8s.ContainerPorts(8080),
+		},
+		ImageName: sdk.String("registry.example.com/team/shop@sha256:f7ed9277c480591d7ec36fe7da13e112b33d898b7687f9bcbcda5c214a242099").ToStringOutput(),
+		AddOpts:   addOpts,
+	}
+}
+
+// Regression: the workload must not roll out before the image is signed and
+// attested.
+//
+// BuildAndPushImages returns the security fan-in on ContainerImage.AddOpts, but
+// DeploySimpleContainer used to drop it, leaving the Deployment with no
+// dependency edge to signing. Pulumi could then update the workload first and
+// surface the signing failure afterwards, which puts an unsigned, unattested
+// image in front of traffic while the run reports failure. The ECS path already
+// folded AddOpts into its resource options; this asserts the Kubernetes path
+// does the same.
+func TestDeploySimpleContainer_RolloutWaitsForImageSecurityGate(t *testing.T) {
+	mocks := NewSimpleContainerMocks()
+
+	var gateURN string
+	err := sdk.RunErr(func(ctx *sdk.Context) error {
+		gate := &securityGate{}
+		if err := ctx.RegisterResource("test:index:SecurityGate", "sign-shop", nil, gate); err != nil {
+			return err
+		}
+		gate.URN().ApplyT(func(u sdk.URN) error {
+			gateURN = string(u)
+			return nil
+		})
+
+		provider, err := k8sprovider.NewProvider(ctx, "kube", &k8sprovider.ProviderArgs{})
+		if err != nil {
+			return err
+		}
+
+		img := testContainerImage(sdk.DependsOn([]sdk.Resource{gate}))
+		_, err = DeploySimpleContainer(ctx, deployArgsWithImage(img, provider))
+		return err
+	}, sdk.WithMocks("test", "test", mocks))
+	require.NoError(t, err)
+	require.NotEmpty(t, gateURN, "the stand-in gate resource must have registered")
+
+	deps := mocks.DependenciesFor("kubernetes:apps/v1:Deployment")
+	require.NotEmpty(t, deps, "the Deployment registered with no dependencies at all")
+	require.True(t, containsURN(deps, gateURN),
+		"Deployment dependencies %v do not include the image security gate %q", deps, gateURN)
+}
+
+// The counterpart: an image that contributes no security options (security
+// disabled, or a pre-built image reference SC never pushed) must still deploy.
+func TestDeploySimpleContainer_NoSecurityOptsStillDeploys(t *testing.T) {
+	mocks := NewSimpleContainerMocks()
+
+	err := sdk.RunErr(func(ctx *sdk.Context) error {
+		provider, err := k8sprovider.NewProvider(ctx, "kube", &k8sprovider.ProviderArgs{})
+		if err != nil {
+			return err
+		}
+		_, err = DeploySimpleContainer(ctx, deployArgsWithImage(testContainerImage(), provider))
+		return err
+	}, sdk.WithMocks("test", "test", mocks))
+	require.NoError(t, err)
+	require.Positive(t, mocks.GetResourceCount("kubernetes:apps/v1:Deployment"))
+}
+
+func TestImageSecurityOpts(t *testing.T) {
+	first := sdk.DependsOn(nil)
+	second := sdk.DependsOn(nil)
+
+	require.Empty(t, imageSecurityOpts(nil))
+	require.Empty(t, imageSecurityOpts([]*ContainerImage{nil, {}}))
+	require.Len(t, imageSecurityOpts([]*ContainerImage{
+		{AddOpts: []sdk.ResourceOption{first}},
+		nil,
+		{AddOpts: []sdk.ResourceOption{second}},
+	}), 2, "every image contributes its own gate")
+}
+
+func containsURN(urns []string, want string) bool {
+	for _, u := range urns {
+		if u == want || strings.HasSuffix(u, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/clouds/pulumi/kubernetes/simple_container_mocks_test.go
+++ b/pkg/clouds/pulumi/kubernetes/simple_container_mocks_test.go
@@ -19,6 +19,8 @@ type simpleContainerMocks struct {
 	resourceCounts map[string]int
 	// Store created resources for validation
 	createdResources map[string]resource.PropertyMap
+	// Registered resource dependencies (URNs) keyed by type token
+	dependencies map[string][]string
 }
 
 // NewSimpleContainerMocks creates a new mock instance
@@ -26,6 +28,7 @@ func NewSimpleContainerMocks() *simpleContainerMocks {
 	return &simpleContainerMocks{
 		resourceCounts:   make(map[string]int),
 		createdResources: make(map[string]resource.PropertyMap),
+		dependencies:     make(map[string][]string),
 	}
 }
 
@@ -35,6 +38,9 @@ func (m *simpleContainerMocks) NewResource(args pulumi.MockResourceArgs) (string
 	m.mu.Lock()
 	m.resourceCounts[args.TypeToken]++
 	count := m.resourceCounts[args.TypeToken]
+	if args.RegisterRPC != nil {
+		m.dependencies[args.TypeToken] = append(m.dependencies[args.TypeToken], args.RegisterRPC.GetDependencies()...)
+	}
 	m.mu.Unlock()
 
 	// Generate unique resource ID
@@ -86,6 +92,14 @@ func (m *simpleContainerMocks) GetResourceCount(resourceType string) int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.resourceCounts[resourceType]
+}
+
+// DependenciesFor returns every dependency URN Pulumi was asked to register for
+// resources of the given type token.
+func (m *simpleContainerMocks) DependenciesFor(resourceType string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return append([]string(nil), m.dependencies[resourceType]...)
 }
 
 // GetCreatedResource returns the properties of a created resource

--- a/pkg/security/provenance/attach_rekor_test.go
+++ b/pkg/security/provenance/attach_rekor_test.go
@@ -78,7 +78,23 @@ func TestProvenanceAttach_PersistentConflictStillFails(t *testing.T) {
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
-	Expect(fake.Calls(t)).To(Equal(3))
+	Expect(fake.Calls(t)).To(Equal(5))
+	Expect(fake.Probes(t)).To(Equal(5), "every conflict is checked against the registry")
+}
+
+// The sbom twin: a provenance predicate for an unchanged digest is
+// byte-identical on every redeploy, so the conflict never clears. The
+// attestation is already attached, so the run is already done.
+func TestProvenanceAttach_ConflictWithAttestationAlreadyAttachedSucceeds(t *testing.T) {
+	RegisterTestingT(t)
+
+	fake := cosigntest.Install(t, cosigntest.Options{ConflictsBefore: 99, ArtifactAlreadyAttached: true})
+
+	err := provTestAttacher().Attach(context.Background(), provTestStatement(), provTestImage)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(fake.Calls(t)).To(Equal(1), "confirmation must short-circuit the retry loop")
+	Expect(fake.Probes(t)).To(Equal(1))
 }
 
 func TestProvenanceAttach_NoRetryOnOtherErrors(t *testing.T) {

--- a/pkg/security/provenance/attach_rekor_test.go
+++ b/pkg/security/provenance/attach_rekor_test.go
@@ -23,10 +23,17 @@ func provTestStatement() *Statement {
 	return NewStatement(FormatSLSAV10, predicate, provTestImage, &Metadata{BuilderID: "sc"})
 }
 
+// See the sbom twin: the identity fields are what make a conflict confirmable.
 func provTestAttacher() *Attacher {
 	return &Attacher{
-		SigningConfig: &signing.Config{Enabled: true, Keyless: true, OIDCToken: "a.b.c"},
-		Timeout:       provAttestTimeout,
+		SigningConfig: &signing.Config{
+			Enabled:        true,
+			Keyless:        true,
+			OIDCToken:      "a.b.c",
+			IdentityRegexp: "^https://example.test/wf@refs/heads/main$",
+			OIDCIssuer:     "https://token.example.test",
+		},
+		Timeout: provAttestTimeout,
 	}
 }
 
@@ -88,13 +95,45 @@ func TestProvenanceAttach_PersistentConflictStillFails(t *testing.T) {
 func TestProvenanceAttach_ConflictWithAttestationAlreadyAttachedSucceeds(t *testing.T) {
 	RegisterTestingT(t)
 
-	fake := cosigntest.Install(t, cosigntest.Options{ConflictsBefore: 99, ArtifactAlreadyAttached: true})
+	fake := cosigntest.Install(t, cosigntest.Options{
+		ConflictsBefore:         99,
+		ArtifactAlreadyAttached: true,
+		Image:                   provTestImage,
+	})
 
 	err := provTestAttacher().Attach(context.Background(), provTestStatement(), provTestImage)
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(fake.Calls(t)).To(Equal(1), "confirmation must short-circuit the retry loop")
 	Expect(fake.Probes(t)).To(Equal(1))
+	// --type must carry the provenance predicate URI. Without it an SBOM
+	// attestation on the same image would confirm a missing provenance one.
+	probe := fake.LastProbeArgs(t)
+	Expect(probe).To(Equal([]string{
+		"verify-attestation",
+		"--type", attestationType(FormatSLSAV10),
+		"--certificate-identity-regexp", "^https://example.test/wf@refs/heads/main$",
+		"--certificate-oidc-issuer", "https://token.example.test",
+		provTestImage,
+	}))
+}
+
+// See the sbom twin: presence alone is not attribution, so a config with no
+// verification identity gets no probe and keeps the retry-then-report path.
+func TestProvenanceAttach_ConflictWithoutAVerificationIdentityStillFails(t *testing.T) {
+	RegisterTestingT(t)
+
+	fake := cosigntest.Install(t, cosigntest.Options{ConflictsBefore: 99, ArtifactAlreadyAttached: true})
+	a := &Attacher{
+		SigningConfig: &signing.Config{Enabled: true, Keyless: true, OIDCToken: "a.b.c"},
+		Timeout:       provAttestTimeout,
+	}
+
+	err := a.Attach(context.Background(), provTestStatement(), provTestImage)
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+	Expect(fake.Probes(t)).To(Equal(0))
 }
 
 func TestProvenanceAttach_NoRetryOnOtherErrors(t *testing.T) {

--- a/pkg/security/provenance/provenance.go
+++ b/pkg/security/provenance/provenance.go
@@ -210,8 +210,11 @@ func (a *Attacher) Attach(ctx context.Context, statement *Statement, imageRef st
 	args = append(args, imageRef)
 
 	// Every retry is a fresh process with its own full a.Timeout budget. The
-	// predicate file outlives the loop via the deferred remove above.
-	_, err = signing.RunCosignWithRetry(ctx, "provenance attest", args, a.buildSigningEnv(), a.Timeout)
+	// predicate file outlives the loop via the deferred remove above. See the
+	// SBOM attacher for why the confirm probe verifies rather than downloads,
+	// and why a nil probe keeps the retry-then-report path.
+	confirm := a.SigningConfig.AttestationConfirmProbe(attestationType(statement.Format))
+	_, err = signing.RunCosignWithRetryConfirm(ctx, "provenance attest", args, a.buildSigningEnv(), a.Timeout, confirm)
 	return err
 }
 

--- a/pkg/security/sbom/attacher.go
+++ b/pkg/security/sbom/attacher.go
@@ -57,9 +57,21 @@ func (a *Attacher) Attach(ctx context.Context, sbom *SBOM, image string) error {
 	args = append(args, image)
 
 	// Every retry is a fresh process with its own full a.Timeout budget. The
-	// predicate file outlives the loop via the deferred remove above.
-	_, err = signing.RunCosignWithRetry(ctx, "sbom attest", args, a.buildSigningEnv(), a.Timeout)
+	// predicate file outlives the loop via the deferred remove above. The
+	// confirm probe turns a Rekor conflict over an attestation that is already
+	// on the image into an idempotent success; it is nil when SigningConfig
+	// names no verification identity, in which case a conflict is retried and
+	// then reported rather than assumed benign.
+	confirm := a.confirmProbe(sbom.Format)
+	_, err = signing.RunCosignWithRetryConfirm(ctx, "sbom attest", args, a.buildSigningEnv(), a.Timeout, confirm)
 	return err
+}
+
+// confirmProbe builds the read-only verification that confirms an SBOM
+// attestation of this format is already attached under the identity this
+// attacher signs with.
+func (a *Attacher) confirmProbe(format Format) *signing.ConfirmProbe {
+	return a.SigningConfig.AttestationConfirmProbe(format.AttestationType())
 }
 
 // Verify verifies an SBOM attestation

--- a/pkg/security/sbom/attacher_rekor_test.go
+++ b/pkg/security/sbom/attacher_rekor_test.go
@@ -16,10 +16,20 @@ import (
 
 const attestTimeout = 5 * time.Second
 
+// The identity fields are what let a Rekor conflict be confirmed: the probe
+// verifies that the attestation on the image is ours, not merely that one
+// exists. A config without them gets no probe at all, which
+// TestAttach_ConflictWithoutAVerificationIdentityStillFails covers.
 func rekorTestAttacher() *Attacher {
 	return &Attacher{
-		SigningConfig: &signing.Config{Enabled: true, Keyless: true, OIDCToken: "a.b.c"},
-		Timeout:       attestTimeout,
+		SigningConfig: &signing.Config{
+			Enabled:        true,
+			Keyless:        true,
+			OIDCToken:      "a.b.c",
+			IdentityRegexp: "^https://example.test/wf@refs/heads/main$",
+			OIDCIssuer:     "https://token.example.test",
+		},
+		Timeout: attestTimeout,
 	}
 }
 
@@ -94,13 +104,68 @@ func TestAttach_PersistentConflictStillFails(t *testing.T) {
 func TestAttach_ConflictWithAttestationAlreadyAttachedSucceeds(t *testing.T) {
 	RegisterTestingT(t)
 
-	fake := cosigntest.Install(t, cosigntest.Options{ConflictsBefore: 99, ArtifactAlreadyAttached: true})
+	fake := cosigntest.Install(t, cosigntest.Options{
+		ConflictsBefore:         99,
+		ArtifactAlreadyAttached: true,
+		Image:                   rekorTestImage,
+	})
 
 	err := rekorTestAttacher().Attach(context.Background(), rekorTestSBOM(), rekorTestImage)
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(fake.Calls(t)).To(Equal(1), "confirmation must short-circuit the retry loop")
 	Expect(fake.Probes(t)).To(Equal(1))
+	// The probe has to be a typed verify against the signing identity. A
+	// presence-only `download` probe returns nothing at all on cosign v3, and a
+	// verify without --type would let a provenance attestation stand in for a
+	// missing SBOM one.
+	probe := fake.LastProbeArgs(t)
+	Expect(probe).To(Equal([]string{
+		"verify-attestation",
+		"--type", FormatCycloneDXJSON.AttestationType(),
+		"--certificate-identity-regexp", "^https://example.test/wf@refs/heads/main$",
+		"--certificate-oidc-issuer", "https://token.example.test",
+		rekorTestImage,
+	}))
+}
+
+// A config that names no verification identity gets no probe. Confirming on
+// mere presence would accept an attestation made under a rotated key, so the
+// conflict is retried and then reported instead.
+func TestAttach_ConflictWithoutAVerificationIdentityStillFails(t *testing.T) {
+	RegisterTestingT(t)
+
+	fake := cosigntest.Install(t, cosigntest.Options{ConflictsBefore: 99, ArtifactAlreadyAttached: true})
+	a := &Attacher{
+		SigningConfig: &signing.Config{Enabled: true, Keyless: true, OIDCToken: "a.b.c"},
+		Timeout:       attestTimeout,
+	}
+
+	err := a.Attach(context.Background(), rekorTestSBOM(), rekorTestImage)
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+	Expect(fake.Probes(t)).To(Equal(0))
+}
+
+// Regression guard for the empirically reproduced cosign v3 breakage: under the
+// default new bundle format `cosign download` finds nothing however the image
+// was signed, so a download-shaped probe never confirms and every conflict runs
+// to exhaustion. The fake answers `download` the way cosign v3 does, so this
+// passing means the probe is not download-shaped.
+func TestAttach_ConfirmationDoesNotDependOnTheLegacyDownloadPath(t *testing.T) {
+	RegisterTestingT(t)
+
+	fake := cosigntest.Install(t, cosigntest.Options{
+		ConflictsBefore:         99,
+		ArtifactAlreadyAttached: true,
+		Image:                   rekorTestImage,
+	})
+
+	err := rekorTestAttacher().Attach(context.Background(), rekorTestSBOM(), rekorTestImage)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(fake.LastProbeArgs(t)[0]).ToNot(Equal("download"))
 }
 
 func TestAttach_NoRetryOnOtherErrors(t *testing.T) {

--- a/pkg/security/sbom/attacher_rekor_test.go
+++ b/pkg/security/sbom/attacher_rekor_test.go
@@ -72,8 +72,9 @@ func TestAttach_EachRetryGetsItsOwnTimeoutBudget(t *testing.T) {
 	Expect(fake.Calls(t)).To(Equal(2), "the retry must not inherit the exhausted budget")
 }
 
-// A conflict on every attempt must still fail: cosign uploads to Rekor before it
-// pushes to the registry, so a tlog entry does not prove the attestation landed.
+// A conflict on every attempt, with no attestation on the image to back it,
+// must still fail: cosign uploads to Rekor before it pushes to the registry, so
+// a tlog entry on its own does not prove the attestation landed.
 func TestAttach_PersistentConflictStillFails(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -83,7 +84,23 @@ func TestAttach_PersistentConflictStillFails(t *testing.T) {
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
-	Expect(fake.Calls(t)).To(Equal(3))
+	Expect(fake.Calls(t)).To(Equal(5))
+	Expect(fake.Probes(t)).To(Equal(5), "every conflict is checked against the registry")
+}
+
+// Redeploying an unchanged digest regenerates a byte-identical predicate, so
+// Rekor rejects it forever. The attestation is already on the image, which is
+// the end state the deploy wanted: report success instead of breaking it.
+func TestAttach_ConflictWithAttestationAlreadyAttachedSucceeds(t *testing.T) {
+	RegisterTestingT(t)
+
+	fake := cosigntest.Install(t, cosigntest.Options{ConflictsBefore: 99, ArtifactAlreadyAttached: true})
+
+	err := rekorTestAttacher().Attach(context.Background(), rekorTestSBOM(), rekorTestImage)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(fake.Calls(t)).To(Equal(1), "confirmation must short-circuit the retry loop")
+	Expect(fake.Probes(t)).To(Equal(1))
 }
 
 func TestAttach_NoRetryOnOtherErrors(t *testing.T) {

--- a/pkg/security/signing/config.go
+++ b/pkg/security/signing/config.go
@@ -49,7 +49,12 @@ func (c *Config) CreateSigner(oidcToken string) (Signer, error) {
 		if token == "" {
 			return nil, fmt.Errorf("OIDC token required for keyless signing")
 		}
-		return NewKeylessSigner(token, timeout), nil
+		signer := NewKeylessSigner(token, timeout)
+		// Needed to confirm a Rekor conflict against the image; see
+		// KeylessSigner.IdentityRegexp.
+		signer.IdentityRegexp = c.IdentityRegexp
+		signer.OIDCIssuer = c.OIDCIssuer
+		return signer, nil
 	}
 
 	if c.PrivateKey == "" {
@@ -134,4 +139,58 @@ func VerifyImage(ctx context.Context, config *Config, imageRef string) (*VerifyR
 	}
 
 	return verifier.Verify(ctx, imageRef)
+}
+
+// verificationIdentityArgs returns the cosign flags that bind a verification to
+// the identity this config signs with. Empty when the config cannot express
+// one, which is the signal to skip conflict confirmation entirely: a probe that
+// only asks whether *some* artifact is attached would accept one produced under
+// a rotated key or by an unrelated workflow.
+func (c *Config) verificationIdentityArgs() []string {
+	if c == nil {
+		return nil
+	}
+
+	if c.Keyless {
+		if c.IdentityRegexp == "" || c.OIDCIssuer == "" {
+			return nil
+		}
+		return []string{
+			"--certificate-identity-regexp", c.IdentityRegexp,
+			"--certificate-oidc-issuer", c.OIDCIssuer,
+		}
+	}
+
+	// cosign resolves --key against a public key, a KMS URI or a private key,
+	// deriving the public half where needed, so a config carrying only the
+	// signing key can still confirm against the identity it just signed with.
+	key := c.PublicKey
+	if key == "" {
+		key = c.PrivateKey
+	}
+	if key == "" {
+		return nil
+	}
+	return []string{"--key", key}
+}
+
+// AttestationConfirmProbe builds the read-only check that decides whether a
+// Rekor conflict on `cosign attest --type predicateType` is an idempotent
+// no-op. Nil when the config names no verification identity.
+func (c *Config) AttestationConfirmProbe(predicateType string) *ConfirmProbe {
+	identity := c.verificationIdentityArgs()
+	if len(identity) == 0 || predicateType == "" {
+		return nil
+	}
+	args := append([]string{"verify-attestation", "--type", predicateType}, identity...)
+	return &ConfirmProbe{Args: args, What: predicateType + " attestation"}
+}
+
+// SignatureConfirmProbe is AttestationConfirmProbe's twin for `cosign sign`.
+func (c *Config) SignatureConfirmProbe() *ConfirmProbe {
+	identity := c.verificationIdentityArgs()
+	if len(identity) == 0 {
+		return nil
+	}
+	return &ConfirmProbe{Args: append([]string{"verify"}, identity...), What: "signature"}
 }

--- a/pkg/security/signing/confirm_probe_integration_test.go
+++ b/pkg/security/signing/confirm_probe_integration_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Simple Container
+
+//go:build integration
+// +build integration
+
+package signing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/simple-container-com/api/pkg/security/tools"
+)
+
+// The confirmation probe is the one piece of the Rekor-conflict path that the
+// fake cosign harness cannot honestly certify. The harness decides what the
+// probe means; if the probe shape is one real cosign rejects, or one that finds
+// nothing under current defaults, every unit test still passes and the feature
+// silently never fires in production. That is exactly how a `cosign download`
+// probe survived review: it works on cosign v2 and returns nothing on v3, where
+// the new bundle format leaves the legacy signature tag empty.
+//
+// So this runs the real binary against a real registry: push an image, sign it
+// for real, then drive the retry loop with a synthetic Rekor conflict and let
+// the probe be genuine cosign. The synthetic conflict is deliberate: reaching a
+// real 409 would mean uploading to a public transparency log, which a test must
+// not do. Everything the probe touches is real.
+//
+// Requires docker and cosign; skips without either, and under -short.
+func TestConfirmProbe_ConfirmsAgainstARealRegistry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: starts a local container registry and shells out to cosign")
+	}
+	requireBinary(t, "docker")
+	requireBinary(t, "cosign")
+	RegisterTestingT(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	registry := startLocalRegistry(t)
+	signedRef := buildAndPush(t, registry, "confirm-signed")
+	unsignedRef := buildAndPush(t, registry, "confirm-unsigned")
+
+	keyDir := t.TempDir()
+	privateKey, publicKey, err := GenerateKeyPair(ctx, keyDir, keyPassword)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Sign for real, but keep it off the public transparency log.
+	signArgs := []string{
+		"sign", "--key", privateKey, "--yes",
+		"--tlog-upload=false", "--allow-insecure-registry", signedRef,
+	}
+	_, stderr, err := tools.ExecCommand(ctx, "cosign", signArgs, cosignEnv(), 2*time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "cosign sign failed: %s", stderr)
+
+	// What a caller would build for a key-based signer, plus the two flags this
+	// offline local-registry setup needs.
+	probe := &ConfirmProbe{
+		Args: []string{
+			"verify", "--key", publicKey,
+			"--insecure-ignore-tlog=true", "--allow-insecure-registry",
+		},
+		What: "signature",
+	}
+
+	// Documented, not asserted: which of these the installed cosign answers is
+	// version-dependent, and that dependency is the whole point. On v3 the
+	// legacy download path returns nothing for an image the verify path
+	// confirms, so a download-shaped probe is a permanent false negative.
+	logLegacyDownload(t, ctx, signedRef)
+
+	t.Run("a conflict over an image that really is signed confirms", func(t *testing.T) {
+		RegisterTestingT(t)
+		noBackoff(t)
+
+		attempts := 0
+		_, confirmed, err := runCosignWithRetry(ctx, "sign", signArgs, cosignEnv(), 2*time.Minute, probe,
+			conflictOnSign(&attempts))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(confirmed).To(BeTrue(), "the signature is on the image and verifies, so the conflict is a no-op")
+		Expect(attempts).To(Equal(1), "confirmation must short-circuit the retry loop")
+	})
+
+	// The half that makes the half above mean something. Same probe, same real
+	// cosign, an image nobody signed: it must not confirm.
+	t.Run("a conflict over an unsigned image does not confirm", func(t *testing.T) {
+		RegisterTestingT(t)
+		noBackoff(t)
+
+		unsignedArgs := []string{
+			"sign", "--key", privateKey, "--yes",
+			"--tlog-upload=false", "--allow-insecure-registry", unsignedRef,
+		}
+		attempts := 0
+		_, confirmed, err := runCosignWithRetry(ctx, "sign", unsignedArgs, cosignEnv(), 2*time.Minute, probe,
+			conflictOnSign(&attempts))
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+		Expect(confirmed).To(BeFalse())
+		Expect(attempts).To(Equal(maxCosignAttempts), "an unconfirmed conflict is retried and then reported")
+	})
+}
+
+const keyPassword = "confirm-probe-integration"
+
+func cosignEnv() []string { return []string{"COSIGN_PASSWORD=" + keyPassword} }
+
+// conflictOnSign answers every sign/attest with a Rekor 409 and lets everything
+// else through to the real cosign binary, so the probe under test is genuine.
+func conflictOnSign(attempts *int) execFn {
+	return func(ctx context.Context, name string, args, env []string, timeout time.Duration) (string, string, error) {
+		if len(args) > 0 && (args[0] == "sign" || args[0] == "attest") {
+			*attempts++
+			return "", conflictStderr, fmt.Errorf("exit status 1")
+		}
+		return tools.ExecCommand(ctx, name, args, env, timeout)
+	}
+}
+
+func logLegacyDownload(t *testing.T, ctx context.Context, ref string) {
+	t.Helper()
+	stdout, stderr, err := tools.ExecCommand(ctx, "cosign",
+		[]string{"download", "signature", "--allow-insecure-registry", ref}, cosignEnv(), 30*time.Second)
+	version, _, _ := tools.ExecCommand(ctx, "cosign", []string{"version"}, nil, 30*time.Second)
+	t.Logf("cosign version:\n%s", strings.TrimSpace(version))
+	t.Logf("legacy `cosign download signature` on a signed image: err=%v stdout=%q stderr=%q",
+		err, strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+}
+
+func requireBinary(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("skipping: %s is not installed", name)
+	}
+}
+
+// startLocalRegistry runs registry:2 on a loopback port and returns host:port.
+func startLocalRegistry(t *testing.T) string {
+	t.Helper()
+
+	out, err := exec.Command("docker", "run", "-d", "--rm", "-p", "127.0.0.1:0:5000", "registry:2").CombinedOutput()
+	if err != nil {
+		t.Skipf("skipping: cannot start registry:2 (%v): %s", err, out)
+	}
+	id := strings.TrimSpace(string(out))
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rm", "-f", id).Run()
+	})
+
+	portOut, err := exec.Command("docker", "port", id, "5000/tcp").Output()
+	if err != nil {
+		t.Fatalf("reading the registry port: %v", err)
+	}
+	addr := strings.TrimSpace(strings.SplitN(string(portOut), "\n", 2)[0])
+	// Normalise 0.0.0.0:PORT to a loopback address cosign will treat as local.
+	if i := strings.LastIndex(addr, ":"); i >= 0 {
+		addr = "127.0.0.1" + addr[i:]
+	}
+
+	// The registry needs a moment before it answers /v2/.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := exec.Command("docker", "exec", id, "true").Run(); err == nil {
+			if probeErr := exec.Command("curl", "-fsS", "-o", "/dev/null",
+				"http://"+addr+"/v2/").Run(); probeErr == nil {
+				return addr
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("registry at %s never answered /v2/", addr)
+	return ""
+}
+
+// buildAndPush builds a minimal scratch image and pushes it, returning the
+// digest reference. Signing by digest is what production does, and it is what
+// makes the probe's target unambiguous.
+func buildAndPush(t *testing.T, registry, name string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "payload"), []byte(name+"\n"), 0o644); err != nil {
+		t.Fatalf("writing the image payload: %v", err)
+	}
+	dockerfile := "FROM scratch\nCOPY payload /payload\n"
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		t.Fatalf("writing the Dockerfile: %v", err)
+	}
+
+	tag := fmt.Sprintf("%s/%s:%d", registry, name, time.Now().UnixNano())
+	if out, err := exec.Command("docker", "build", "-t", tag, dir).CombinedOutput(); err != nil {
+		t.Fatalf("docker build: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("docker", "rmi", "-f", tag).Run() })
+
+	if out, err := exec.Command("docker", "push", tag).CombinedOutput(); err != nil {
+		t.Fatalf("docker push: %v: %s", err, out)
+	}
+
+	out, err := exec.Command("docker", "inspect", "--format", "{{index .RepoDigests 0}}", tag).Output()
+	if err != nil {
+		t.Fatalf("reading the pushed digest: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/pkg/security/signing/keybased.go
+++ b/pkg/security/signing/keybased.go
@@ -83,12 +83,24 @@ func (s *KeyBasedSigner) Sign(ctx context.Context, imageRef string) (*SignResult
 	if exec == nil {
 		exec = tools.ExecCommand
 	}
-	if _, err := runCosignSign(ctx, exec, args, env, s.Timeout); err != nil {
+	// `cosign verify --key` loads the private key and derives the public half,
+	// so the confirmation probe checks the signature is this key's own rather
+	// than merely present. COSIGN_PASSWORD is already in env and survives the
+	// probe's environment filter.
+	confirm := &ConfirmProbe{Args: []string{"verify", "--key", keyPath}, What: "signature"}
+	_, confirmed, err := runCosignSign(ctx, exec, args, env, s.Timeout, confirm)
+	if err != nil {
 		return nil, err
+	}
+	if confirmed {
+		fmt.Fprintf(os.Stderr,
+			"cosign sign %s: signature confirmed already present; no new transparency-log entry was created\n",
+			imageRef)
 	}
 
 	result := &SignResult{
-		SignedAt: time.Now().UTC().Format(time.RFC3339),
+		SignedAt:  time.Now().UTC().Format(time.RFC3339),
+		Confirmed: confirmed,
 	}
 
 	return result, nil
@@ -105,14 +117,19 @@ func GenerateKeyPair(ctx context.Context, outputDir string, password string) (pr
 		return "", "", fmt.Errorf("creating output directory: %w", err)
 	}
 
-	privateKeyPath = filepath.Join(outputDir, "cosign.key")
-	publicKeyPath = filepath.Join(outputDir, "cosign.pub")
+	prefix := filepath.Join(outputDir, "cosign")
+	privateKeyPath = prefix + ".key"
+	publicKeyPath = prefix + ".pub"
 
 	// Prepare environment
 	env := []string{"COSIGN_PASSWORD=" + password}
 
-	// Execute cosign generate-key-pair
-	args := []string{"generate-key-pair"}
+	// Execute cosign generate-key-pair. Without --output-key-prefix cosign
+	// writes cosign.key and cosign.pub into the PROCESS working directory, not
+	// into outputDir, so every caller passing a directory got the pair written
+	// somewhere else and then failed on the chmod below. Found by the
+	// real-registry confirmation-probe test.
+	args := []string{"generate-key-pair", "--output-key-prefix", prefix}
 	_, stderr, err := tools.ExecCommand(ctx, "cosign", args, env, 30*time.Second)
 	if err != nil {
 		return "", "", fmt.Errorf("cosign generate-key-pair failed: %w\nStderr: %s", err, stderr)

--- a/pkg/security/signing/keybased_test.go
+++ b/pkg/security/signing/keybased_test.go
@@ -107,15 +107,17 @@ func TestKeyBasedSignerPasswordHandling(t *testing.T) {
 
 func TestKeyBasedSigner_Sign_GivesUpOnPersistentRekorConflict(t *testing.T) {
 	RegisterTestingT(t)
+	noBackoff(t)
 
-	// Deterministic keys reproduce the same signature: a persistent conflict
-	// must exhaust the loop and fail, never be treated as success.
+	// Deterministic keys reproduce the same signature, so the conflict never
+	// clears. With no signature on the image to confirm it, the loop must
+	// exhaust and fail rather than report a success nothing backs.
 	calls := 0
 	signer := NewKeyBasedSigner("test-key-content", "", time.Second)
-	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+	signer.exec = probeAbsent(func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
-	}
+	})
 
 	_, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
 
@@ -126,16 +128,17 @@ func TestKeyBasedSigner_Sign_GivesUpOnPersistentRekorConflict(t *testing.T) {
 
 func TestKeyBasedSigner_Sign_RetriesOnceOnTransientConflict(t *testing.T) {
 	RegisterTestingT(t)
+	noBackoff(t)
 
 	calls := 0
 	signer := NewKeyBasedSigner("test-key-content", "", time.Second)
-	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+	signer.exec = probeAbsent(func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		if calls == 1 {
 			return "", "createLogEntryConflict", fmt.Errorf("exit status 1")
 		}
 		return "", "", nil
-	}
+	})
 
 	result, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
 

--- a/pkg/security/signing/keyless.go
+++ b/pkg/security/signing/keyless.go
@@ -6,6 +6,7 @@ package signing
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -17,16 +18,25 @@ import (
 type execFn func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error)
 
 // runCosignSign retries the full `cosign sign` on Rekor entry conflicts.
-// See RunCosignWithRetry for why a retry — not a success — is the right
-// response to a conflict.
-func runCosignSign(ctx context.Context, exec execFn, args, env []string, timeout time.Duration) (string, error) {
-	return runCosignWithRetry(ctx, "sign", args, env, timeout, exec)
+// See RunCosignWithRetryConfirm for why a retry, not a success, is the right
+// response to an unconfirmed conflict. It reports whether the run ended by
+// confirming an existing signature instead of producing a new one.
+func runCosignSign(ctx context.Context, exec execFn, args, env []string, timeout time.Duration, confirm *ConfirmProbe) (string, bool, error) {
+	return runCosignWithRetry(ctx, "sign", args, env, timeout, confirm, exec)
 }
 
 // KeylessSigner implements keyless signing using OIDC tokens
 type KeylessSigner struct {
 	OIDCToken string
 	Timeout   time.Duration
+
+	// IdentityRegexp and OIDCIssuer name the certificate identity this signer
+	// produces. Both are needed to confirm a Rekor conflict against the image;
+	// with either missing the signer keeps the plain retry-then-report path
+	// rather than accepting a signature it cannot attribute. Config.CreateSigner
+	// populates them.
+	IdentityRegexp string
+	OIDCIssuer     string
 
 	// exec overrides command execution in tests; nil means tools.ExecCommand.
 	exec execFn
@@ -61,20 +71,33 @@ func (s *KeylessSigner) Sign(ctx context.Context, imageRef string) (*SignResult,
 	if exec == nil {
 		exec = tools.ExecCommand
 	}
-	stdout, err := runCosignSign(ctx, exec, args, env, s.Timeout)
+	stdout, confirmed, err := runCosignSign(ctx, exec, args, env, s.Timeout, s.confirmProbe())
 	if err != nil {
 		return nil, err
 	}
 
 	// Parse output for Rekor entry URL
 	rekorEntry := parseRekorEntry(stdout)
+	if confirmed {
+		fmt.Fprintf(os.Stderr,
+			"cosign sign %s: signature confirmed already present; no new transparency-log entry, RekorEntry is unavailable\n",
+			imageRef)
+	}
 
 	result := &SignResult{
 		RekorEntry: rekorEntry,
 		SignedAt:   time.Now().UTC().Format(time.RFC3339),
+		Confirmed:  confirmed,
 	}
 
 	return result, nil
+}
+
+// confirmProbe returns the verification that confirms an existing signature is
+// this signer's own. Nil unless the certificate identity is known.
+func (s *KeylessSigner) confirmProbe() *ConfirmProbe {
+	cfg := &Config{Keyless: true, IdentityRegexp: s.IdentityRegexp, OIDCIssuer: s.OIDCIssuer}
+	return cfg.SignatureConfirmProbe()
 }
 
 // parseRekorEntry extracts the Rekor entry URL from cosign output

--- a/pkg/security/signing/keyless_test.go
+++ b/pkg/security/signing/keyless_test.go
@@ -151,12 +151,13 @@ func TestGetRekorEntryFromOutput(t *testing.T) {
 
 func TestKeylessSigner_Sign_RetriesOnRekorConflict(t *testing.T) {
 	RegisterTestingT(t)
+	noBackoff(t)
 
 	conflictStderr := `signing bundle: error signing bundle: [POST /api/v1/log/entries][409] createLogEntryConflict {"code":409,"message":"an equivalent entry already exists in the transparency log"}`
 
 	calls := 0
 	signer := NewKeylessSigner("a.b.c", time.Second)
-	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+	signer.exec = probeAbsent(func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		Expect(name).To(Equal("cosign"))
 		Expect(args[0]).To(Equal("sign"))
@@ -164,7 +165,7 @@ func TestKeylessSigner_Sign_RetriesOnRekorConflict(t *testing.T) {
 			return "", conflictStderr, fmt.Errorf("exit status 1")
 		}
 		return "tlog entry created with index: 123456", "", nil
-	}
+	})
 	result, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
 
 	Expect(err).ToNot(HaveOccurred())
@@ -190,16 +191,38 @@ func TestKeylessSigner_Sign_NoRetryOnOtherErrors(t *testing.T) {
 
 func TestKeylessSigner_Sign_GivesUpAfterMaxConflictAttempts(t *testing.T) {
 	RegisterTestingT(t)
+	noBackoff(t)
 
 	calls := 0
 	signer := NewKeylessSigner("a.b.c", time.Second)
-	signer.exec = func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+	signer.exec = probeAbsent(func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
-	}
+	})
 	_, err := signer.Sign(context.Background(), "registry.example.com/app:1.0.0")
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
 	Expect(calls).To(Equal(maxCosignAttempts))
+}
+
+// A redeploy of an unchanged digest: the signature is already on the image, so
+// the conflict is the expected outcome and the deploy must not fail on it.
+func TestKeylessSigner_Sign_ConfirmedConflictSucceeds(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	calls, probes := 0, 0
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	signer.exec = probePresent(func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+		calls++
+		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
+	}, &probes)
+
+	result, err := signer.Sign(context.Background(), "registry.example.com/app@sha256:f7ed9277c480591d7ec36fe7da13e112b33d898b7687f9bcbcda5c214a242099")
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(result).ToNot(BeNil())
+	Expect(calls).To(Equal(1))
+	Expect(probes).To(Equal(1))
 }

--- a/pkg/security/signing/keyless_test.go
+++ b/pkg/security/signing/keyless_test.go
@@ -214,6 +214,10 @@ func TestKeylessSigner_Sign_ConfirmedConflictSucceeds(t *testing.T) {
 
 	calls, probes := 0, 0
 	signer := NewKeylessSigner("a.b.c", time.Second)
+	// Confirmation needs an identity to verify against; Config.CreateSigner
+	// plumbs these from the signing config in production.
+	signer.IdentityRegexp = "^https://example.test/wf@refs/heads/main$"
+	signer.OIDCIssuer = "https://token.example.test"
 	signer.exec = probePresent(func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
 		calls++
 		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
@@ -225,4 +229,49 @@ func TestKeylessSigner_Sign_ConfirmedConflictSucceeds(t *testing.T) {
 	Expect(result).ToNot(BeNil())
 	Expect(calls).To(Equal(1))
 	Expect(probes).To(Equal(1))
+	Expect(result.Confirmed).To(BeTrue(), "the signature was confirmed, not freshly made")
+	Expect(result.RekorEntry).To(BeEmpty(), "no new transparency-log entry exists to point at")
+}
+
+// A keyless signer with no certificate identity cannot tell its own signature
+// from anyone else's, so it must not confirm. The conflict is retried and then
+// reported, which is the pre-confirmation behaviour.
+func TestKeylessSigner_Sign_WithoutAnIdentityDoesNotConfirm(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	calls, probes := 0, 0
+	signer := NewKeylessSigner("a.b.c", time.Second)
+	signer.exec = probePresent(func(ctx context.Context, name string, args []string, env []string, timeout time.Duration) (string, string, error) {
+		calls++
+		return "", "[POST /api/v1/log/entries][409] createLogEntryConflict", fmt.Errorf("exit status 1")
+	}, &probes)
+
+	_, err := signer.Sign(context.Background(), "registry.example.com/app@sha256:f7ed9277c480591d7ec36fe7da13e112b33d898b7687f9bcbcda5c214a242099")
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+	Expect(calls).To(Equal(maxCosignAttempts))
+	Expect(probes).To(Equal(0), "there is nothing to verify against")
+}
+
+// CreateSigner is where the identity reaches the signer. Without this wiring
+// the confirmation path is dead code in every production keyless run.
+func TestConfig_CreateSigner_PlumbsTheKeylessIdentity(t *testing.T) {
+	RegisterTestingT(t)
+
+	cfg := &Config{
+		Enabled:        true,
+		Keyless:        true,
+		OIDCIssuer:     "https://token.example.test",
+		IdentityRegexp: "^https://example.test/wf@refs/heads/main$",
+	}
+	signer, err := cfg.CreateSigner("a.b.c")
+	Expect(err).ToNot(HaveOccurred())
+
+	keyless, ok := signer.(*KeylessSigner)
+	Expect(ok).To(BeTrue())
+	Expect(keyless.IdentityRegexp).To(Equal(cfg.IdentityRegexp))
+	Expect(keyless.OIDCIssuer).To(Equal(cfg.OIDCIssuer))
+	Expect(keyless.confirmProbe()).ToNot(BeNil())
 }

--- a/pkg/security/signing/rekor_retry.go
+++ b/pkg/security/signing/rekor_retry.go
@@ -15,11 +15,16 @@ import (
 	"github.com/simple-container-com/api/pkg/security/tools"
 )
 
-// maxCosignAttempts bounds the Rekor-conflict retry loop for every cosign
-// subcommand routed through runCosignWithRetry.
-const maxCosignAttempts = 3
+// maxCosignAttempts bounds the retry loop for every cosign subcommand routed
+// through runCosignWithRetry.
+//
+// Sized for the contended case. Both retryable classes below are contention
+// artifacts of several jobs signing the same digest at once, and the public
+// Rekor instance can stay hot for longer than the ~3s that three attempts
+// spanned.
+const maxCosignAttempts = 5
 
-// Backoff between conflict retries. The conflict is a contention artifact —
+// Backoff between retries. Both retryable classes are contention artifacts —
 // parallel deploys attesting against the public-good instance — so retrying
 // instantly maximizes the chance of colliding again. Jittered, to keep a
 // fleet-wide deploy from resynchronizing on one schedule. Vars, not consts, so
@@ -38,13 +43,34 @@ var (
 var rekorConflictRe = regexp.MustCompile(`\[POST /api/v1/log/entries\]\[409\]`)
 
 // isRekorConflict reports a Rekor createLogEntryConflict (HTTP 409) — an
-// identical entry already in the tlog, typically a cosign upload retry after a
-// client-side timeout whose first attempt succeeded server-side.
+// identical entry already in the tlog. Two ways to get there: a cosign upload
+// retry after a client-side timeout whose first attempt succeeded server-side,
+// and a redeploy of an unchanged digest whose predicate is byte-identical to
+// the one already attested.
 //
 // Callers classify each stream separately. Concatenating stdout and stderr first
 // would let the marker be assembled from tokens cosign never emitted together.
 func isRekorConflict(output string) bool {
 	return strings.Contains(output, "createLogEntryConflict") || rekorConflictRe.MatchString(output)
+}
+
+// rekorGiveUpRe matches cosign exhausting its own HTTP retry budget against the
+// Rekor log-entries endpoint, e.g.
+//
+//	signing bundle: Post "https://rekor.sigstore.dev/api/v1/log/entries": EOF — giving up after 2 attempt(s)
+//
+// Both halves are required, and the URL must be a log-entries POST, so an
+// unrelated "giving up" from a registry or from Fulcio does not match.
+var rekorGiveUpRe = regexp.MustCompile(`(?s)Post "https?://[^"]+/api/v1/log/entries".{0,400}?giving up after \d+ attempt`)
+
+// isRekorTransient reports a transient failure to reach the transparency log:
+// cosign's internal HTTP client ran out of attempts posting the entry. Nothing
+// was attached, so unlike a conflict this is retried rather than confirmed —
+// but it is retried, where before it fell through to the fail-fast branch and
+// broke the deploy on the first hiccup. Concurrent deploys of the same digest
+// are exactly when the endpoint is most likely to be slow.
+func isRekorTransient(output string) bool {
+	return rekorGiveUpRe.MatchString(output)
 }
 
 // RunCosignWithRetry runs `cosign <args>` and returns its stdout, retrying Rekor
@@ -56,10 +82,15 @@ func isRekorConflict(output string) bool {
 // keyless signing each invocation mints a new ephemeral certificate, so the body
 // cosign replays differs and the conflict clears.
 //
-// Retrying rather than treating a 409 as success is deliberate: cosign uploads
-// to Rekor before it pushes to the registry, so a tlog entry does not prove the
-// signature or attestation was attached. Exhausting the loop therefore means a
-// persistent server-side condition, and surfacing it is correct.
+// Two failure classes are retried. A Rekor 409 conflict says the transparency
+// log already holds an identical entry, and "already attested" is the desired
+// end state of an idempotent re-run — a redeploy of an unchanged digest
+// regenerates a byte-identical predicate and lands there every time. It is not
+// proof on its own, because cosign uploads to Rekor before it pushes to the
+// registry, so each conflict is confirmed against the registry (see
+// confirmArtifactAttached): a confirmed conflict returns success, an
+// unconfirmed one is retried and then reported. A transient give-up against
+// the log-entries endpoint attached nothing, so it is simply retried.
 func RunCosignWithRetry(ctx context.Context, label string, args, env []string, timeout time.Duration) (string, error) {
 	return runCosignWithRetry(ctx, label, args, env, timeout, tools.ExecCommand)
 }
@@ -70,7 +101,7 @@ func runCosignWithRetry(ctx context.Context, label string, args, env []string, t
 		subcommand = args[0]
 	}
 
-	var firstConflictErr, lastErr error
+	var firstRetryableErr, lastErr error
 	for attempt := 1; attempt <= maxCosignAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return "", err
@@ -87,28 +118,129 @@ func runCosignWithRetry(ctx context.Context, label string, args, env []string, t
 		}
 		lastErr = fmt.Errorf("cosign %s failed: %w\nStderr: %s\nStdout: %s", subcommand, err, stderr, stdout)
 
-		if !isRekorConflict(stderr) && !isRekorConflict(stdout) {
+		conflict := isRekorConflict(stderr) || isRekorConflict(stdout)
+		transient := isRekorTransient(stderr) || isRekorTransient(stdout)
+		if !conflict && !transient {
 			return "", lastErr
 		}
-		if firstConflictErr == nil {
-			firstConflictErr = lastErr
+		if firstRetryableErr == nil {
+			firstRetryableErr = lastErr
 		}
+
+		// The artifact this invocation was asked to produce may already be on
+		// the image, put there by the run that wrote the conflicting tlog
+		// entry. That is the normal outcome of redeploying an unchanged digest
+		// with a deterministic predicate. Re-signing it would be a no-op, so
+		// stop here and report success rather than failing a deploy over an
+		// artifact that is already in place.
+		if conflict {
+			if what, attached := confirmArtifactAttached(ctx, args, env, timeout, exec); attached {
+				fmt.Fprintf(os.Stderr,
+					"Rekor transparency-log conflict on cosign %s: %s already attached to the image, nothing to do\n",
+					label, what)
+				return "", nil
+			}
+		}
+
 		if attempt < maxCosignAttempts {
-			fmt.Fprintf(os.Stderr, "Warning: Rekor transparency-log conflict on cosign %s attempt %d/%d, retrying\n",
-				label, attempt, maxCosignAttempts)
+			reason := "transparency-log conflict"
+			if !conflict {
+				reason = "transparency-log upload gave up"
+			}
+			fmt.Fprintf(os.Stderr, "Warning: Rekor %s on cosign %s attempt %d/%d, retrying\n",
+				reason, label, attempt, maxCosignAttempts)
 		}
 	}
 
-	// Report the first conflict rather than the last error. A later attempt can
-	// die for an incidental reason, and losing the createLogEntryConflict text
-	// strands the operator: that string is what the troubleshooting docs key on.
-	if firstConflictErr != nil {
-		return "", fmt.Errorf("cosign %s failed after %d attempts: %w", subcommand, maxCosignAttempts, firstConflictErr)
+	// Report the first retryable failure rather than the last error. A later
+	// attempt can die for an incidental reason, and losing the
+	// createLogEntryConflict text strands the operator: that string is what the
+	// troubleshooting docs key on.
+	if firstRetryableErr != nil {
+		return "", fmt.Errorf("cosign %s failed after %d attempts: %w", subcommand, maxCosignAttempts, firstRetryableErr)
 	}
 	if lastErr != nil {
 		return "", lastErr
 	}
 	return "", fmt.Errorf("cosign %s not attempted: retry bound %d is non-positive", subcommand, maxCosignAttempts)
+}
+
+// artifactProbe is a read-only cosign invocation that answers "is the artifact
+// this attempt was meant to produce already attached to the image?".
+type artifactProbe struct {
+	args []string
+	what string
+}
+
+// probeFor derives the presence check for a cosign argv. Every call site in
+// this package appends the image reference last, which is what the probe reads.
+//
+// `cosign download signature|attestation` reads the registry only: it neither
+// contacts Rekor nor needs a verification key, so one probe covers the keyless
+// and the key-based signer. Anything other than sign/attest gets no probe and
+// keeps the plain retry-then-report behaviour.
+func probeFor(args []string) (artifactProbe, bool) {
+	if len(args) < 2 {
+		return artifactProbe{}, false
+	}
+	imageRef := args[len(args)-1]
+	if imageRef == "" || strings.HasPrefix(imageRef, "-") {
+		return artifactProbe{}, false
+	}
+
+	switch args[0] {
+	case "sign":
+		return artifactProbe{args: []string{"download", "signature", imageRef}, what: "signature"}, true
+	case "attest":
+		probe := []string{"download", "attestation"}
+		what := "attestation"
+		// `cosign attest --type` and `cosign download attestation
+		// --predicate-type` take the same vocabulary (shorthand names and full
+		// predicate URIs alike), so the type carries over verbatim. Without it
+		// the probe would answer "some attestation exists", and an SBOM
+		// attestation would mask a missing provenance one.
+		if t := flagValue(args, "--type"); t != "" {
+			probe = append(probe, "--predicate-type", t)
+			what = t + " attestation"
+		}
+		return artifactProbe{args: append(probe, imageRef), what: what}, true
+	}
+	return artifactProbe{}, false
+}
+
+// confirmArtifactAttached reports whether the registry already carries the
+// artifact the conflicting invocation was producing.
+//
+// Deliberately fail-closed: only a clean exit AND non-empty output count as
+// present. A probe that errors, times out, or prints nothing leaves the caller
+// on its existing retry-then-report path, so a broken probe can never convert a
+// genuine signing failure into a green deploy.
+func confirmArtifactAttached(ctx context.Context, args, env []string, timeout time.Duration, exec execFn) (string, bool) {
+	probe, ok := probeFor(args)
+	if !ok {
+		return "", false
+	}
+	if ctx.Err() != nil {
+		return probe.what, false
+	}
+	stdout, _, err := exec(ctx, "cosign", probe.args, env, timeout)
+	if err != nil || strings.TrimSpace(stdout) == "" {
+		return probe.what, false
+	}
+	return probe.what, true
+}
+
+// flagValue returns the value of `--name value` or `--name=value` in args.
+func flagValue(args []string, name string) string {
+	for i, a := range args {
+		if a == name && i+1 < len(args) {
+			return args[i+1]
+		}
+		if v, found := strings.CutPrefix(a, name+"="); found {
+			return v
+		}
+	}
+	return ""
 }
 
 // cosignBackoff returns a jittered delay before the given attempt, capped at

--- a/pkg/security/signing/rekor_retry.go
+++ b/pkg/security/signing/rekor_retry.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -23,6 +24,16 @@ import (
 // Rekor instance can stay hot for longer than the ~3s that three attempts
 // spanned.
 const maxCosignAttempts = 5
+
+// maxConfirmProbeTimeout caps a single confirmation probe.
+//
+// The probe used to inherit the caller's full sign/attest timeout, which makes
+// the worst case maxCosignAttempts x (timeout + timeout) plus backoff: ~20
+// minutes for an attacher on a 2-minute budget, against 6 minutes before
+// confirmation existed. A probe is one read-only registry round trip and a
+// signature check; if it needs more than this, treating it as "not confirmed"
+// and retrying the real operation is both faster and fail-closed.
+const maxConfirmProbeTimeout = 30 * time.Second
 
 // Backoff between retries. Both retryable classes are contention artifacts —
 // parallel deploys attesting against the public-good instance — so retrying
@@ -57,11 +68,16 @@ func isRekorConflict(output string) bool {
 // rekorGiveUpRe matches cosign exhausting its own HTTP retry budget against the
 // Rekor log-entries endpoint, e.g.
 //
-//	signing bundle: Post "https://rekor.sigstore.dev/api/v1/log/entries": EOF — giving up after 2 attempt(s)
+//	signing bundle: Post "https://rekor.example/api/v1/log/entries": EOF, giving up after 2 attempt(s)
 //
-// Both halves are required, and the URL must be a log-entries POST, so an
-// unrelated "giving up" from a registry or from Fulcio does not match.
-var rekorGiveUpRe = regexp.MustCompile(`(?s)Post "https?://[^"]+/api/v1/log/entries".{0,400}?giving up after \d+ attempt`)
+// The two halves must belong to the same message. An earlier version allowed up
+// to 400 arbitrary characters between them with (?s), which only required them
+// to appear near each other in the same stream: a log-entries POST that
+// returned 201, followed by a registry, Fulcio or OIDC give-up, matched and was
+// retried five times while the operator was pointed at the transparency-log
+// runbook. Excluding quotes and newlines from the gap keeps the match inside
+// one message, because every competing give-up names its own quoted URL first.
+var rekorGiveUpRe = regexp.MustCompile(`Post "https?://[^"\n]+/api/v1/log/entries": [^"\n]{0,200}giving up after \d+ attempt`)
 
 // isRekorTransient reports a transient failure to reach the transparency log:
 // cosign's internal HTTP client ran out of attempts posting the entry. Nothing
@@ -73,10 +89,67 @@ func isRekorTransient(output string) bool {
 	return rekorGiveUpRe.MatchString(output)
 }
 
-// RunCosignWithRetry runs `cosign <args>` and returns its stdout, retrying Rekor
-// entry conflicts. label names the operation in the retry warning ("sbom
-// attest"); the returned error is prefixed from args[0], so it reads "cosign
-// attest failed".
+// ConfirmProbe is the read-only cosign invocation that decides whether a Rekor
+// conflict is an idempotent no-op. Args is a cosign argv WITHOUT the image
+// reference; the retry loop appends the same image reference the conflicting
+// attempt used. What names the artifact in the log line.
+//
+// It must be a verify form, not a download form. `cosign download signature`
+// and `cosign download attestation` answer "is anything of this shape stored
+// under the legacy signature tag", which accepts a signature made under a
+// rotated key or an attestation of the same predicate family produced by an
+// unrelated workflow. They also return nothing at all under cosign v3, which
+// defaults to the new bundle format and stores nothing in the legacy tag: on a
+// current cosign the download probe never confirms, so every conflict runs the
+// loop to exhaustion and the operation fails. `cosign verify` and `cosign
+// verify-attestation` read both formats and check the identity, so a
+// confirmation means the artifact the caller wanted is present AND ours.
+//
+// The probe's exit code is the whole signal. Its stdout is not inspected:
+// cosign prints the verification banner to stderr, so requiring non-empty
+// stdout is another way to never confirm.
+type ConfirmProbe struct {
+	Args []string
+	What string
+}
+
+// probeEnvAllowlist is the set of environment variables a verify probe may
+// inherit from the signing invocation. Everything else is dropped, most
+// importantly SIGSTORE_ID_TOKEN: the probe mints no certificate, so handing the
+// OIDC identity token to an extra process buys nothing. (The probe still
+// inherits the ambient process environment, which this package does not own.)
+var probeEnvAllowlist = []string{
+	"COSIGN_PASSWORD",           // decrypts a private key handed to `verify --key`
+	"COSIGN_REPOSITORY",         // signatures kept in a separate OCI repository
+	"COSIGN_DOCKER_MEDIA_TYPES", // registry compatibility toggle
+	"DOCKER_CONFIG",             // registry credentials
+	"REGISTRY_AUTH_FILE",        // registry credentials
+}
+
+func probeEnv(env []string) []string {
+	var out []string
+	for _, kv := range env {
+		name, _, ok := strings.Cut(kv, "=")
+		if ok && slices.Contains(probeEnvAllowlist, name) {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// RunCosignWithRetry runs `cosign <args>` with no conflict confirmation: a
+// conflict is retried and then reported. See RunCosignWithRetryConfirm.
+func RunCosignWithRetry(ctx context.Context, label string, args, env []string, timeout time.Duration) (string, error) {
+	stdout, _, err := runCosignWithRetry(ctx, label, args, env, timeout, nil, tools.ExecCommand)
+	return stdout, err
+}
+
+// RunCosignWithRetryConfirm runs `cosign <args>` and returns its stdout,
+// retrying Rekor entry conflicts. label names the operation in the retry
+// warning ("sbom attest"); the returned error is prefixed from args[0], so it
+// reads "cosign attest failed". The second return value reports whether the run
+// ended by confirming an existing artifact rather than by producing a new one,
+// in which case stdout is empty because no fresh cosign output exists.
 //
 // Every attempt is a fresh process with its own full timeout budget. Under
 // keyless signing each invocation mints a new ephemeral certificate, so the body
@@ -87,15 +160,17 @@ func isRekorTransient(output string) bool {
 // end state of an idempotent re-run — a redeploy of an unchanged digest
 // regenerates a byte-identical predicate and lands there every time. It is not
 // proof on its own, because cosign uploads to Rekor before it pushes to the
-// registry, so each conflict is confirmed against the registry (see
-// confirmArtifactAttached): a confirmed conflict returns success, an
-// unconfirmed one is retried and then reported. A transient give-up against
-// the log-entries endpoint attached nothing, so it is simply retried.
-func RunCosignWithRetry(ctx context.Context, label string, args, env []string, timeout time.Duration) (string, error) {
-	return runCosignWithRetry(ctx, label, args, env, timeout, tools.ExecCommand)
+// registry, so each conflict is checked with confirm: a confirmed conflict
+// returns success, an unconfirmed one is retried and then reported. A transient
+// give-up against the log-entries endpoint attached nothing, so it is simply
+// retried. A nil confirm disables confirmation, which is the correct setting
+// wherever the caller cannot name the identity to verify against.
+func RunCosignWithRetryConfirm(ctx context.Context, label string, args, env []string, timeout time.Duration, confirm *ConfirmProbe) (string, error) {
+	stdout, _, err := runCosignWithRetry(ctx, label, args, env, timeout, confirm, tools.ExecCommand)
+	return stdout, err
 }
 
-func runCosignWithRetry(ctx context.Context, label string, args, env []string, timeout time.Duration, exec execFn) (string, error) {
+func runCosignWithRetry(ctx context.Context, label string, args, env []string, timeout time.Duration, confirm *ConfirmProbe, exec execFn) (string, bool, error) {
 	subcommand := label
 	if len(args) > 0 {
 		subcommand = args[0]
@@ -104,24 +179,24 @@ func runCosignWithRetry(ctx context.Context, label string, args, env []string, t
 	var firstRetryableErr, lastErr error
 	for attempt := 1; attempt <= maxCosignAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
-			return "", err
+			return "", false, err
 		}
 		if attempt > 1 {
 			if err := sleepWithContext(ctx, cosignBackoff(attempt)); err != nil {
-				return "", err
+				return "", false, err
 			}
 		}
 
 		stdout, stderr, err := exec(ctx, "cosign", args, env, timeout)
 		if err == nil {
-			return stdout, nil
+			return stdout, false, nil
 		}
 		lastErr = fmt.Errorf("cosign %s failed: %w\nStderr: %s\nStdout: %s", subcommand, err, stderr, stdout)
 
 		conflict := isRekorConflict(stderr) || isRekorConflict(stdout)
 		transient := isRekorTransient(stderr) || isRekorTransient(stdout)
 		if !conflict && !transient {
-			return "", lastErr
+			return "", false, lastErr
 		}
 		if firstRetryableErr == nil {
 			firstRetryableErr = lastErr
@@ -132,14 +207,12 @@ func runCosignWithRetry(ctx context.Context, label string, args, env []string, t
 		// entry. That is the normal outcome of redeploying an unchanged digest
 		// with a deterministic predicate. Re-signing it would be a no-op, so
 		// stop here and report success rather than failing a deploy over an
-		// artifact that is already in place.
-		if conflict {
-			if what, attached := confirmArtifactAttached(ctx, args, env, timeout, exec); attached {
-				fmt.Fprintf(os.Stderr,
-					"Rekor transparency-log conflict on cosign %s: %s already attached to the image, nothing to do\n",
-					label, what)
-				return "", nil
-			}
+		// artifact that is already in place and already verifies.
+		if conflict && confirmArtifactAttached(ctx, confirm, args, env, timeout, exec) {
+			fmt.Fprintf(os.Stderr,
+				"Rekor transparency-log conflict on cosign %s: %s already verifies against the image, nothing to do\n",
+				label, confirm.What)
+			return "", true, nil
 		}
 
 		if attempt < maxCosignAttempts {
@@ -157,90 +230,45 @@ func runCosignWithRetry(ctx context.Context, label string, args, env []string, t
 	// createLogEntryConflict text strands the operator: that string is what the
 	// troubleshooting docs key on.
 	if firstRetryableErr != nil {
-		return "", fmt.Errorf("cosign %s failed after %d attempts: %w", subcommand, maxCosignAttempts, firstRetryableErr)
+		return "", false, fmt.Errorf("cosign %s failed after %d attempts: %w", subcommand, maxCosignAttempts, firstRetryableErr)
 	}
 	if lastErr != nil {
-		return "", lastErr
+		return "", false, lastErr
 	}
-	return "", fmt.Errorf("cosign %s not attempted: retry bound %d is non-positive", subcommand, maxCosignAttempts)
+	return "", false, fmt.Errorf("cosign %s not attempted: retry bound %d is non-positive", subcommand, maxCosignAttempts)
 }
 
-// artifactProbe is a read-only cosign invocation that answers "is the artifact
-// this attempt was meant to produce already attached to the image?".
-type artifactProbe struct {
-	args []string
-	what string
-}
-
-// probeFor derives the presence check for a cosign argv. Every call site in
-// this package appends the image reference last, which is what the probe reads.
+// confirmArtifactAttached reports whether the image already carries the
+// artifact the conflicting invocation was producing, signed by the identity the
+// caller signs with.
 //
-// `cosign download signature|attestation` reads the registry only: it neither
-// contacts Rekor nor needs a verification key, so one probe covers the keyless
-// and the key-based signer. Anything other than sign/attest gets no probe and
-// keeps the plain retry-then-report behaviour.
-func probeFor(args []string) (artifactProbe, bool) {
-	if len(args) < 2 {
-		return artifactProbe{}, false
+// Deliberately fail-closed: a nil probe, an unusable argv, a probe that errors
+// and a probe that times out all leave the caller on its existing
+// retry-then-report path, so a broken probe can never convert a genuine signing
+// failure into a green deploy.
+func confirmArtifactAttached(ctx context.Context, confirm *ConfirmProbe, args, env []string, timeout time.Duration, exec execFn) bool {
+	if confirm == nil || len(confirm.Args) == 0 || len(args) < 2 {
+		return false
 	}
+	// Every call site in this package appends the image reference last.
 	imageRef := args[len(args)-1]
 	if imageRef == "" || strings.HasPrefix(imageRef, "-") {
-		return artifactProbe{}, false
-	}
-
-	switch args[0] {
-	case "sign":
-		return artifactProbe{args: []string{"download", "signature", imageRef}, what: "signature"}, true
-	case "attest":
-		probe := []string{"download", "attestation"}
-		what := "attestation"
-		// `cosign attest --type` and `cosign download attestation
-		// --predicate-type` take the same vocabulary (shorthand names and full
-		// predicate URIs alike), so the type carries over verbatim. Without it
-		// the probe would answer "some attestation exists", and an SBOM
-		// attestation would mask a missing provenance one.
-		if t := flagValue(args, "--type"); t != "" {
-			probe = append(probe, "--predicate-type", t)
-			what = t + " attestation"
-		}
-		return artifactProbe{args: append(probe, imageRef), what: what}, true
-	}
-	return artifactProbe{}, false
-}
-
-// confirmArtifactAttached reports whether the registry already carries the
-// artifact the conflicting invocation was producing.
-//
-// Deliberately fail-closed: only a clean exit AND non-empty output count as
-// present. A probe that errors, times out, or prints nothing leaves the caller
-// on its existing retry-then-report path, so a broken probe can never convert a
-// genuine signing failure into a green deploy.
-func confirmArtifactAttached(ctx context.Context, args, env []string, timeout time.Duration, exec execFn) (string, bool) {
-	probe, ok := probeFor(args)
-	if !ok {
-		return "", false
+		return false
 	}
 	if ctx.Err() != nil {
-		return probe.what, false
+		return false
 	}
-	stdout, _, err := exec(ctx, "cosign", probe.args, env, timeout)
-	if err != nil || strings.TrimSpace(stdout) == "" {
-		return probe.what, false
-	}
-	return probe.what, true
+	probeArgs := append(slices.Clone(confirm.Args), imageRef)
+	_, _, err := exec(ctx, "cosign", probeArgs, probeEnv(env), confirmProbeTimeout(timeout))
+	return err == nil
 }
 
-// flagValue returns the value of `--name value` or `--name=value` in args.
-func flagValue(args []string, name string) string {
-	for i, a := range args {
-		if a == name && i+1 < len(args) {
-			return args[i+1]
-		}
-		if v, found := strings.CutPrefix(a, name+"="); found {
-			return v
-		}
+// confirmProbeTimeout bounds the probe independently of the signing budget.
+func confirmProbeTimeout(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return maxConfirmProbeTimeout
 	}
-	return ""
+	return min(timeout, maxConfirmProbeTimeout)
 }
 
 // cosignBackoff returns a jittered delay before the given attempt, capped at

--- a/pkg/security/signing/rekor_retry_test.go
+++ b/pkg/security/signing/rekor_retry_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/simple-container-com/api/pkg/security/tools/cosigntest"
 )
 
 // conflictStderr reproduces the cosign stderr shape observed when several deploy
@@ -31,27 +33,44 @@ func noBackoff(t *testing.T) {
 	t.Cleanup(func() { cosignBaseBackoff = orig })
 }
 
-// probeAbsent wraps a fake exec so the read-only presence probe
-// (`cosign download signature|attestation`) reports nothing attached. Attempt
-// counts in the wrapped fake then stay about sign/attest invocations only.
+// attestConfirm is the confirmation probe an SBOM attest carries in production:
+// a typed verify-attestation bound to a verification key, with the image
+// reference left off for the retry loop to append.
+var attestConfirm = &ConfirmProbe{
+	Args: []string{"verify-attestation", "--type", "cyclonedx", "--key", "/tmp/cosign.pub"},
+	What: "cyclonedx attestation",
+}
+
+// isProbe reports whether an argv is the read-only confirmation probe rather
+// than the sign/attest under test.
+func isProbe(args []string) bool {
+	return len(args) > 0 && (args[0] == "verify" || args[0] == "verify-attestation")
+}
+
+// probeAbsent wraps a fake exec so the confirmation probe reports the artifact
+// as not verifiable. Attempt counts in the wrapped fake then stay about
+// sign/attest invocations only.
 func probeAbsent(exec execFn) execFn {
 	return func(ctx context.Context, name string, args, env []string, timeout time.Duration) (string, string, error) {
-		if len(args) > 0 && args[0] == "download" {
+		if isProbe(args) {
 			return "", "Error: no matching attestations", fmt.Errorf("exit status 1")
 		}
 		return exec(ctx, name, args, env, timeout)
 	}
 }
 
-// probePresent is probeAbsent's twin: the probe reports the artifact already on
-// the image, which is what a redeploy of an unchanged digest sees.
+// probePresent is probeAbsent's twin: the probe verifies, which is what a
+// redeploy of an unchanged digest sees. It returns empty stdout on purpose.
+// cosign writes its verification banner to stderr and prints nothing on stdout
+// for `verify`, so a loop that demanded non-empty stdout could never confirm
+// against a real cosign.
 func probePresent(exec execFn, probes *int) execFn {
 	return func(ctx context.Context, name string, args, env []string, timeout time.Duration) (string, string, error) {
-		if len(args) > 0 && args[0] == "download" {
+		if isProbe(args) {
 			if probes != nil {
 				*probes++
 			}
-			return `{"payloadType":"application/vnd.in-toto+json","payload":"e30="}`, "", nil
+			return "", "Verification for registry.example.com/team/app --\n", nil
 		}
 		return exec(ctx, name, args, env, timeout)
 	}
@@ -77,7 +96,7 @@ func TestRunCosignWithRetry_SucceedsOnRetry(t *testing.T) {
 		return "tlog entry created with index: 123456", "", nil
 	}
 
-	out, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	out, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(out).To(Equal("tlog entry created with index: 123456"))
@@ -98,7 +117,7 @@ func TestRunCosignWithRetry_ClassifiesConflictOnStdout(t *testing.T) {
 		return "ok", "", nil
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(calls).To(Equal(2), "a conflict on stdout must be retried too")
@@ -119,7 +138,7 @@ func TestRunCosignWithRetry_RegistryConflictPlusRekorURLIsNotAConflict(t *testin
 			fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(calls).To(Equal(1), "a registry 409 must fail fast, not retry")
@@ -135,7 +154,7 @@ func TestRunCosignWithRetry_NoRetryOnOtherErrors(t *testing.T) {
 		return "", "error signing: getting signer: oidc: token expired", fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("token expired"))
@@ -156,7 +175,7 @@ func TestRunCosignWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
@@ -180,7 +199,7 @@ func TestRunCosignWithRetry_SurfacesFirstConflictNotLastError(t *testing.T) {
 		return "", "", fmt.Errorf("signal: killed")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("signal: killed"))
@@ -200,7 +219,7 @@ func TestRunCosignWithRetry_SucceedsOnFinalAllowedAttempt(t *testing.T) {
 		return "ok", "", nil
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(calls).To(Equal(maxCosignAttempts))
@@ -218,7 +237,7 @@ func TestRunCosignWithRetry_ConflictTextOnSuccessIsIgnored(t *testing.T) {
 		return conflictStderr, "", nil
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(calls).To(Equal(1))
@@ -237,7 +256,7 @@ func TestRunCosignWithRetry_StopsOnCancelledContext(t *testing.T) {
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(ctx, "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(ctx, "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).To(MatchError(context.Canceled))
 	Expect(calls).To(Equal(0), "a cancelled context must not invoke cosign")
@@ -255,7 +274,7 @@ func TestRunCosignWithRetry_EachAttemptGetsFullTimeout(t *testing.T) {
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, _ = runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, 90*time.Second, probeAbsent(exec))
+	_, _, _ = runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, 90*time.Second, attestConfirm, probeAbsent(exec))
 
 	Expect(seen).To(HaveLen(maxCosignAttempts))
 	for i, d := range seen {
@@ -337,7 +356,7 @@ func TestRunCosignWithRetry_ConfirmedConflictIsSuccess(t *testing.T) {
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	out, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probePresent(exec, &probes))
+	out, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probePresent(exec, &probes))
 
 	Expect(err).ToNot(HaveOccurred(), "a conflict confirmed against the registry is an idempotent success")
 	Expect(out).To(BeEmpty(), "no fresh cosign output to report")
@@ -345,42 +364,54 @@ func TestRunCosignWithRetry_ConfirmedConflictIsSuccess(t *testing.T) {
 	Expect(probes).To(Equal(1))
 }
 
-// The probe must ask about the exact artifact the attempt was producing.
-// Dropping --predicate-type would let an existing SBOM attestation stand in for
-// a missing provenance one.
+// The probe must ask about the exact artifact the attempt was producing, under
+// the identity the caller signs with, against the image the attempt targeted.
+// Dropping --type would let an existing SBOM attestation stand in for a missing
+// provenance one; dropping the identity flags would accept an artifact produced
+// under a rotated key or by an unrelated workflow.
 func TestRunCosignWithRetry_ProbeTargetsTheSpecificArtifact(t *testing.T) {
 	RegisterTestingT(t)
-	noBackoff(t)
+
+	const imageRef = "registry.example.com/team/app@sha256:abc"
+	keyless := &Config{Keyless: true, IdentityRegexp: "^https://example.test/wf@refs/heads/main$", OIDCIssuer: "https://token.example.test"}
+	keyed := &Config{PublicKey: "/tmp/cosign.pub"}
 
 	tests := []struct {
 		name      string
 		args      []string
+		confirm   *ConfirmProbe
 		wantProbe []string
 	}{
 		{
-			name:      "keyless sign probes the signature",
-			args:      []string{"sign", "--yes", "registry.example.com/team/app@sha256:abc"},
-			wantProbe: []string{"download", "signature", "registry.example.com/team/app@sha256:abc"},
-		},
-		{
-			name:      "key-based sign probes the signature",
-			args:      []string{"sign", "--key", "/tmp/cosign.key", "registry.example.com/team/app@sha256:abc"},
-			wantProbe: []string{"download", "signature", "registry.example.com/team/app@sha256:abc"},
-		},
-		{
-			name: "sbom attest probes the cyclonedx attestation",
-			args: []string{"attest", "--predicate", "/tmp/p.json", "--type", "cyclonedx", "--yes", "registry.example.com/team/app@sha256:abc"},
+			name:    "keyless sign verifies the signature under the signing identity",
+			args:    []string{"sign", "--yes", imageRef},
+			confirm: keyless.SignatureConfirmProbe(),
 			wantProbe: []string{
-				"download", "attestation", "--predicate-type", "cyclonedx",
-				"registry.example.com/team/app@sha256:abc",
+				"verify",
+				"--certificate-identity-regexp", "^https://example.test/wf@refs/heads/main$",
+				"--certificate-oidc-issuer", "https://token.example.test",
+				imageRef,
 			},
 		},
 		{
-			name: "provenance attest probes its own predicate URI",
-			args: []string{"attest", "--predicate", "/tmp/p.json", "--type", "https://slsa.dev/provenance/v1", "--yes", "registry.example.com/team/app@sha256:abc"},
+			name:      "key-based sign verifies the signature under the key",
+			args:      []string{"sign", "--key", "/tmp/cosign.key", imageRef},
+			confirm:   &ConfirmProbe{Args: []string{"verify", "--key", "/tmp/cosign.key"}, What: "signature"},
+			wantProbe: []string{"verify", "--key", "/tmp/cosign.key", imageRef},
+		},
+		{
+			name:      "sbom attest verifies the cyclonedx attestation",
+			args:      []string{"attest", "--predicate", "/tmp/p.json", "--type", "cyclonedx", "--yes", imageRef},
+			confirm:   keyed.AttestationConfirmProbe("cyclonedx"),
+			wantProbe: []string{"verify-attestation", "--type", "cyclonedx", "--key", "/tmp/cosign.pub", imageRef},
+		},
+		{
+			name:    "provenance attest verifies its own predicate URI",
+			args:    []string{"attest", "--predicate", "/tmp/p.json", "--type", "https://slsa.dev/provenance/v1", "--yes", imageRef},
+			confirm: keyed.AttestationConfirmProbe("https://slsa.dev/provenance/v1"),
 			wantProbe: []string{
-				"download", "attestation", "--predicate-type", "https://slsa.dev/provenance/v1",
-				"registry.example.com/team/app@sha256:abc",
+				"verify-attestation", "--type", "https://slsa.dev/provenance/v1",
+				"--key", "/tmp/cosign.pub", imageRef,
 			},
 		},
 	}
@@ -390,41 +421,123 @@ func TestRunCosignWithRetry_ProbeTargetsTheSpecificArtifact(t *testing.T) {
 			RegisterTestingT(t)
 			var seen []string
 			exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
-				if len(args) > 0 && args[0] == "download" {
+				if isProbe(args) {
 					seen = args
-					return `{"payload":"e30="}`, "", nil
+					return "", "", nil
 				}
 				return "", conflictStderr, fmt.Errorf("exit status 1")
 			}
 
-			_, err := runCosignWithRetry(context.Background(), "attest", tt.args, nil, time.Minute, exec)
+			_, confirmed, err := runCosignWithRetry(context.Background(), "attest", tt.args, nil, time.Minute, tt.confirm, exec)
 
 			Expect(err).ToNot(HaveOccurred())
+			Expect(confirmed).To(BeTrue())
 			Expect(seen).To(Equal(tt.wantProbe))
 		})
 	}
 }
 
-// Fail-closed: the probe only confirms on a clean exit AND real output. A
-// cosign build that exits 0 while printing nothing must not turn a genuine
-// signing failure into a green deploy.
-func TestRunCosignWithRetry_EmptyProbeOutputIsNotConfirmation(t *testing.T) {
+// The probe argv the loop builds must not alias the caller's ConfirmProbe.
+// Appending the image reference in place would grow a shared backing array and
+// leave the next probe carrying the previous image.
+func TestRunCosignWithRetry_ProbeDoesNotMutateTheCallersArgs(t *testing.T) {
 	RegisterTestingT(t)
 	noBackoff(t)
 
-	attempts := 0
+	confirm := &ConfirmProbe{Args: []string{"verify", "--key", "/tmp/cosign.pub"}, What: "signature"}
+	before := append([]string(nil), confirm.Args...)
+
 	exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
-		if len(args) > 0 && args[0] == "download" {
-			return "   \n", "", nil
+		if isProbe(args) {
+			return "", "", fmt.Errorf("exit status 1")
+		}
+		return "", conflictStderr, fmt.Errorf("exit status 1")
+	}
+
+	_, _, _ = runCosignWithRetry(context.Background(), "sign",
+		[]string{"sign", "--yes", "registry.example.com/team/app@sha256:abc"}, nil, time.Minute, confirm, exec)
+
+	Expect(confirm.Args).To(Equal(before), "the loop must clone the probe argv before appending the image")
+}
+
+// The probe's exit status is the whole signal. `cosign verify` writes its
+// banner to stderr and nothing to stdout, so the earlier rule of "clean exit
+// AND non-empty stdout" could never confirm against a real cosign. The
+// converse still has to hold: output without a clean exit confirms nothing.
+func TestRunCosignWithRetry_ExitCodeIsTheConfirmationSignal(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		name         string
+		probeStdout  string
+		probeErr     error
+		wantErr      bool
+		wantAttempts int
+	}{
+		{
+			name:         "exit 0 with empty stdout confirms",
+			wantAttempts: 1,
+		},
+		{
+			name:         "non-zero exit confirms nothing, however much it prints",
+			probeStdout:  `{"payloadType":"application/vnd.in-toto+json","payload":"e30="}`,
+			probeErr:     fmt.Errorf("exit status 1"),
+			wantErr:      true,
+			wantAttempts: maxCosignAttempts,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			noBackoff(t)
+
+			attempts := 0
+			exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
+				if isProbe(args) {
+					return tt.probeStdout, "", tt.probeErr
+				}
+				attempts++
+				return "", conflictStderr, fmt.Errorf("exit status 1")
+			}
+
+			_, confirmed, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, exec)
+
+			if tt.wantErr {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+				Expect(confirmed).To(BeFalse())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(confirmed).To(BeTrue())
+			}
+			Expect(attempts).To(Equal(tt.wantAttempts))
+		})
+	}
+}
+
+// A caller that cannot name an identity to verify against passes no probe. It
+// must keep the retry-then-report path rather than assume the conflict benign:
+// signing an image the caller cannot verify is not the same as having signed it.
+func TestRunCosignWithRetry_NilConfirmNeverProbes(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	attempts, probes := 0, 0
+	exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
+		if isProbe(args) {
+			probes++
+			return "", "", nil
 		}
 		attempts++
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, confirmed, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, nil, exec)
 
 	Expect(err).To(HaveOccurred())
-	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+	Expect(confirmed).To(BeFalse())
+	Expect(probes).To(Equal(0))
 	Expect(attempts).To(Equal(maxCosignAttempts))
 }
 
@@ -435,18 +548,18 @@ func TestRunCosignWithRetry_ConflictConfirmedOnLaterAttempt(t *testing.T) {
 
 	attempts, probes := 0, 0
 	exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
-		if len(args) > 0 && args[0] == "download" {
+		if isProbe(args) {
 			probes++
 			if probes < 3 {
 				return "", "Error: no matching attestations", fmt.Errorf("exit status 1")
 			}
-			return `{"payload":"e30="}`, "", nil
+			return "", "", nil
 		}
 		attempts++
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, exec)
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(attempts).To(Equal(3))
@@ -461,7 +574,7 @@ func TestRunCosignWithRetry_RetriesTransientRekorGiveUp(t *testing.T) {
 
 	attempts, probes := 0, 0
 	exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
-		if len(args) > 0 && args[0] == "download" {
+		if isProbe(args) {
 			probes++
 			return "", "", fmt.Errorf("probe must not run for a transient failure")
 		}
@@ -472,7 +585,7 @@ func TestRunCosignWithRetry_RetriesTransientRekorGiveUp(t *testing.T) {
 		return "tlog entry created with index: 7", "", nil
 	}
 
-	out, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	out, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, exec)
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(out).To(Equal("tlog entry created with index: 7"))
@@ -490,7 +603,7 @@ func TestRunCosignWithRetry_PersistentGiveUpStillFails(t *testing.T) {
 		return "", giveUpStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+	_, _, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, attestConfirm, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("giving up after 2 attempt"))
@@ -527,6 +640,35 @@ func TestIsRekorTransient(t *testing.T) {
 			output: `Post "https://rekor.sigstore.dev/api/v1/log/entries": 201 Created`,
 			want:   false,
 		},
+		// The three below all matched before the pattern was tightened. The old
+		// form allowed 400 arbitrary characters between the two halves with
+		// (?s), so a successful log-entry POST followed anywhere in the same
+		// stream by an unrelated give-up read as a transparency-log hiccup: a
+		// permanent registry-auth failure was retried five times and the
+		// operator was sent to the wrong runbook.
+		{
+			name: "successful log-entry POST followed by a registry give-up",
+			output: `Post "https://rekor.sigstore.dev/api/v1/log/entries": 201 Created` + "\n" +
+				`pushing signature: Put "https://registry.example.com/v2/team/app/manifests/sha256-abc": unauthorized, giving up after 3 attempt(s)`,
+			want: false,
+		},
+		{
+			name: "successful log-entry POST followed by a fulcio give-up",
+			output: `Post "https://rekor.sigstore.dev/api/v1/log/entries": 201 Created` + "\n" +
+				`Post "https://fulcio.sigstore.dev/api/v2/signingCert": EOF, giving up after 2 attempt(s)`,
+			want: false,
+		},
+		{
+			name: "successful log-entry POST followed by an OIDC give-up",
+			output: `Post "https://rekor.sigstore.dev/api/v1/log/entries": 201 Created` + "\n" +
+				`fetching ambient token: Post "https://oauth2.example.test/token": EOF, giving up after 5 attempt(s)`,
+			want: false,
+		},
+		{
+			name:   "a give-up whose quoted URL is a different endpoint on the same host",
+			output: `Post "https://rekor.sigstore.dev/api/v1/index/retrieve": EOF, giving up after 2 attempt(s)`,
+			want:   false,
+		},
 		{name: "a plain conflict is not the transient class", output: conflictStderr, want: false},
 		{name: "empty", output: "", want: false},
 	}
@@ -539,38 +681,181 @@ func TestIsRekorTransient(t *testing.T) {
 	}
 }
 
-func TestProbeFor(t *testing.T) {
+// The probe must not inherit the signing budget. With it, the worst case per
+// artifact became maxCosignAttempts x (timeout + timeout) plus backoff: about
+// 20 minutes for an attacher on a 2-minute budget, against 6 minutes before
+// confirmation existed, and both attachers run per image.
+func TestRunCosignWithRetry_ProbeTimeoutIsBoundedIndependently(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	const signBudget = 5 * time.Minute
+	var signTimeouts, probeTimeouts []time.Duration
+	exec := func(_ context.Context, _ string, args, _ []string, timeout time.Duration) (string, string, error) {
+		if isProbe(args) {
+			probeTimeouts = append(probeTimeouts, timeout)
+			return "", "", fmt.Errorf("exit status 1")
+		}
+		signTimeouts = append(signTimeouts, timeout)
+		return "", conflictStderr, fmt.Errorf("exit status 1")
+	}
+
+	_, _, _ = runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, signBudget, attestConfirm, exec)
+
+	Expect(signTimeouts).To(HaveLen(maxCosignAttempts))
+	for i, d := range signTimeouts {
+		Expect(d).To(Equal(signBudget), "signing attempt %d must keep the full budget", i+1)
+	}
+	Expect(probeTimeouts).To(HaveLen(maxCosignAttempts))
+	for i, d := range probeTimeouts {
+		Expect(d).To(Equal(maxConfirmProbeTimeout), "probe %d must be capped independently", i+1)
+	}
+}
+
+func TestConfirmProbeTimeout(t *testing.T) {
 	RegisterTestingT(t)
 
+	Expect(maxConfirmProbeTimeout).To(Equal(30*time.Second), "the cap is what bounds the worst case; pinned deliberately")
+	Expect(confirmProbeTimeout(5 * time.Minute)).To(Equal(maxConfirmProbeTimeout))
+	Expect(confirmProbeTimeout(2 * time.Minute)).To(Equal(maxConfirmProbeTimeout))
+	Expect(confirmProbeTimeout(10*time.Second)).To(Equal(10*time.Second), "a budget under the cap is used as is")
+	Expect(confirmProbeTimeout(0)).To(Equal(maxConfirmProbeTimeout))
+	Expect(confirmProbeTimeout(-time.Second)).To(Equal(maxConfirmProbeTimeout))
+}
+
+// The probe reads the registry. It mints no certificate, so it has no business
+// holding the OIDC identity token the signing invocation was given.
+func TestRunCosignWithRetry_ProbeDropsTheIdentityToken(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	signEnv := []string{
+		"COSIGN_EXPERIMENTAL=1",
+		"SIGSTORE_ID_TOKEN=header.payload.signature",
+		"COSIGN_PASSWORD=pw",
+		"DOCKER_CONFIG=/tmp/docker",
+		"MALFORMED",
+	}
+
+	var seenSignEnv, seenProbeEnv []string
+	exec := func(_ context.Context, _ string, args, env []string, _ time.Duration) (string, string, error) {
+		if isProbe(args) {
+			seenProbeEnv = env
+			return "", "", nil
+		}
+		seenSignEnv = env
+		return "", conflictStderr, fmt.Errorf("exit status 1")
+	}
+
+	_, confirmed, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, signEnv, time.Minute, attestConfirm, exec)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(confirmed).To(BeTrue())
+	Expect(seenSignEnv).To(Equal(signEnv), "signing itself still needs the token")
+	Expect(seenProbeEnv).To(Equal([]string{"COSIGN_PASSWORD=pw", "DOCKER_CONFIG=/tmp/docker"}))
+}
+
+func TestConfig_ConfirmProbes(t *testing.T) {
+	RegisterTestingT(t)
+
+	const (
+		ident  = "^https://example.test/wf@refs/heads/main$"
+		issuer = "https://token.example.test"
+	)
+
 	tests := []struct {
-		name string
-		args []string
-		ok   bool
-		what string
+		name       string
+		cfg        *Config
+		wantSign   []string
+		wantAttest []string
 	}{
-		{name: "sign", args: []string{"sign", "--yes", "img"}, ok: true, what: "signature"},
-		{name: "untyped attest", args: []string{"attest", "--predicate", "p", "img"}, ok: true, what: "attestation"},
 		{
-			name: "typed attest", args: []string{"attest", "--type=cyclonedx", "img"},
-			ok: true, what: "cyclonedx attestation",
+			name:       "keyless with a complete identity",
+			cfg:        &Config{Keyless: true, IdentityRegexp: ident, OIDCIssuer: issuer},
+			wantSign:   []string{"verify", "--certificate-identity-regexp", ident, "--certificate-oidc-issuer", issuer},
+			wantAttest: []string{"verify-attestation", "--type", "cyclonedx", "--certificate-identity-regexp", ident, "--certificate-oidc-issuer", issuer},
 		},
-		{name: "unknown subcommand gets no probe", args: []string{"copy", "a", "b"}, ok: false},
-		{name: "verify gets no probe", args: []string{"verify", "--key", "k", "img"}, ok: false},
-		{name: "argv too short", args: []string{"sign"}, ok: false},
-		{name: "trailing flag is not an image ref", args: []string{"sign", "--yes"}, ok: false},
-		{name: "empty argv", args: nil, ok: false},
+		{name: "keyless without an issuer cannot attribute a signature", cfg: &Config{Keyless: true, IdentityRegexp: ident}},
+		{name: "keyless without an identity regexp cannot attribute a signature", cfg: &Config{Keyless: true, OIDCIssuer: issuer}},
+		{
+			name:       "key-based prefers the public key",
+			cfg:        &Config{PublicKey: "/tmp/cosign.pub", PrivateKey: "/tmp/cosign.key"},
+			wantSign:   []string{"verify", "--key", "/tmp/cosign.pub"},
+			wantAttest: []string{"verify-attestation", "--type", "cyclonedx", "--key", "/tmp/cosign.pub"},
+		},
+		{
+			name:       "key-based falls back to the signing key, which cosign can derive the public half from",
+			cfg:        &Config{PrivateKey: "/tmp/cosign.key"},
+			wantSign:   []string{"verify", "--key", "/tmp/cosign.key"},
+			wantAttest: []string{"verify-attestation", "--type", "cyclonedx", "--key", "/tmp/cosign.key"},
+		},
+		{name: "no key material at all", cfg: &Config{}},
+		{name: "nil config", cfg: nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			RegisterTestingT(t)
-			probe, ok := probeFor(tt.args)
-			Expect(ok).To(Equal(tt.ok))
-			if tt.ok {
-				Expect(probe.what).To(Equal(tt.what))
-				Expect(probe.args[0]).To(Equal("download"))
-				Expect(probe.args[len(probe.args)-1]).To(Equal("img"))
+
+			sign := tt.cfg.SignatureConfirmProbe()
+			attest := tt.cfg.AttestationConfirmProbe("cyclonedx")
+
+			if tt.wantSign == nil {
+				Expect(sign).To(BeNil(), "a probe that cannot check identity must not exist")
+				Expect(attest).To(BeNil())
+				return
 			}
+			Expect(sign).ToNot(BeNil())
+			Expect(sign.Args).To(Equal(tt.wantSign))
+			Expect(sign.What).To(Equal("signature"))
+			Expect(attest).ToNot(BeNil())
+			Expect(attest.Args).To(Equal(tt.wantAttest))
+			Expect(attest.What).To(Equal("cyclonedx attestation"))
 		})
 	}
+
+	Expect((&Config{PublicKey: "/tmp/cosign.pub"}).AttestationConfirmProbe("")).To(BeNil(),
+		"an untyped verify-attestation accepts any predicate, which is the bug this replaced")
+}
+
+// The two exported wrappers, driven through the real exec path rather than an
+// injected fake, so the argv actually reaches a process. RunCosignWithRetry is
+// the no-confirmation form: it must retry a conflict and never probe.
+func TestExportedWrappers_DriveTheRealExecPath(t *testing.T) {
+	t.Run("RunCosignWithRetry retries a conflict without probing", func(t *testing.T) {
+		RegisterTestingT(t)
+		noBackoff(t)
+
+		fake := cosigntest.Install(t, cosigntest.Options{ConflictsBefore: 1})
+
+		out, err := RunCosignWithRetry(context.Background(), "sbom attest",
+			[]string{"attest", "--predicate", "/tmp/p.json", "registry.example.com/team/app@sha256:abc"},
+			nil, 30*time.Second)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("tlog entry created with index"))
+		Expect(fake.Calls(t)).To(Equal(2))
+		Expect(fake.Probes(t)).To(Equal(0), "no probe was supplied, so none may run")
+	})
+
+	t.Run("RunCosignWithRetryConfirm confirms a permanent conflict", func(t *testing.T) {
+		RegisterTestingT(t)
+		noBackoff(t)
+
+		const image = "registry.example.com/team/app@sha256:abc"
+		fake := cosigntest.Install(t, cosigntest.Options{
+			ConflictsBefore:         99,
+			ArtifactAlreadyAttached: true,
+			Image:                   image,
+		})
+
+		out, err := RunCosignWithRetryConfirm(context.Background(), "sbom attest",
+			[]string{"attest", "--predicate", "/tmp/p.json", "--type", "cyclonedx", image},
+			nil, 30*time.Second, attestConfirm)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(BeEmpty(), "nothing fresh was produced")
+		Expect(fake.Calls(t)).To(Equal(1))
+		Expect(fake.LastProbeArgs(t)).To(Equal(append(append([]string{}, attestConfirm.Args...), image)))
+	})
 }

--- a/pkg/security/signing/rekor_retry_test.go
+++ b/pkg/security/signing/rekor_retry_test.go
@@ -31,11 +31,37 @@ func noBackoff(t *testing.T) {
 	t.Cleanup(func() { cosignBaseBackoff = orig })
 }
 
+// probeAbsent wraps a fake exec so the read-only presence probe
+// (`cosign download signature|attestation`) reports nothing attached. Attempt
+// counts in the wrapped fake then stay about sign/attest invocations only.
+func probeAbsent(exec execFn) execFn {
+	return func(ctx context.Context, name string, args, env []string, timeout time.Duration) (string, string, error) {
+		if len(args) > 0 && args[0] == "download" {
+			return "", "Error: no matching attestations", fmt.Errorf("exit status 1")
+		}
+		return exec(ctx, name, args, env, timeout)
+	}
+}
+
+// probePresent is probeAbsent's twin: the probe reports the artifact already on
+// the image, which is what a redeploy of an unchanged digest sees.
+func probePresent(exec execFn, probes *int) execFn {
+	return func(ctx context.Context, name string, args, env []string, timeout time.Duration) (string, string, error) {
+		if len(args) > 0 && args[0] == "download" {
+			if probes != nil {
+				*probes++
+			}
+			return `{"payloadType":"application/vnd.in-toto+json","payload":"e30="}`, "", nil
+		}
+		return exec(ctx, name, args, env, timeout)
+	}
+}
+
 // Pins the retry bound. Without this every call-count assertion derives from the
-// constant itself, so widening 3 -> 5 would go unnoticed.
+// constant itself, so widening 5 -> 7 would go unnoticed.
 func TestMaxCosignAttempts_IsPinned(t *testing.T) {
 	RegisterTestingT(t)
-	Expect(maxCosignAttempts).To(Equal(3))
+	Expect(maxCosignAttempts).To(Equal(5))
 }
 
 func TestRunCosignWithRetry_SucceedsOnRetry(t *testing.T) {
@@ -51,7 +77,7 @@ func TestRunCosignWithRetry_SucceedsOnRetry(t *testing.T) {
 		return "tlog entry created with index: 123456", "", nil
 	}
 
-	out, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	out, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(out).To(Equal("tlog entry created with index: 123456"))
@@ -72,7 +98,7 @@ func TestRunCosignWithRetry_ClassifiesConflictOnStdout(t *testing.T) {
 		return "ok", "", nil
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(calls).To(Equal(2), "a conflict on stdout must be retried too")
@@ -93,7 +119,7 @@ func TestRunCosignWithRetry_RegistryConflictPlusRekorURLIsNotAConflict(t *testin
 			fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(calls).To(Equal(1), "a registry 409 must fail fast, not retry")
@@ -109,17 +135,17 @@ func TestRunCosignWithRetry_NoRetryOnOtherErrors(t *testing.T) {
 		return "", "error signing: getting signer: oidc: token expired", fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("token expired"))
 	Expect(calls).To(Equal(1))
 }
 
-// A fresh invocation always produces a new signature, so exhausting the loop
-// means a persistent server-side condition. Surfacing it is correct: cosign
-// uploads to Rekor before it pushes to the registry, so a tlog entry does not
-// prove the attestation landed.
+// A conflict the registry cannot confirm means the artifact is genuinely not
+// attached, so exhausting the loop must still fail. Surfacing it is correct:
+// cosign uploads to Rekor before it pushes to the registry, so a tlog entry on
+// its own does not prove the attestation landed.
 func TestRunCosignWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 	RegisterTestingT(t)
 	noBackoff(t)
@@ -130,11 +156,11 @@ func TestRunCosignWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
-	Expect(err.Error()).To(ContainSubstring("after 3 attempts"))
+	Expect(err.Error()).To(ContainSubstring("after 5 attempts"))
 	Expect(err.Error()).To(ContainSubstring("cosign attest failed"), "prefix comes from args[0]")
 	Expect(calls).To(Equal(maxCosignAttempts))
 }
@@ -154,7 +180,7 @@ func TestRunCosignWithRetry_SurfacesFirstConflictNotLastError(t *testing.T) {
 		return "", "", fmt.Errorf("signal: killed")
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("signal: killed"))
@@ -174,7 +200,7 @@ func TestRunCosignWithRetry_SucceedsOnFinalAllowedAttempt(t *testing.T) {
 		return "ok", "", nil
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(calls).To(Equal(maxCosignAttempts))
@@ -192,7 +218,7 @@ func TestRunCosignWithRetry_ConflictTextOnSuccessIsIgnored(t *testing.T) {
 		return conflictStderr, "", nil
 	}
 
-	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(calls).To(Equal(1))
@@ -211,7 +237,7 @@ func TestRunCosignWithRetry_StopsOnCancelledContext(t *testing.T) {
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, err := runCosignWithRetry(ctx, "sbom attest", attestArgs, nil, time.Minute, exec)
+	_, err := runCosignWithRetry(ctx, "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
 
 	Expect(err).To(MatchError(context.Canceled))
 	Expect(calls).To(Equal(0), "a cancelled context must not invoke cosign")
@@ -229,7 +255,7 @@ func TestRunCosignWithRetry_EachAttemptGetsFullTimeout(t *testing.T) {
 		return "", conflictStderr, fmt.Errorf("exit status 1")
 	}
 
-	_, _ = runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, 90*time.Second, exec)
+	_, _ = runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, 90*time.Second, probeAbsent(exec))
 
 	Expect(seen).To(HaveLen(maxCosignAttempts))
 	for i, d := range seen {
@@ -289,4 +315,262 @@ func TestCosignBackoff_ZeroBaseDisablesDelay(t *testing.T) {
 
 	Expect(cosignBackoff(2)).To(Equal(time.Duration(0)))
 	Expect(cosignBackoff(5)).To(Equal(time.Duration(0)))
+}
+
+// giveUpStderr reproduces cosign exhausting its own HTTP retry budget against
+// the Rekor log-entries endpoint, the shape seen when several deploys of the
+// same digest hit the public-good instance together.
+const giveUpStderr = `Error: signing registry.example.com/team/worker@sha256:f7ed9277c480591d7ec36fe7da13e112b33d898b7687f9bcbcda5c214a242099: ` +
+	`signing bundle: Post "https://rekor.sigstore.dev/api/v1/log/entries": ` +
+	`net/http: TLS handshake timeout, giving up after 2 attempt(s)`
+
+// The whole point of the fix: an entry that Rekor already holds, for an
+// artifact the registry already carries, is the desired end state. It must not
+// fail the deploy, and it must not burn the retry budget getting there.
+func TestRunCosignWithRetry_ConfirmedConflictIsSuccess(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	attempts, probes := 0, 0
+	exec := func(_ context.Context, _ string, _, _ []string, _ time.Duration) (string, string, error) {
+		attempts++
+		return "", conflictStderr, fmt.Errorf("exit status 1")
+	}
+
+	out, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probePresent(exec, &probes))
+
+	Expect(err).ToNot(HaveOccurred(), "a conflict confirmed against the registry is an idempotent success")
+	Expect(out).To(BeEmpty(), "no fresh cosign output to report")
+	Expect(attempts).To(Equal(1), "confirmation must short-circuit the retry loop, not run it to exhaustion")
+	Expect(probes).To(Equal(1))
+}
+
+// The probe must ask about the exact artifact the attempt was producing.
+// Dropping --predicate-type would let an existing SBOM attestation stand in for
+// a missing provenance one.
+func TestRunCosignWithRetry_ProbeTargetsTheSpecificArtifact(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantProbe []string
+	}{
+		{
+			name:      "keyless sign probes the signature",
+			args:      []string{"sign", "--yes", "registry.example.com/team/app@sha256:abc"},
+			wantProbe: []string{"download", "signature", "registry.example.com/team/app@sha256:abc"},
+		},
+		{
+			name:      "key-based sign probes the signature",
+			args:      []string{"sign", "--key", "/tmp/cosign.key", "registry.example.com/team/app@sha256:abc"},
+			wantProbe: []string{"download", "signature", "registry.example.com/team/app@sha256:abc"},
+		},
+		{
+			name: "sbom attest probes the cyclonedx attestation",
+			args: []string{"attest", "--predicate", "/tmp/p.json", "--type", "cyclonedx", "--yes", "registry.example.com/team/app@sha256:abc"},
+			wantProbe: []string{
+				"download", "attestation", "--predicate-type", "cyclonedx",
+				"registry.example.com/team/app@sha256:abc",
+			},
+		},
+		{
+			name: "provenance attest probes its own predicate URI",
+			args: []string{"attest", "--predicate", "/tmp/p.json", "--type", "https://slsa.dev/provenance/v1", "--yes", "registry.example.com/team/app@sha256:abc"},
+			wantProbe: []string{
+				"download", "attestation", "--predicate-type", "https://slsa.dev/provenance/v1",
+				"registry.example.com/team/app@sha256:abc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			var seen []string
+			exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
+				if len(args) > 0 && args[0] == "download" {
+					seen = args
+					return `{"payload":"e30="}`, "", nil
+				}
+				return "", conflictStderr, fmt.Errorf("exit status 1")
+			}
+
+			_, err := runCosignWithRetry(context.Background(), "attest", tt.args, nil, time.Minute, exec)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(seen).To(Equal(tt.wantProbe))
+		})
+	}
+}
+
+// Fail-closed: the probe only confirms on a clean exit AND real output. A
+// cosign build that exits 0 while printing nothing must not turn a genuine
+// signing failure into a green deploy.
+func TestRunCosignWithRetry_EmptyProbeOutputIsNotConfirmation(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	attempts := 0
+	exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
+		if len(args) > 0 && args[0] == "download" {
+			return "   \n", "", nil
+		}
+		attempts++
+		return "", conflictStderr, fmt.Errorf("exit status 1")
+	}
+
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("createLogEntryConflict"))
+	Expect(attempts).To(Equal(maxCosignAttempts))
+}
+
+// A confirmation on a later attempt still ends the run successfully.
+func TestRunCosignWithRetry_ConflictConfirmedOnLaterAttempt(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	attempts, probes := 0, 0
+	exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
+		if len(args) > 0 && args[0] == "download" {
+			probes++
+			if probes < 3 {
+				return "", "Error: no matching attestations", fmt.Errorf("exit status 1")
+			}
+			return `{"payload":"e30="}`, "", nil
+		}
+		attempts++
+		return "", conflictStderr, fmt.Errorf("exit status 1")
+	}
+
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(attempts).To(Equal(3))
+	Expect(probes).To(Equal(3))
+}
+
+// Before the fix this fell straight through to the fail-fast branch, so one
+// slow transparency log broke the deploy on the first try.
+func TestRunCosignWithRetry_RetriesTransientRekorGiveUp(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	attempts, probes := 0, 0
+	exec := func(_ context.Context, _ string, args, _ []string, _ time.Duration) (string, string, error) {
+		if len(args) > 0 && args[0] == "download" {
+			probes++
+			return "", "", fmt.Errorf("probe must not run for a transient failure")
+		}
+		attempts++
+		if attempts == 1 {
+			return "", giveUpStderr, fmt.Errorf("exit status 1")
+		}
+		return "tlog entry created with index: 7", "", nil
+	}
+
+	out, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, exec)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(Equal("tlog entry created with index: 7"))
+	Expect(attempts).To(Equal(2))
+	Expect(probes).To(Equal(0), "nothing was uploaded, so there is nothing to confirm")
+}
+
+func TestRunCosignWithRetry_PersistentGiveUpStillFails(t *testing.T) {
+	RegisterTestingT(t)
+	noBackoff(t)
+
+	attempts := 0
+	exec := func(_ context.Context, _ string, _, _ []string, _ time.Duration) (string, string, error) {
+		attempts++
+		return "", giveUpStderr, fmt.Errorf("exit status 1")
+	}
+
+	_, err := runCosignWithRetry(context.Background(), "sbom attest", attestArgs, nil, time.Minute, probeAbsent(exec))
+
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("giving up after 2 attempt"))
+	Expect(err.Error()).To(ContainSubstring("after 5 attempts"))
+	Expect(attempts).To(Equal(maxCosignAttempts))
+}
+
+func TestIsRekorTransient(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{name: "cosign gave up posting the log entry", output: giveUpStderr, want: true},
+		{
+			name:   "give-up on a self-hosted rekor",
+			output: `signing bundle: Post "https://tlog.internal.example/api/v1/log/entries": EOF, giving up after 3 attempt(s)`,
+			want:   true,
+		},
+		{
+			name:   "give-up against fulcio is not a log-entry failure",
+			output: `Post "https://fulcio.sigstore.dev/api/v2/signingCert": EOF, giving up after 2 attempt(s)`,
+			want:   false,
+		},
+		{
+			name:   "registry give-up is not a log-entry failure",
+			output: `Put "https://registry.example.com/v2/team/app/manifests/sha256-abc": EOF, giving up after 4 attempt(s)`,
+			want:   false,
+		},
+		{
+			name:   "log-entry POST that succeeded",
+			output: `Post "https://rekor.sigstore.dev/api/v1/log/entries": 201 Created`,
+			want:   false,
+		},
+		{name: "a plain conflict is not the transient class", output: conflictStderr, want: false},
+		{name: "empty", output: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			Expect(isRekorTransient(tt.output)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestProbeFor(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		name string
+		args []string
+		ok   bool
+		what string
+	}{
+		{name: "sign", args: []string{"sign", "--yes", "img"}, ok: true, what: "signature"},
+		{name: "untyped attest", args: []string{"attest", "--predicate", "p", "img"}, ok: true, what: "attestation"},
+		{
+			name: "typed attest", args: []string{"attest", "--type=cyclonedx", "img"},
+			ok: true, what: "cyclonedx attestation",
+		},
+		{name: "unknown subcommand gets no probe", args: []string{"copy", "a", "b"}, ok: false},
+		{name: "verify gets no probe", args: []string{"verify", "--key", "k", "img"}, ok: false},
+		{name: "argv too short", args: []string{"sign"}, ok: false},
+		{name: "trailing flag is not an image ref", args: []string{"sign", "--yes"}, ok: false},
+		{name: "empty argv", args: nil, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			probe, ok := probeFor(tt.args)
+			Expect(ok).To(Equal(tt.ok))
+			if tt.ok {
+				Expect(probe.what).To(Equal(tt.what))
+				Expect(probe.args[0]).To(Equal("download"))
+				Expect(probe.args[len(probe.args)-1]).To(Equal("img"))
+			}
+		})
+	}
 }

--- a/pkg/security/signing/signer.go
+++ b/pkg/security/signing/signer.go
@@ -14,6 +14,12 @@ type SignResult struct {
 	Bundle      string
 	RekorEntry  string // URL to Rekor transparency log entry
 	SignedAt    string
+
+	// Confirmed reports that the signature was not produced by this run: the
+	// transparency log already held an identical entry and a verification probe
+	// confirmed the signature is on the image. Nothing fresh was emitted, so
+	// RekorEntry is empty even though the operation succeeded.
+	Confirmed bool
 }
 
 // Signer is the interface for signing container images

--- a/pkg/security/signing/signing_more_test.go
+++ b/pkg/security/signing/signing_more_test.go
@@ -113,7 +113,7 @@ func TestRunCosignSign_RetryOnRekorConflict(t *testing.T) {
 			}
 			return "done", "", nil
 		}
-		out, err := runCosignSign(ctx, exec, []string{"sign"}, nil, time.Minute)
+		out, _, err := runCosignSign(ctx, exec, []string{"sign"}, nil, time.Minute, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(Equal("done"))
 		Expect(calls).To(Equal(2))
@@ -122,7 +122,7 @@ func TestRunCosignSign_RetryOnRekorConflict(t *testing.T) {
 	t.Run("exhausts attempts on persistent conflict", func(t *testing.T) {
 		RegisterTestingT(t)
 		exec := fakeSignExec("", "createLogEntryConflict", fmt.Errorf("409"))
-		_, err := runCosignSign(ctx, exec, []string{"sign"}, nil, time.Minute)
+		_, _, err := runCosignSign(ctx, exec, []string{"sign"}, nil, time.Minute, nil)
 		Expect(err).To(HaveOccurred())
 	})
 }

--- a/pkg/security/tools/cosigntest/cosigntest.go
+++ b/pkg/security/tools/cosigntest/cosigntest.go
@@ -47,10 +47,17 @@ type Options struct {
 	// budget shared across attempts: each invocation fits in its own window,
 	// but two cannot fit in a single shared one.
 	DelayEach time.Duration
+
+	// ArtifactAlreadyAttached makes the read-only presence probe
+	// (`cosign download signature|attestation`) report the artifact as already
+	// on the image. The retry loop treats a Rekor conflict confirmed this way
+	// as an idempotent success. Default false: the probe reports nothing
+	// attached, so conflicts keep flowing through the retry path.
+	ArtifactAlreadyAttached bool
 }
 
 // Fake is an installed stub. Calls reports how many times it ran.
-type Fake struct{ counter string }
+type Fake struct{ counter, probes string }
 
 // Install writes a `cosign` stub into a fresh temp dir and prepends that dir to
 // PATH for the duration of the test. The invocation count lives in a file so it
@@ -63,9 +70,26 @@ func Install(t *testing.T, o Options) *Fake {
 
 	dir := t.TempDir()
 	counter := filepath.Join(dir, "calls")
+	probes := filepath.Join(dir, "probes")
 
 	var b strings.Builder
 	b.WriteString("#!/bin/sh\n")
+	// The presence probe is a separate, read-only subcommand. Count it apart
+	// from sign/attest so existing attempt-count assertions keep measuring
+	// signing attempts, and answer it before any of the scripted failures
+	// below apply.
+	b.WriteString("if [ \"$1\" = \"download\" ]; then\n")
+	b.WriteString("  p=$(cat " + shellQuote(probes) + " 2>/dev/null || echo 0)\n")
+	b.WriteString("  p=$((p+1))\n")
+	b.WriteString("  echo $p > " + shellQuote(probes) + "\n")
+	if o.ArtifactAlreadyAttached {
+		b.WriteString("  printf '%s\\n' '{\"payloadType\":\"application/vnd.in-toto+json\",\"payload\":\"e30=\"}'\n")
+		b.WriteString("  exit 0\n")
+	} else {
+		b.WriteString("  printf '%s\\n' 'Error: no matching attestations' 1>&2\n")
+		b.WriteString("  exit 1\n")
+	}
+	b.WriteString("fi\n")
 	b.WriteString("n=$(cat " + shellQuote(counter) + " 2>/dev/null || echo 0)\n")
 	b.WriteString("n=$((n+1))\n")
 	b.WriteString("echo $n > " + shellQuote(counter) + "\n")
@@ -103,7 +127,7 @@ func Install(t *testing.T, o Options) *Fake {
 	// Prepend so the stub wins over any real cosign on the runner.
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	return &Fake{counter: counter}
+	return &Fake{counter: counter, probes: probes}
 }
 
 // Calls returns how many times the stub ran. It fails the test when the counter
@@ -117,6 +141,25 @@ func (f *Fake) Calls(t *testing.T) int {
 	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
 		t.Fatalf("cosign stub counter %q is not a number: %v", data, err)
+	}
+	return n
+}
+
+// Probes returns how many times the read-only presence probe
+// (`cosign download …`) ran. Zero when it never ran; unlike Calls, an absent
+// counter file is a legitimate result.
+func (f *Fake) Probes(t *testing.T) int {
+	t.Helper()
+	data, err := os.ReadFile(f.probes)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("cosign stub probe counter %s unreadable: %v", f.probes, err)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("cosign stub probe counter %q is not a number: %v", data, err)
 	}
 	return n
 }

--- a/pkg/security/tools/cosigntest/cosigntest.go
+++ b/pkg/security/tools/cosigntest/cosigntest.go
@@ -39,25 +39,39 @@ type Options struct {
 	// instead of a Rekor conflict. ConflictsBefore is then ignored.
 	FailStderr string
 
-	// DelayFirst pauses the first invocation.
+	// DelayFirst pauses the first signing invocation.
 	DelayFirst time.Duration
 
-	// DelayEach pauses every invocation. Set it just under the caller's
-	// per-attempt timeout to distinguish a fresh per-attempt deadline from one
-	// budget shared across attempts: each invocation fits in its own window,
-	// but two cannot fit in a single shared one.
+	// DelayEach pauses every invocation, confirmation probes included. Set it
+	// just under the caller's per-attempt timeout to distinguish a fresh
+	// per-attempt deadline from one budget shared across attempts: each
+	// invocation fits in its own window, but two cannot fit in a single shared
+	// one.
 	DelayEach time.Duration
 
-	// ArtifactAlreadyAttached makes the read-only presence probe
-	// (`cosign download signature|attestation`) report the artifact as already
-	// on the image. The retry loop treats a Rekor conflict confirmed this way
-	// as an idempotent success. Default false: the probe reports nothing
-	// attached, so conflicts keep flowing through the retry path.
+	// ArtifactAlreadyAttached makes the read-only confirmation probe
+	// (`cosign verify` / `cosign verify-attestation`) succeed, which is what a
+	// redeploy of an unchanged digest sees. The retry loop treats a Rekor
+	// conflict confirmed this way as an idempotent success. Default false: the
+	// probe fails, so conflicts keep flowing through the retry path.
 	ArtifactAlreadyAttached bool
+
+	// ProbeExit overrides the probe's exit status; ProbeStdout overrides what
+	// it prints. Zero means "follow ArtifactAlreadyAttached" (0 when attached,
+	// 1 otherwise), so a test asking for a specific failure sets it explicitly:
+	// 1 for "no matching attestations", 10 for a registry auth error. Together
+	// the pair models the cases the boolean cannot: a probe that exits 0 while
+	// printing nothing, and one that prints a payload while exiting non-zero.
+	ProbeExit   int
+	ProbeStdout string
+
+	// Image, when set, is the image reference the probe must target. A probe
+	// aimed anywhere else is rejected the way real cosign would reject it.
+	Image string
 }
 
 // Fake is an installed stub. Calls reports how many times it ran.
-type Fake struct{ counter, probes string }
+type Fake struct{ counter, probes, probeArgs string }
 
 // Install writes a `cosign` stub into a fresh temp dir and prepends that dir to
 // PATH for the duration of the test. The invocation count lives in a file so it
@@ -71,35 +85,51 @@ func Install(t *testing.T, o Options) *Fake {
 	dir := t.TempDir()
 	counter := filepath.Join(dir, "calls")
 	probes := filepath.Join(dir, "probes")
+	probeArgs := filepath.Join(dir, "probeargs")
 
 	var b strings.Builder
 	b.WriteString("#!/bin/sh\n")
-	// The presence probe is a separate, read-only subcommand. Count it apart
-	// from sign/attest so existing attempt-count assertions keep measuring
-	// signing attempts, and answer it before any of the scripted failures
-	// below apply.
-	b.WriteString("if [ \"$1\" = \"download\" ]; then\n")
+	// Classify the invocation. The confirmation probe is a separate, read-only
+	// subcommand; count it apart from sign/attest so existing attempt-count
+	// assertions keep measuring signing attempts.
+	b.WriteString("case \"$1\" in\n")
+	b.WriteString("  verify|verify-attestation) kind=probe ;;\n")
+	b.WriteString("  download) kind=legacy ;;\n")
+	b.WriteString("  *) kind=op ;;\n")
+	b.WriteString("esac\n")
+
+	b.WriteString("if [ \"$kind\" = probe ]; then\n")
 	b.WriteString("  p=$(cat " + shellQuote(probes) + " 2>/dev/null || echo 0)\n")
 	b.WriteString("  p=$((p+1))\n")
 	b.WriteString("  echo $p > " + shellQuote(probes) + "\n")
-	if o.ArtifactAlreadyAttached {
-		b.WriteString("  printf '%s\\n' '{\"payloadType\":\"application/vnd.in-toto+json\",\"payload\":\"e30=\"}'\n")
-		b.WriteString("  exit 0\n")
-	} else {
-		b.WriteString("  printf '%s\\n' 'Error: no matching attestations' 1>&2\n")
-		b.WriteString("  exit 1\n")
-	}
+	b.WriteString("  printf '%s\\n' \"$@\" > " + shellQuote(probeArgs) + "\n")
+	b.WriteString("else\n")
+	b.WriteString("  n=$(cat " + shellQuote(counter) + " 2>/dev/null || echo 0)\n")
+	b.WriteString("  n=$((n+1))\n")
+	b.WriteString("  echo $n > " + shellQuote(counter) + "\n")
 	b.WriteString("fi\n")
-	b.WriteString("n=$(cat " + shellQuote(counter) + " 2>/dev/null || echo 0)\n")
-	b.WriteString("n=$((n+1))\n")
-	b.WriteString("echo $n > " + shellQuote(counter) + "\n")
 
+	// Delays apply to probes too. A probe is a real registry round trip in
+	// production, so a harness that answers it for free cannot show that the
+	// probe shares the caller's timeout model.
 	if o.DelayFirst > 0 {
-		b.WriteString("if [ \"$n\" -eq 1 ]; then sleep " + seconds(o.DelayFirst) + "; fi\n")
+		b.WriteString("if [ \"${n:-0}\" -eq 1 ]; then sleep " + seconds(o.DelayFirst) + "; fi\n")
 	}
 	if o.DelayEach > 0 {
 		b.WriteString("sleep " + seconds(o.DelayEach) + "\n")
 	}
+
+	// cosign v3 defaults to the new bundle format and writes nothing to the
+	// legacy `sha256-<digest>.sig` tag, so `download signature` and `download
+	// attestation` find nothing however the image was signed. Modelled so a
+	// regression back to a download-shaped probe fails the suite instead of
+	// silently never confirming.
+	b.WriteString("if [ \"$kind\" = legacy ]; then\n")
+	b.WriteString("  printf '%s\\n' 'Error: no signatures associated with the image' 1>&2\n")
+	b.WriteString("  exit 1\n")
+	b.WriteString("fi\n")
+
+	writeProbeBranch(&b, o)
 
 	if o.FailStderr != "" {
 		b.WriteString("printf '%s\\n' " + shellQuote(o.FailStderr) + " 1>&2\n")
@@ -127,7 +157,64 @@ func Install(t *testing.T, o Options) *Fake {
 	// Prepend so the stub wins over any real cosign on the runner.
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	return &Fake{counter: counter, probes: probes}
+	return &Fake{counter: counter, probes: probes, probeArgs: probeArgs}
+}
+
+// writeProbeBranch emits the confirmation-probe half of the stub. It validates
+// the argv the way real cosign would before answering, because a stub that
+// answers on "$1" alone lets a probe real cosign rejects, or one aimed at the
+// wrong image, read as a clean confirm.
+func writeProbeBranch(b *strings.Builder, o Options) {
+	exit := o.ProbeExit
+	if exit == 0 && !o.ArtifactAlreadyAttached {
+		exit = 1
+	}
+
+	b.WriteString("if [ \"$kind\" = probe ]; then\n")
+	b.WriteString("  sub=$1; shift\n")
+	b.WriteString("  ident=0; ptype=0; ref=''\n")
+	// Value-taking flags consume their argument, the way real cosign parses.
+	// Without that, `verify --key /tmp/k.pub` reads the key path as the image
+	// reference and a probe with no image at all looks well formed.
+	b.WriteString("  while [ $# -gt 0 ]; do\n")
+	b.WriteString("    case \"$1\" in\n")
+	b.WriteString("      --key=*|--certificate-identity=*|--certificate-identity-regexp=*) ident=1 ;;\n")
+	b.WriteString("      --key|--certificate-identity|--certificate-identity-regexp)\n")
+	b.WriteString("        ident=1; if [ $# -gt 1 ]; then shift; fi ;;\n")
+	b.WriteString("      --type=*) ptype=1 ;;\n")
+	b.WriteString("      --type) ptype=1; if [ $# -gt 1 ]; then shift; fi ;;\n")
+	b.WriteString("      --certificate-oidc-issuer|--predicate-type)\n")
+	b.WriteString("        if [ $# -gt 1 ]; then shift; fi ;;\n")
+	b.WriteString("      -*) ;;\n")
+	b.WriteString("      *) ref=$1 ;;\n")
+	b.WriteString("    esac\n")
+	b.WriteString("    shift\n")
+	b.WriteString("  done\n")
+	// A verify with no identity flag is rejected by real cosign, and accepting
+	// it here would mean the suite blesses a presence-only probe.
+	b.WriteString("  if [ \"$ident\" -ne 1 ]; then\n")
+	b.WriteString("    printf '%s\\n' 'Error: no key or certificate identity supplied' 1>&2\n")
+	b.WriteString("    exit 2\n")
+	b.WriteString("  fi\n")
+	b.WriteString("  if [ \"$sub\" = verify-attestation ] && [ \"$ptype\" -ne 1 ]; then\n")
+	b.WriteString("    printf '%s\\n' 'Error: verify-attestation without --type accepts any predicate' 1>&2\n")
+	b.WriteString("    exit 2\n")
+	b.WriteString("  fi\n")
+	b.WriteString("  if [ -z \"$ref\" ]; then\n")
+	b.WriteString("    printf '%s\\n' 'Error: no image reference supplied' 1>&2\n")
+	b.WriteString("    exit 2\n")
+	b.WriteString("  fi\n")
+	if o.Image != "" {
+		b.WriteString("  if [ \"$ref\" != " + shellQuote(o.Image) + " ]; then\n")
+		b.WriteString("    printf '%s\\n' \"Error: MANIFEST_UNKNOWN: $ref\" 1>&2\n")
+		b.WriteString("    exit 2\n")
+		b.WriteString("  fi\n")
+	}
+	if o.ProbeStdout != "" {
+		b.WriteString("  printf '%s\\n' " + shellQuote(o.ProbeStdout) + "\n")
+	}
+	b.WriteString("  exit " + strconv.Itoa(exit) + "\n")
+	b.WriteString("fi\n")
 }
 
 // Calls returns how many times the stub ran. It fails the test when the counter
@@ -145,8 +232,8 @@ func (f *Fake) Calls(t *testing.T) int {
 	return n
 }
 
-// Probes returns how many times the read-only presence probe
-// (`cosign download …`) ran. Zero when it never ran; unlike Calls, an absent
+// Probes returns how many times the read-only confirmation probe
+// (`cosign verify …`) ran. Zero when it never ran; unlike Calls, an absent
 // counter file is a legitimate result.
 func (f *Fake) Probes(t *testing.T) int {
 	t.Helper()
@@ -162,6 +249,24 @@ func (f *Fake) Probes(t *testing.T) int {
 		t.Fatalf("cosign stub probe counter %q is not a number: %v", data, err)
 	}
 	return n
+}
+
+// LastProbeArgs returns the argv of the most recent confirmation probe, one
+// element per argument. Nil when no probe ran.
+func (f *Fake) LastProbeArgs(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(f.probeArgs)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("cosign stub probe argv %s unreadable: %v", f.probeArgs, err)
+	}
+	trimmed := strings.TrimSuffix(string(data), "\n")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
 }
 
 // seconds renders a duration for /bin/sh sleep, which takes a decimal number.

--- a/pkg/security/tools/cosigntest/cosigntest_test.go
+++ b/pkg/security/tools/cosigntest/cosigntest_test.go
@@ -206,3 +206,125 @@ func TestRekorConflictStderr_MatchesWhatCallersClassifyOn(t *testing.T) {
 	Expect(RekorConflictStderr).To(ContainSubstring("[POST /api/v1/log/entries][409]"))
 	Expect(RekorConflictStderr).To(ContainSubstring("createLogEntryConflict"))
 }
+
+// The probe half of the stub used to answer on "$1" alone. That is why the
+// cosign-v3 breakage was invisible: a probe real cosign rejects, or one aimed
+// at another image, still read as a clean confirm. These pin the validation.
+func TestInstall_ProbeRejectsAnArgvRealCosignWouldReject(t *testing.T) {
+	RegisterTestingT(t)
+
+	Install(t, Options{ArtifactAlreadyAttached: true, Image: "registry.example.com/team/app@sha256:abc"})
+
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "verify without an identity to verify against",
+			args: []string{"verify", "registry.example.com/team/app@sha256:abc"},
+			want: "no key or certificate identity",
+		},
+		{
+			name: "verify-attestation without a predicate type",
+			args: []string{"verify-attestation", "--key", "/tmp/k.pub", "registry.example.com/team/app@sha256:abc"},
+			want: "without --type",
+		},
+		{
+			name: "no image reference at all",
+			args: []string{"verify", "--key", "/tmp/k.pub"},
+			want: "no image reference",
+		},
+		{
+			name: "aimed at a different image",
+			args: []string{"verify", "--key", "/tmp/k.pub", "registry.example.com/team/other@sha256:def"},
+			want: "MANIFEST_UNKNOWN",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			_, stderr, err := runStub(tt.args...)
+			Expect(err).To(HaveOccurred())
+			Expect(stderr).To(ContainSubstring(tt.want))
+		})
+	}
+
+	// The well-formed probe still confirms, so the cases above fail for the
+	// reason stated rather than because nothing can ever pass.
+	_, _, err := runStub("verify", "--key", "/tmp/k.pub", "registry.example.com/team/app@sha256:abc")
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// cosign v3 defaults to the new bundle format and writes nothing to the legacy
+// signature tag, so `download` finds nothing however the image was signed.
+func TestInstall_LegacyDownloadNeverConfirms(t *testing.T) {
+	RegisterTestingT(t)
+
+	fake := Install(t, Options{ArtifactAlreadyAttached: true})
+
+	for _, args := range [][]string{
+		{"download", "signature", "registry.example.com/team/app@sha256:abc"},
+		{"download", "attestation", "--predicate-type", "cyclonedx", "registry.example.com/team/app@sha256:abc"},
+	} {
+		_, stderr, err := runStub(args...)
+		Expect(err).To(HaveOccurred(), "cosign v3 answers %v with nothing", args)
+		Expect(stderr).To(ContainSubstring("no signatures associated"))
+	}
+	Expect(fake.Probes(t)).To(Equal(0), "a download is not a confirmation probe")
+}
+
+func TestInstall_ProbeExitAndProbeStdoutAreIndependent(t *testing.T) {
+	RegisterTestingT(t)
+
+	probeArgs := []string{"verify", "--key", "/tmp/k.pub", "registry.example.com/team/app@sha256:abc"}
+
+	t.Run("exit 0 with empty stdout", func(t *testing.T) {
+		RegisterTestingT(t)
+		Install(t, Options{ArtifactAlreadyAttached: true})
+		stdout, _, err := runStub(probeArgs...)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stdout).To(BeEmpty(), "real `cosign verify` prints its banner to stderr")
+	})
+
+	t.Run("registry auth failure", func(t *testing.T) {
+		RegisterTestingT(t)
+		Install(t, Options{ProbeExit: 10})
+		_, _, err := runStub(probeArgs...)
+		Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("payload on stdout with a non-zero exit", func(t *testing.T) {
+		RegisterTestingT(t)
+		Install(t, Options{ProbeExit: 1, ProbeStdout: `{"payload":"e30="}`})
+		stdout, _, err := runStub(probeArgs...)
+		Expect(err).To(HaveOccurred(), "output is not confirmation")
+		Expect(stdout).To(ContainSubstring("payload"))
+	})
+}
+
+// The probe branch sits below the delay scripting now. Before, probes cost zero
+// simulated time, so no test could show the probe sharing the timeout model.
+func TestInstall_DelayEachAppliesToProbesToo(t *testing.T) {
+	RegisterTestingT(t)
+
+	const delay = 300 * time.Millisecond
+	fake := Install(t, Options{DelayEach: delay, ArtifactAlreadyAttached: true})
+
+	start := time.Now()
+	_, _, err := runStub("verify", "--key", "/tmp/k.pub", "registry.example.com/team/app@sha256:abc")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(time.Since(start)).To(BeNumerically(">=", delay))
+	Expect(fake.Probes(t)).To(Equal(1))
+}
+
+func TestFake_LastProbeArgsRecordsTheWholeArgv(t *testing.T) {
+	RegisterTestingT(t)
+
+	fake := Install(t, Options{ArtifactAlreadyAttached: true})
+	Expect(fake.LastProbeArgs(t)).To(BeNil(), "no probe has run yet")
+
+	args := []string{"verify-attestation", "--type", "cyclonedx", "--key", "/tmp/k.pub", "registry.example.com/team/app@sha256:abc"}
+	_, _, err := runStub(args...)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(fake.LastProbeArgs(t)).To(Equal(args))
+}


### PR DESCRIPTION
Four related supply-chain fixes. The first two break deploys today; the third
is why nobody notices when they do; the fourth is that "nothing is published"
was not true for images.

A review pass over the first three reproduced two of its findings
empirically. Everything it raised is addressed here; the mechanism in
section 1 changed substantially as a result. See **Review round 2** at the end
for the finding-by-finding list.

## 1. A Rekor 409 on an already-attested image now succeeds

Redeploying an unchanged image digest regenerates a byte-identical SBOM or
provenance predicate. The transparency log already holds that exact entry, so
it answers 409 and the deploy fails on an artifact that is already in the state
the deploy wanted:

```
cosign attest failed: signing bundle: [POST /api/v1/log/entries][409]
createLogEntryConflict {"code":409,"message":"an equivalent entry already
exists in the transparency log with UUID ..."}
Error: failed to attach SBOM: cosign attest failed: exit status 1
```

Retrying cannot clear it. Under key-based signing the body is deterministic, so
every attempt reproduces the same conflict and the loop only delays the failure.

`RunCosignWithRetry` already refused to read a 409 as success, and its reasoning
was right: cosign uploads to Rekor before it pushes to the registry, so a tlog
entry is not proof the artifact was attached. Rather than drop that guarantee,
this closes the gap. On a conflict the loop asks the registry directly, with
`cosign verify --key/--certificate-identity-regexp` for a signature and
`cosign verify-attestation --type <type> ...` for an attestation. Artifact
present and verifying means the run is already done, so it returns success
immediately without burning the rest of the retry budget. Otherwise the
previous retry-then-report behaviour is untouched.

**Verify, not download.** The first draft of this probe used `cosign download
signature` / `cosign download attestation`. Two problems, both raised in review
and one reproduced against a local registry with cosign v3.0.2:

- cosign v3 defaults to the new bundle format and writes nothing to the legacy
  `sha256-<digest>.sig` tag. On a signed image, `cosign download signature`
  returns `no signatures associated` while `cosign verify --key` succeeds. The
  download probe is therefore a permanent false negative on current cosign, so
  every conflict would run to exhaustion and fail. Combined with fix 2 below,
  which makes signing a hard predecessor of the Deployment, the exact case this
  PR exists to fix would have degraded from "rolls out, run is red" to "does not
  roll out at all".
- `download` answers presence, not identity. Any entry under the legacy tag
  counted, so a signature made under a rotated key, or an attestation of the
  same predicate family written by an unrelated workflow, read as proof.
  `security.Signing.Verify` is opt-in, so nothing downstream re-checked.

`verify` reads both formats and checks the identity, so a confirmation now means
the artifact is present **and** ours. The probe's exit code is the whole signal:
cosign prints its verification banner to stderr and nothing to stdout, so the
earlier "clean exit **and** non-empty stdout" rule was itself a way never to
confirm.

The confirmation stays fail-closed. A probe that errors, times out, or cannot be
built at all leaves the caller on retry-then-report, so it can never convert a
genuine signing failure into a green deploy. It is only built when the config
can name an identity to verify against; without one the caller keeps the plain
retry path rather than accept an artifact it cannot attribute. The predicate
type carries through from the attest invocation, otherwise an existing SBOM
attestation would stand in for a missing provenance one.

The probe is bounded at 30s rather than inheriting the sign/attest budget.
Reusing it made the worst case per artifact 5 x (timeout + timeout) plus
backoff, roughly 20 minutes for the SBOM attacher against 6 minutes before
confirmation existed, and both attachers run per image. It also no longer
inherits `SIGSTORE_ID_TOKEN`: it mints no certificate, so its environment is
filtered to registry-relevant variables.

**Proving the probe actually fires.** A fake cosign cannot certify this: the
fake decides what the probe means, which is exactly why the v3 breakage was
invisible to a green suite. So the suite now has an integration test that starts
a real `registry:2`, pushes an image, signs it for real, and drives the
confirmation path with the genuine cosign binary, plus the negative half over an
unsigned image. The synthetic part is only the 409 itself, because reaching a
real one would mean uploading to a public transparency log. On the run used to
develop this, that test logged:

```
cosign v3.0.2
legacy `cosign download signature` on a signed image:
  err=exit status 1 stderr="... no signatures associated"
```

while the verify probe confirmed. The fake was hardened to match: it validates
the probe argv the way real cosign does (identity flag required, `--type`
required for `verify-attestation`, image reference must be the one under test),
answers `download` the way cosign v3 does, and models probe exit status and
stdout separately so exit-0-empty, auth failure and false-negative are all
expressible. Its probe branch also moved below the delay scripting, so probes
cost simulated time like every other invocation.

**Sibling symptom.** Concurrent deploys of one digest also hit

```
signing bundle: Post "https://rekor.sigstore.dev/api/v1/log/entries": ...
giving up after 2 attempt(s)
```

That is cosign exhausting its own HTTP retries against the log, not a conflict.
It used to fall straight through to the fail-fast branch and break the deploy on
the first hiccup. It is now a second retryable class, matched only on a
log-entries POST so an unrelated give-up from a registry or from Fulcio still
fails fast.

The first draft matched the two halves with `(?s)` and a 400-character gap,
which only required them to appear near each other in the same stream. Review
confirmed all three of these matched: a log-entries POST returning `201 Created`
followed by a registry `unauthorized, giving up after 3 attempt(s)`, the same
followed by a Fulcio `signingCert` give-up, and the same followed by an OIDC
token give-up. None of them falsely succeeded, but a permanent registry-auth
failure was retried five times and the operator was pointed at the
transparency-log runbook. The gap now excludes quotes and newlines, so the match
stays inside one message; every competing give-up names its own quoted URL
first. All three are regression tests.

**Retry budget.** With two retryable classes the bound goes from 3 attempts to
5. The jittered full-backoff schedule is unchanged (1s base doubling to an 8s
cap), so the worst case grows from about 3s to about 15s of waiting. That only
applies to the genuinely-contended path now: a conflict on an artifact that is
already attached short-circuits on the first attempt and never sleeps at all.

## 2. Signing no longer runs after the workload has rolled out

`BuildAndPushImage` models sign, verify, SBOM attestation and provenance
attestation as resources hanging off the image push and returns their fan-in on
`ImageOut.AddOpts`. The documented contract is that the workload update depends
on them. The ECS path implements it (`aws/ecs_fargate.go` folds `img.AddOpts`
into its options). The Kubernetes path did not: `BuildAndPushImages` copied
`AddOpts` onto `ContainerImage` and nothing read it again, so
`DeploySimpleContainer` created the Deployment with no dependency edge to any
security operation.

Pulumi was therefore free to update the workload first. Observed ordering in a
failing run: rollout completed at 06:42:04, signing failed at 06:42:26, then

```
Image Signing         SKIPPED
Provenance Generation SKIPPED
Report Uploads        SKIPPED
error: update failed
```

Worst of both outcomes: an unsigned, unattested image with no SBOM is already
serving traffic, and CI is red so the next deploy looks like the problem rather
than the symptom.

**This is the full fix, not a guard.** Folding the per-image options into the
options `DeploySimpleContainer` builds makes signing a precondition of the
rollout, the same way the ECS path already worked. Images SC did not build, and
stacks with security disabled, contribute no options and deploy exactly as
before. Nothing about the security resources themselves changed.

The regression test drives `DeploySimpleContainer` under Pulumi mocks with a
stand-in gate resource on `AddOpts` and asserts the registered Deployment lists
it as a dependency. Reverting the one-line wiring fails it with the gate URN
absent from the dependency list.

## 3. The attestation chain now blocks a release

In `push.yaml` every step of the chain is `continue-on-error: true` and the
collector only emits `::warning title=Attestation incomplete::...`. A release
can therefore publish a tarball with no SBOM, no signature and no provenance on
a fully green workflow. `docs/SECURITY.md` tells consumers the opposite: "Every
release produces signed, attested artifacts". Nothing downstream closes the gap
either, since `verify-attestations` runs after publish and its own header says
it surfaces the regression "without blocking the release that already shipped".

**Which path I took, and why.** The soft-fail is scoped in the comments as a
14-day bake-in tracked in a `HARDENING.md` Phase 2 plan. I looked for evidence
that this is still a live decision and found the opposite:

- `HARDENING.md` does not exist in the repository and never has
  (`git log --diff-filter=A -- '**HARDENING.md'` is empty)
- no open issue tracks flipping it
- the soft-fail comments landed on 2026-05-21 at the latest, so a 14-day window
  closed roughly three months ago

So this enforces rather than hiding behind a flag defaulting to today's
behaviour. The three collectors in `push.yaml` now `exit 1`: the per-platform
tarball chain, the per-image chain, and the sidecar count assertion guarding the
bundle actually uploaded to the CDN (it runs before publish, so a gap there
blocks the upload).

What the chain does is unchanged. Every sub-step deliberately stays soft, so one
failure does not mask the others and the gate reports the whole picture at once
instead of aborting at the first missing piece.

**Break glass, with an expiry.** `ATTESTATION_SOFT_FAIL` degrades all three back
to warnings for the duration of a Sigstore or Rekor outage. It is unset by
default, so the enforcing path is what runs.

Review pointed out that the first draft was an unbounded, unattributed and
invisible bypass: `vars.*` also resolves ORGANIZATION variables, so one set on
the org silently disabled the gate in every repository that reads it, nothing
printed which scope supplied it, there was no expiry or recorded reason, and a
break-glass release was byte-indistinguishable from a clean one at the consumer
end. So the value is now an ISO-8601 UTC expiry date (`YYYY-MM-DD`) and:

- it stops applying on that date whether or not anyone remembers to remove it
- anything that is not a date, including the historical `true`, is rejected with
  an `::error` and does **not** bypass
- every gate echoes the value on every run, pass or fail, so a stale value shows
  up in green runs
- a bypassed run writes `attestation-breakglass=<date>` to the job summary
- an expired value logs a `Break-glass expired` warning before blocking

`docs/SECURITY.md` documents the format, the organization-scope caveat and who
may set it.

**Sidecar pairing.** The bundle assertion compared totals per sidecar kind
against the tarball count, so it passed a bundle in which one tarball carried
two of a kind and another none, which is exactly the shape a half-failed matrix
leg produces. It now pairs each tarball with its own four sidecars, and an empty
sidecar counts as missing.

`branch-preview.yaml` and `build-staging.yml` stay warn-only and gain a comment
saying why: neither is a release, no published contract promises their artifacts
carry a complete chain, and blocking them would stall iteration on an upstream
hiccup.

Matrix values in the rewritten gate scripts are read through `env` rather than
interpolated into the shell.

## 4. Release image tags are published only after the gate

Fix 3 made the gate block, but for images it blocked too late. The build step
ran `docker/build-push-action` with `push: true` and `tags:` containing both
`<img>:latest` and `:<version>`, so the release tags were live before
`Sign + attest` and before the gate. A failing gate only failed the job and
skipped `docker-finalize`, which left a mutable `:latest` pointing at an
unsigned, un-SBOM'd image while `dist.simple-container.com` still served the
previous version. The tarball path already gates before upload, so this was an
oversight rather than a design choice, and `docs/SECURITY.md` was left asserting
in writing something that was false for images.

The image now builds to a throwaway `:ci-<run>-<attempt>` tag, because cosign
signs by digest and needs the manifest in the registry before it can sign
anything. The release tags are applied by a promote step after the gate, and the
throwaway tag is deleted afterwards, including when the gate blocked, since that
is precisely when an unsigned image would otherwise stay reachable under a
predictable name.

**Promotion has to preserve the digest, and the obvious tool does not.** The
natural shape is `docker buildx imagetools create -t <tag> <repo>@<digest>`.
Measured against a local registry, given a single platform-specific manifest it
wraps it in a **new index**: source `sha256:dd54c6...` came back as
`sha256:45b9e3...`. The tag would then resolve to a digest that was never
signed, and `cosign verify <repo>:latest` would fail for every consumer
following the documented verification path. Promotion instead re-PUTs the signed
manifest byte for byte under each release tag, which is what `crane tag` does
and what the registry v2 API is for, needing nothing on the runner beyond curl
and jq. The step then compares the registry's `Docker-Content-Digest` against
the signed digest and fails the release if they ever diverge, so a promotion
that stops preserving the digest cannot ship silently.

With this, "the release build fails and nothing is published" is literally true
on both paths, and `docs/SECURITY.md` says how.

## Validation

- `go build ./...` clean, `go vet ./...` clean
- `go test ./...`: 48 packages, all pass, 0 failures. The `pkg/api/git`
  environment failure noted in the first round no longer reproduces (this run
  used a worktree outside `/tmp`).
- the integration test in `pkg/security/signing` was run for real against a
  local `registry:2` with cosign v3.0.2: both halves pass, and it is the source
  of the download-versus-verify evidence quoted in section 1. Build-tagged
  `integration` and skipped under `-short`, so it does not run in normal CI.
- every workflow touched YAML-parses; `actionlint` reports the same finding set
  before and after (6 `runner-label` for the self-hosted runners, 1 pre-existing
  `stack-name` expression warning)
- the registry-API promotion and the break-glass date logic were both executed
  against a local registry / shell before being written into the workflow: the
  promotion preserves the digest across two tags, and `true`, a malformed value,
  an expired date, today's date and a future date all behave as documented
- `gofmt -l` clean on every file in the diff
- no deploys run, nothing pushed to a registry other than a throwaway local one,
  nothing written to a transparency log

## Review round 2

Every finding from that review, and what happened to it.

| Finding | Status |
|---|---|
| P0 image tags public before the gate can block them | fixed, section 4 |
| P0 idempotency fix does not fire on cosign v3, and the rollout gate turns that into a blocked deploy | fixed, section 1 (verify probe) |
| P1 presence vs identity in the probe | fixed by the same change; the probe now checks identity |
| P1 `rekorGiveUpRe` over-matches | fixed; three confirmed cases added as `want: false` |
| P1 probe reuses the full signing timeout | fixed; capped at 30s, with a test |
| P1 `ATTESTATION_SOFT_FAIL` unbounded and invisible | fixed; ISO-8601 expiry, echoed every run, written to the job summary, org-scope documented |
| P1 the cosign fake cannot catch a broken probe | fixed; argv validation, `ProbeExit`/`ProbeStdout`, probe below the delay, plus the real-registry integration test |
| P2 confirmed conflict returns an empty `RekorEntry` while reporting success | fixed; `SignResult.Confirmed` plus an explicit log line |
| P2 probe inherits `SIGSTORE_ID_TOKEN` | fixed; environment filtered to an allowlist |
| P2 sidecar assertion compares totals, not pairs | fixed; per-tarball iteration, empty counts as missing |
| P2 `containsURN` accepts a suffix | fixed; equality |
| P2 `ecs_fargate.go` missing the nil guard `imageSecurityOpts` has | fixed |
| docs drift: `SECURITY.md` "nothing is published", preview/staging "mirrors push.yaml", preview same-guarantees contradiction, `verify-attestations` header | all four fixed |

Two things worth flagging to a human:

- **Found by the new integration test:** `GenerateKeyPair` never honoured its
  `outputDir`. Without `--output-key-prefix`, cosign writes the pair into the
  process working directory, so every caller passing a directory failed on the
  chmod that follows, after dropping an encrypted private key into the source
  tree. Fixed, and both filenames are now git-ignored as a second line of
  defence. `pkg/security/signing/e2e_test.go` has been calling it that way.
- **Out of scope, reported not fixed:** the review found pre-existing
  private-organisation references on `main` of this public repository,
  including a real cloud account id in a test fixture. They are untouched here
  and need their own change plus an owner decision.

## Note on #383

#383 is red only because its base predates the `go` directive move to 1.26.6. A
rebase clears it. Not touched here.