### PR TITLE
fix(security): deploy built images by digest on every cloud, not just Kubernetes

### DIFF
--- a/pkg/clouds/pulumi/docker/build_and_push.go
+++ b/pkg/clouds/pulumi/docker/build_and_push.go
@@ -50,6 +50,11 @@ type Image struct {
 type ImageOut struct {
 	Image   *docker.Image
 	AddOpts []sdk.ResourceOption
+	// DeployImageRef is the reference a runtime should be pointed at. It is the
+	// immutable digest whenever one is available, so that what runs is what was
+	// scanned, signed and verified rather than whatever the tag points at by the
+	// time the runtime pulls.
+	DeployImageRef sdk.StringOutput
 }
 
 // BuildAndPushImage builds a Docker image, pushes it, and runs security
@@ -111,7 +116,11 @@ func BuildAndPushImage(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionP
 		addOpts = append(addOpts, sdk.DependsOn([]sdk.Resource{res}))
 	}
 
-	return &ImageOut{Image: res, AddOpts: addOpts}, nil
+	return &ImageOut{
+		Image:          res,
+		AddOpts:        addOpts,
+		DeployImageRef: resolveDeployImageRef(res.RepoDigest, res.ImageName, signingEnabled(stack.Client.Security)),
+	}, nil
 }
 
 // executeSecurityOperations creates Pulumi resources for post-push security ops.
@@ -675,5 +684,30 @@ func resolveSecurityImageRef(ctx *sdk.Context, repoDigest, imageURL sdk.StringOu
 			return imageURLValue, nil
 		}
 		return "", errors.Errorf("docker image repo digest is unavailable for %s; security operations require an immutable digest", imageURLValue)
+	}).(sdk.StringOutput)
+}
+
+// resolveDeployImageRef returns the reference to hand to a runtime. Verification
+// runs against the digest, so deploying the tag would leave a window in which
+// whoever can write to the registry moves the tag between verification and the
+// runtime's pull, and something that was never verified runs.
+//
+// strict is tied to whether the stack signs its images. A stack that asked for
+// signing gets a hard failure when no digest is available, because deploying a
+// mutable reference would silently void the guarantee it asked for. A stack that
+// does not sign keeps working on the tag, since this would otherwise break every
+// consumer whose registry or provider does not report a digest.
+func resolveDeployImageRef(repoDigest, imageName sdk.StringOutput, strict bool) sdk.StringOutput {
+	return sdk.All(repoDigest, imageName).ApplyT(func(values []interface{}) (string, error) {
+		repoDigestValue, _ := values[0].(string)
+		imageNameValue, _ := values[1].(string)
+		if repoDigestRe.MatchString(repoDigestValue) {
+			return repoDigestValue, nil
+		}
+		if strict {
+			return "", errors.Errorf("no immutable digest available for %s (got %q); signing is enabled for this stack, so refusing to deploy a mutable image reference", imageNameValue, repoDigestValue)
+		}
+		fmt.Printf("Warning: deploying %s by tag because no immutable digest is available; the running image is not pinned to what was built\n", imageNameValue)
+		return imageNameValue, nil
 	}).(sdk.StringOutput)
 }

--- a/pkg/clouds/pulumi/docker/build_and_push.go
+++ b/pkg/clouds/pulumi/docker/build_and_push.go
@@ -119,7 +119,7 @@ func BuildAndPushImage(ctx *sdk.Context, stack api.Stack, params pApi.ProvisionP
 	return &ImageOut{
 		Image:          res,
 		AddOpts:        addOpts,
-		DeployImageRef: resolveDeployImageRef(res.RepoDigest, res.ImageName, signingEnabled(stack.Client.Security)),
+		DeployImageRef: resolveDeployImageRef(ctx, res.RepoDigest, res.ImageName, securitySigningEnabled(stack.Client.Security)),
 	}, nil
 }
 
