### PR TITLE
fix(kubernetes): deploy built images by digest, not by tag

### DIFF
--- a/pkg/clouds/pulumi/docker/build_and_push.go
+++ b/pkg/clouds/pulumi/docker/build_and_push.go
@@ -50,6 +50,11 @@ type Image struct {
 type ImageOut struct {
 	Image   *docker.Image
 	AddOpts []sdk.ResourceOption
+	// DeployImageRef is the reference a runtime should be pointed at. It is the
+	// immutable digest whenever one is available, so that what runs is what was
+	// scanned, signed and verified rather than whatever the tag points at by the
+	// time the runtime pulls.
+	DeployImageRef sdk.StringOutput
 }
 
 // BuildAndPushImage builds a Docker image, pushes it, and runs security
@@ -111,7 +116,11 @@ func BuildAndPushImage(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionP
 		addOpts = append(addOpts, sdk.DependsOn([]sdk.Resource{res}))
 	}
 
-	return &ImageOut{Image: res, AddOpts: addOpts}, nil
+	return &ImageOut{
+		Image:          res,
+		AddOpts:        addOpts,
+		DeployImageRef: resolveDeployImageRef(res.RepoDigest, res.ImageName, signingEnabled(stack.Client.Security)),
+	}, nil
 }
 
 // executeSecurityOperations creates Pulumi resources for post-push security ops.
@@ -675,5 +684,30 @@ func resolveSecurityImageRef(ctx *sdk.Context, repoDigest, imageURL sdk.StringOu
 			return imageURLValue, nil
 		}
 		return "", errors.Errorf("docker image repo digest is unavailable for %s; security operations require an immutable digest", imageURLValue)
+	}).(sdk.StringOutput)
+}
+
+// resolveDeployImageRef returns the reference to hand to a runtime. Verification
+// runs against the digest, so deploying the tag would leave a window in which
+// whoever can write to the registry moves the tag between verification and the
+// runtime's pull, and something that was never verified runs.
+//
+// strict is tied to whether the stack signs its images. A stack that asked for
+// signing gets a hard failure when no digest is available, because deploying a
+// mutable reference would silently void the guarantee it asked for. A stack that
+// does not sign keeps working on the tag, since this would otherwise break every
+// consumer whose registry or provider does not report a digest.
+func resolveDeployImageRef(repoDigest, imageName sdk.StringOutput, strict bool) sdk.StringOutput {
+	return sdk.All(repoDigest, imageName).ApplyT(func(values []interface{}) (string, error) {
+		repoDigestValue, _ := values[0].(string)
+		imageNameValue, _ := values[1].(string)
+		if repoDigestRe.MatchString(repoDigestValue) {
+			return repoDigestValue, nil
+		}
+		if strict {
+			return "", errors.Errorf("no immutable digest available for %s (got %q); signing is enabled for this stack, so refusing to deploy a mutable image reference", imageNameValue, repoDigestValue)
+		}
+		fmt.Printf("Warning: deploying %s by tag because no immutable digest is available; the running image is not pinned to what was built\n", imageNameValue)
+		return imageNameValue, nil
 	}).(sdk.StringOutput)
 }

--- a/pkg/clouds/pulumi/docker/build_and_push.go
+++ b/pkg/clouds/pulumi/docker/build_and_push.go
@@ -119,7 +119,7 @@ func BuildAndPushImage(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionP
 	return &ImageOut{
 		Image:          res,
 		AddOpts:        addOpts,
-		DeployImageRef: resolveDeployImageRef(res.RepoDigest, res.ImageName, signingEnabled(stack.Client.Security)),
+		DeployImageRef: resolveDeployImageRef(ctx, res.RepoDigest, res.ImageName, securitySigningEnabled(stack.Client.Security)),
 	}, nil
 }
 