@@ -692,22 +692,41 @@ func resolveSecurityImageRef(ctx *sdk.Context, repoDigest, imageURL sdk.StringOu
 // whoever can write to the registry moves the tag between verification and the
 // runtime's pull, and something that was never verified runs.
 //
-// strict is tied to whether the stack signs its images. A stack that asked for
-// signing gets a hard failure when no digest is available, because deploying a
-// mutable reference would silently void the guarantee it asked for. A stack that
-// does not sign keeps working on the tag, since this would otherwise break every
-// consumer whose registry or provider does not report a digest.
-func resolveDeployImageRef(repoDigest, imageName sdk.StringOutput, strict bool) sdk.StringOutput {
+// strict is tied to whether the stack actually signs its images, meaning both
+// the top level security flag and the signing flag, since signing only runs when
+// both are set. A stack that asked for signing gets a hard failure when no
+// digest is available, because deploying a mutable reference would silently void
+// the guarantee it asked for. A stack that does not sign keeps working on the
+// tag, since this would otherwise break every consumer whose registry or
+// provider does not report a digest.
+//
+// During a preview nothing is pushed, so there is no digest to resolve and a
+// strict failure there would block the plan rather than the deployment. The tag
+// is returned quietly in that case and the check happens on the update.
+func resolveDeployImageRef(ctx *sdk.Context, repoDigest, imageName sdk.StringOutput, strict bool) sdk.StringOutput {
 	return sdk.All(repoDigest, imageName).ApplyT(func(values []interface{}) (string, error) {
 		repoDigestValue, _ := values[0].(string)
 		imageNameValue, _ := values[1].(string)
 		if repoDigestRe.MatchString(repoDigestValue) {
 			return repoDigestValue, nil
 		}
+		if ctx != nil && ctx.DryRun() {
+			return imageNameValue, nil
+		}
 		if strict {
 			return "", errors.Errorf("no immutable digest available for %s (got %q); signing is enabled for this stack, so refusing to deploy a mutable image reference", imageNameValue, repoDigestValue)
 		}
-		fmt.Printf("Warning: deploying %s by tag because no immutable digest is available; the running image is not pinned to what was built\n", imageNameValue)
+		if ctx != nil {
+			_ = ctx.Log.Warn(fmt.Sprintf("deploying %s by tag because no immutable digest is available; the running image is not pinned to what was built", imageNameValue), nil)
+		}
 		return imageNameValue, nil
 	}).(sdk.StringOutput)
+}
+
+// securitySigningEnabled mirrors the gate that decides whether the security
+// operations run at all: signing.enabled alone is not enough if the top level
+// security block is off, and treating it as enough would make an unsigned stack
+// fail closed for a guarantee it never had.
+func securitySigningEnabled(security *api.SecurityDescriptor) bool {
+	return security != nil && security.Enabled && signingEnabled(security)
 }

--- a/pkg/clouds/pulumi/docker/build_and_push_test.go
+++ b/pkg/clouds/pulumi/docker/build_and_push_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	sdk "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/simple-container-com/api/pkg/api"
@@ -209,6 +210,104 @@ func TestRepoDigestRegex(t *testing.T) {
 	for _, ref := range invalid {
 		Expect(repoDigestRe.MatchString(ref)).To(BeFalse(), "repoDigestRe should not match %q", ref)
 	}
+}
+
+func TestResolveDeployImageRef(t *testing.T) {
+	RegisterTestingT(t)
+
+	validDigest := "registry.example.com/repo@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	tests := []struct {
+		name        string
+		repoDigest  string
+		imageName   string
+		strict      bool
+		want        string
+		wantErrText string
+	}{
+		{
+			name:       "valid digest",
+			repoDigest: validDigest,
+			imageName:  "registry.example.com/repo:v1",
+			strict:     true,
+			want:       validDigest,
+		},
+		{
+			name:        "truncated digest while signing",
+			repoDigest:  "registry.example.com/repo@sha256:abcdef",
+			imageName:   "registry.example.com/repo:v1",
+			strict:      true,
+			wantErrText: "refusing to deploy a mutable image reference",
+		},
+		{
+			name:        "empty digest while signing",
+			repoDigest:  "",
+			imageName:   "registry.example.com/repo:v1",
+			strict:      true,
+			wantErrText: "refusing to deploy a mutable image reference",
+		},
+		{
+			name:       "valid digest wins over the tag",
+			repoDigest: validDigest,
+			imageName:  "registry.example.com/repo:attacker-moved-tag",
+			strict:     true,
+			want:       validDigest,
+		},
+		{
+			name:       "digest is still preferred when not signing",
+			repoDigest: validDigest,
+			imageName:  "registry.example.com/repo:v1",
+			strict:     false,
+			want:       validDigest,
+		},
+		{
+			name:       "falls back to the tag when not signing",
+			repoDigest: "",
+			imageName:  "registry.example.com/repo:v1",
+			strict:     false,
+			want:       "registry.example.com/repo:v1",
+		},
+		{
+			name:       "malformed digest falls back to the tag when not signing",
+			repoDigest: "<none>",
+			imageName:  "registry.example.com/repo:v1",
+			strict:     false,
+			want:       "registry.example.com/repo:v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterTestingT(t)
+			err := sdk.RunErr(func(ctx *sdk.Context) error {
+				resolved := resolveDeployImageRef(
+					sdk.String(tt.repoDigest).ToStringOutput(),
+					sdk.String(tt.imageName).ToStringOutput(),
+					tt.strict,
+				)
+				resolved.ApplyT(func(value string) string {
+					Expect(value).To(Equal(tt.want))
+					return value
+				})
+				ctx.Export("resolved", resolved)
+				return nil
+			}, sdk.WithMocks("project", "stack", &deployImageRefMocks{}))
+			if tt.wantErrText != "" {
+				Expect(err).To(MatchError(ContainSubstring(tt.wantErrText)))
+				return
+			}
+			Expect(err).ToNot(HaveOccurred())
+		})
+	}
+}
+
+type deployImageRefMocks struct{}
+
+func (*deployImageRefMocks) NewResource(args sdk.MockResourceArgs) (string, resource.PropertyMap, error) {
+	return args.Name, args.Inputs, nil
+}
+
+func (*deployImageRefMocks) Call(args sdk.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
 }
 
 func TestDockerConfigJSON(t *testing.T) {

--- a/pkg/clouds/pulumi/docker/build_and_push_test.go
+++ b/pkg/clouds/pulumi/docker/build_and_push_test.go
@@ -280,6 +280,7 @@ func TestResolveDeployImageRef(t *testing.T) {
 			RegisterTestingT(t)
 			err := sdk.RunErr(func(ctx *sdk.Context) error {
 				resolved := resolveDeployImageRef(
+					ctx,
 					sdk.String(tt.repoDigest).ToStringOutput(),
 					sdk.String(tt.imageName).ToStringOutput(),
 					tt.strict,
@@ -528,4 +529,28 @@ func TestSigningCommandEnvironment(t *testing.T) {
 	Expect(ok).To(BeTrue(), "expected COSIGN_PASSWORD for key-based signing")
 	_, isStringOutput := interface{}(value).(sdk.StringOutput)
 	Expect(isStringOutput).To(BeTrue(), "COSIGN_PASSWORD env value type = %T, want pulumi StringOutput", value)
+}
+
+// signing only runs when both the top level security flag and the signing flag
+// are set, so the digest policy has to read the same pair. Treating
+// signing.enabled alone as strict makes a stack that never signs fail closed
+// for a guarantee it never asked for.
+func TestSecuritySigningEnabledRequiresBothFlags(t *testing.T) {
+	RegisterTestingT(t)
+	tests := []struct {
+		name     string
+		security *api.SecurityDescriptor
+		want     bool
+	}{
+		{name: "nil descriptor", security: nil, want: false},
+		{name: "security off, signing on", security: &api.SecurityDescriptor{Enabled: false, Signing: &api.SigningDescriptor{Enabled: true}}, want: false},
+		{name: "security on, signing off", security: &api.SecurityDescriptor{Enabled: true, Signing: &api.SigningDescriptor{Enabled: false}}, want: false},
+		{name: "security on, no signing block", security: &api.SecurityDescriptor{Enabled: true}, want: false},
+		{name: "both on", security: &api.SecurityDescriptor{Enabled: true, Signing: &api.SigningDescriptor{Enabled: true}}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Expect(securitySigningEnabled(tt.security)).To(Equal(tt.want))
+		})
+	}
 }

--- a/pkg/clouds/pulumi/kubernetes/images_build.go
+++ b/pkg/clouds/pulumi/kubernetes/images_build.go
@@ -68,7 +68,7 @@ func BuildAndPushImages(ctx *sdk.Context, args BuildArgs) ([]*ContainerImage, er
 		}
 		return &ContainerImage{
 			Container: container,
-			ImageName: image.Image.ImageName,
+			ImageName: image.DeployImageRef,
 			AddOpts:   image.AddOpts,
 		}, nil
 	})


### PR DESCRIPTION
Every post-push security operation already runs against the immutable content digest — `resolveSecurityImageRef` rejects anything that is not `name@sha256:<64 hex>`, and scan, sign, verify, SBOM and provenance all use it. The runtime, however, was pointed at a tag.

So the artifact that is scanned, signed and verified was not the artifact the runtime is told to pull. Anyone able to push to the registry can move the tag after verification passes, and what runs is an image no check ever saw. Registry-level immutable tags help, but the guarantee only holds if the manifest reference itself carries the digest.

Three commits, smallest first.

### 1. Kubernetes: deploy by digest

`BuildAndPushImage` now returns `DeployImageRef` and the container spec uses it.

Strictness follows the stack's own posture. A stack with signing enabled fails closed when no digest is available — deploying a mutable reference would silently void the guarantee it asked for. A stack without signing keeps working on the tag and gets a warning, so consumers whose registry or provider does not report a digest are not broken.

### 2. Three corrections from review

- **Nothing is pushed during a preview**, so there is no digest to resolve. The strict path would have failed the plan rather than the deployment — the wrong moment and the wrong signal. The tag is returned quietly during a dry run; the check happens on the update, where it means something.
- **Strictness read `signing.enabled` alone**, but signing only runs when the top-level security flag is set too. A stack with security disabled and signing left on would have been treated as signed and failed closed for a guarantee it never had. It now reads the same pair the security operations do, with a test over all four combinations.
- **The fallback warning went to process stdout**, bypassing the Pulumi diagnostic stream the provisioning output is collected from — so the one case where the guarantee is knowingly given up was the case least likely to be seen. It goes through `ctx.Log.Warn` now.

### 3. AWS: ECS and Lambda were missed

The plumbing existed and was thrown away. `buildAndPushDockerImageV2` dropped `ImageOut.DeployImageRef`, so the ECS task definition took `docker.Image.ImageName` and the Lambda function took the same string as `ImageUri`. Both tags.

Same hole, in the two places nobody looked. On Lambda it is worse than on ECS: the function stores the resolved image, so a moved tag is picked up on the next update with no deployment at all.

`ECRImage.ImageName` stays the tag — it is what the stack exports and what a human reads. The new `DeployImageRef` field is what the container definition references.

## Why the AWS test is structural

The regression is structural, not logical: a new consumer wires up the field that is easy to reach instead of the one that is correct. A behavioural test would assert that a struct assignment happened.

So the test walks the package AST for the fields that decide what actually runs — `ecs.TaskDefinitionContainerDefinitionArgs.Image` and `lambda.FunctionArgs.ImageUri` — and requires each to be fed a `DeployImageRef`. The mirrored helpers image is on an explicit allowlist with its reason: it is built outside `BuildAndPushImage` and has no digest to use. A new runtime image reference fails the test until someone decides which case it is.

Verified by reintroducing the Lambda bug: the test names the file and the line. It also fails if the field names ever go stale, rather than passing by checking nothing.

## Blast radius

The deployed reference changes from `repo:tag` to `repo@sha256:...` on the next update of every stack that builds an image. Stack outputs are unchanged — the exported image name is still the tag.

A stack with signing enabled whose registry does not report a digest will now fail instead of deploying. That is the intended behaviour and it is the only breaking case; without signing, the tag path still works and warns.