@@ -692,22 +692,41 @@ func resolveSecurityImageRef(ctx *sdk.Context, repoDigest, imageURL sdk.StringOu
 // whoever can write to the registry moves the tag between verification and the
 // runtime's pull, and something that was never verified runs.
 //
-// strict is tied to whether the stack signs its images. A stack that asked for
-// signing gets a hard failure when no digest is available, because deploying a
-// mutable reference would silently void the guarantee it asked for. A stack that
-// does not sign keeps working on the tag, since this would otherwise break every
-// consumer whose registry or provider does not report a digest.
-func resolveDeployImageRef(repoDigest, imageName sdk.StringOutput, strict bool) sdk.StringOutput {
+// strict is tied to whether the stack actually signs its images, meaning both
+// the top level security flag and the signing flag, since signing only runs when
+// both are set. A stack that asked for signing gets a hard failure when no
+// digest is available, because deploying a mutable reference would silently void
+// the guarantee it asked for. A stack that does not sign keeps working on the
+// tag, since this would otherwise break every consumer whose registry or
+// provider does not report a digest.
+//
+// During a preview nothing is pushed, so there is no digest to resolve and a
+// strict failure there would block the plan rather than the deployment. The tag
+// is returned quietly in that case and the check happens on the update.
+func resolveDeployImageRef(ctx *sdk.Context, repoDigest, imageName sdk.StringOutput, strict bool) sdk.StringOutput {
 	return sdk.All(repoDigest, imageName).ApplyT(func(values []interface{}) (string, error) {
 		repoDigestValue, _ := values[0].(string)
 		imageNameValue, _ := values[1].(string)
 		if repoDigestRe.MatchString(repoDigestValue) {
 			return repoDigestValue, nil
 		}
+		if ctx != nil && ctx.DryRun() {
+			return imageNameValue, nil
+		}
 		if strict {
 			return "", errors.Errorf("no immutable digest available for %s (got %q); signing is enabled for this stack, so refusing to deploy a mutable image reference", imageNameValue, repoDigestValue)
 		}
-		fmt.Printf("Warning: deploying %s by tag because no immutable digest is available; the running image is not pinned to what was built\n", imageNameValue)
+		if ctx != nil {
+			_ = ctx.Log.Warn(fmt.Sprintf("deploying %s by tag because no immutable digest is available; the running image is not pinned to what was built", imageNameValue), nil)
+		}
 		return imageNameValue, nil
 	}).(sdk.StringOutput)
+}
+
+// securitySigningEnabled mirrors the gate that decides whether the security
+// operations run at all: signing.enabled alone is not enough if the top level
+// security block is off, and treating it as enough would make an unsigned stack
+// fail closed for a guarantee it never had.
+func securitySigningEnabled(security *api.SecurityDescriptor) bool {
+	return security != nil && security.Enabled && signingEnabled(security)
 }

--- a/pkg/clouds/pulumi/docker/build_and_push_test.go
+++ b/pkg/clouds/pulumi/docker/build_and_push_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	sdk "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/simple-container-com/api/pkg/api"
@@ -209,6 +210,104 @@ func TestRepoDigestRegex(t *testing.T) {
 	for _, ref := range invalid {
 		Expect(repoDigestRe.MatchString(ref)).To(BeFalse(), "repoDigestRe should not match %q", ref)
 	}
+}
+
+func TestResolveDeployImageRef(t *testing.T) {
+	RegisterTestingT(t)
+
+	validDigest := "registry.example.com/repo@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	tests := []struct {
+		name        string
+		repoDigest  string
+		imageName   string
+		strict      bool
+		want        string
+		wantErrText string
+	}{
+		{
+			name:       "valid digest",
+			repoDigest: validDigest,
+			imageName:  "registry.example.com/repo:v1",
+			strict:     true,
+			want:       validDigest,
+		},
+		{
+			name:        "truncated digest while signing",
+			repoDigest:  "registry.example.com/repo@sha256:abcdef",
+			imageName:   "registry.example.com/repo:v1",
+			strict:      true,
+			wantErrText: "refusing to deploy a mutable image reference",
+		},
+		{
+			name:        "empty digest while signing",
+			repoDigest:  "",
+			imageName:   "registry.example.com/repo:v1",
+			strict:      true,
+			wantErrText: "refusing to deploy a mutable image reference",
+		},
+		{
+			name:       "valid digest wins over the tag",
+			repoDigest: validDigest,
+			imageName:  "registry.example.com/repo:attacker-moved-tag",
+			strict:     true,
+			want:       validDigest,
+		},
+		{
+			name:       "digest is still preferred when not signing",
+			repoDigest: validDigest,
+			imageName:  "registry.example.com/repo:v1",
+			strict:     false,
+			want:       validDigest,
+		},
+		{
+			name:       "falls back to the tag when not signing",
+			repoDigest: "",
+			imageName:  "registry.example.com/repo:v1",
+			strict:     false,
+			want:       "registry.example.com/repo:v1",
+		},
+		{
+			name:       "malformed digest falls back to the tag when not signing",
+			repoDigest: "<none>",
+			imageName:  "registry.example.com/repo:v1",
+			strict:     false,
+			want:       "registry.example.com/repo:v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			err := sdk.RunErr(func(ctx *sdk.Context) error {
+				resolved := resolveDeployImageRef(
+					sdk.String(tt.repoDigest).ToStringOutput(),
+					sdk.String(tt.imageName).ToStringOutput(),
+					tt.strict,
+				)
+				resolved.ApplyT(func(value string) string {
+					Expect(value).To(Equal(tt.want))
+					return value
+				})
+				ctx.Export("resolved", resolved)
+				return nil
+			}, sdk.WithMocks("project", "stack", &deployImageRefMocks{}))
+			if tt.wantErrText != "" {
+				Expect(err).To(MatchError(ContainSubstring(tt.wantErrText)))
+				return
+			}
+			Expect(err).ToNot(HaveOccurred())
+		})
+	}
+}
+
+type deployImageRefMocks struct{}
+
+func (*deployImageRefMocks) NewResource(args sdk.MockResourceArgs) (string, resource.PropertyMap, error) {
+	return args.Name, args.Inputs, nil
+}
+
+func (*deployImageRefMocks) Call(args sdk.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
 }
 
 func TestDockerConfigJSON(t *testing.T) {

--- a/pkg/clouds/pulumi/docker/build_and_push_test.go
+++ b/pkg/clouds/pulumi/docker/build_and_push_test.go
@@ -280,6 +280,7 @@ func TestResolveDeployImageRef(t *testing.T) {
 			RegisterTestingT(t)
 			err := sdk.RunErr(func(ctx *sdk.Context) error {
 				resolved := resolveDeployImageRef(
+					ctx,
 					sdk.String(tt.repoDigest).ToStringOutput(),
 					sdk.String(tt.imageName).ToStringOutput(),
 					tt.strict,
@@ -528,4 +529,28 @@ func TestSigningCommandEnvironment(t *testing.T) {
 	Expect(ok).To(BeTrue(), "expected COSIGN_PASSWORD for key-based signing")
 	_, isStringOutput := interface{}(value).(sdk.StringOutput)
 	Expect(isStringOutput).To(BeTrue(), "COSIGN_PASSWORD env value type = %T, want pulumi StringOutput", value)
+}
+
+// signing only runs when both the top level security flag and the signing flag
+// are set, so the digest policy has to read the same pair. Treating
+// signing.enabled alone as strict makes a stack that never signs fail closed
+// for a guarantee it never asked for.
+func TestSecuritySigningEnabledRequiresBothFlags(t *testing.T) {
+	RegisterTestingT(t)
+	tests := []struct {
+		name     string
+		security *api.SecurityDescriptor
+		want     bool
+	}{
+		{name: "nil descriptor", security: nil, want: false},
+		{name: "security off, signing on", security: &api.SecurityDescriptor{Enabled: false, Signing: &api.SigningDescriptor{Enabled: true}}, want: false},
+		{name: "security on, signing off", security: &api.SecurityDescriptor{Enabled: true, Signing: &api.SigningDescriptor{Enabled: false}}, want: false},
+		{name: "security on, no signing block", security: &api.SecurityDescriptor{Enabled: true}, want: false},
+		{name: "both on", security: &api.SecurityDescriptor{Enabled: true, Signing: &api.SigningDescriptor{Enabled: true}}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(securitySigningEnabled(tt.security)).To(Equal(tt.want))
+		})
+	}
 }

--- a/pkg/clouds/pulumi/kubernetes/images_build.go
+++ b/pkg/clouds/pulumi/kubernetes/images_build.go
@@ -68,7 +68,7 @@ func BuildAndPushImages(ctx *sdk.Context, args BuildArgs) ([]*ContainerImage, er
 		}
 		return &ContainerImage{
 			Container: container,
-			ImageName: image.Image.ImageName,
+			ImageName: image.DeployImageRef,
 			AddOpts:   image.AddOpts,
 		}, nil
 	})


### PR DESCRIPTION
## The gap

Every post-push security operation in this repo runs against the immutable content digest.
`resolveSecurityImageRef` rejects anything that is not `name@sha256:<64 hex>`, and scan, sign, verify, SBOM
and provenance all consume it. The Kubernetes Deployment that SC emits referenced the image by tag instead
(`images_build.go` returned `image.Image.ImageName`, which `deployment.go` passes straight into the
container spec).

The artifact that is verified is therefore not the artifact the kubelet is told to pull. Whoever can write
to the registry can move the tag after verification has already succeeded, and the cluster runs an image no
check ever saw. It does not even take an attacker: a rebuild that reuses a tag is enough. Registry level
immutable tags reduce the window, but the guarantee only actually holds when the manifest carries the
digest.

## The change

`BuildAndPushImage` now returns `DeployImageRef` alongside the image, and the Kubernetes container spec uses
it instead of the tag.

Strictness follows the stack's own posture rather than being unconditional:

- signing enabled: no valid digest is a hard error, because deploying a mutable reference would silently
  void the guarantee the stack asked for;
- signing disabled: the digest is still preferred, and the tag is used with a warning when no digest is
  reported, so consumers whose registry or provider does not surface one keep working.

Containers that SC does not build are untouched. They reference an externally supplied image and have no
digest to resolve.

## Tests

Table-driven coverage for the resolver: valid digest, truncated digest, empty digest, a malformed
placeholder, digest preferred over a tag, and the strict and non-strict behaviour of each.
`go build ./...` and `go test ./pkg/clouds/pulumi/...` pass.

## Out of scope

The same tag-instead-of-digest gap exists in the AWS paths and is deliberately not touched here:

- ECS: tag selected in `pkg/clouds/pulumi/aws/ecs_fargate.go` and handed to the task definition;
- Lambda: built image tag passed in `pkg/clouds/pulumi/aws/aws_lambda.go`;
- the alert callback Lambda in `pkg/clouds/pulumi/aws/alerts.go`, though that build does not run the shared
  security operations.

GCP Cloud Run creates no runtime resource today, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
